### PR TITLE
Corrected GEAR LEDs sequence in Manual LED mode.

### DIFF
--- a/Source/DCS-BIOS/Properties/AssemblyInfo.cs
+++ b/Source/DCS-BIOS/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.210.7319")]
-[assembly: AssemblyFileVersion("2.1.210.7319")]
+[assembly: AssemblyVersion("2.1.211.1325")]
+[assembly: AssemblyFileVersion("2.1.211.1325")]

--- a/Source/NonVisuals/Properties/AssemblyInfo.cs
+++ b/Source/NonVisuals/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.457.7319")]
-[assembly: AssemblyFileVersion("2.1.457.7319")]
+[assembly: AssemblyVersion("2.1.458.1325")]
+[assembly: AssemblyFileVersion("2.1.458.1325")]

--- a/Source/NonVisuals/SwitchPanelPZ55.cs
+++ b/Source/NonVisuals/SwitchPanelPZ55.cs
@@ -206,6 +206,14 @@ namespace NonVisuals
                 var delayLeft = random.Next(1500, 10000);
                 var millisecsStart = DateTime.Now.Ticks/10000;
 
+                // Corrected the 'Manual LEDS' operation.
+                // Now when the gear knob selection is changed, just like a real aircraft
+                // the lights go to their 'Transit' state showing RED.
+                // Then afterwards they change to their final colour (GREEN = DOWN, DARK = UP)
+                SetLandingGearLED(SwitchPanelPZ55LEDPosition.UP, PanelLEDColor.RED);
+                SetLandingGearLED(SwitchPanelPZ55LEDPosition.RIGHT, PanelLEDColor.RED);
+                SetLandingGearLED(SwitchPanelPZ55LEDPosition.LEFT, PanelLEDColor.RED);
+
                 while (true)
                 {
                     var millisecsNow = DateTime.Now.Ticks/10000;
@@ -265,7 +273,8 @@ namespace NonVisuals
                         {
                             _manualLandingGearThread.Abort();
                         }
-                        _manualLandingGearThread = new Thread(() => SetLandingGearLedsManually(PanelLEDColor.RED));
+                        // Changed Lights to go DARK when gear level is selected to UP, instead of RED.
+                        _manualLandingGearThread = new Thread(() => SetLandingGearLedsManually(PanelLEDColor.DARK));
                         _manualLandingGearThread.Start();
                     }
                     else if (switchPanelKey.SwitchPanelPZ55Key == SwitchPanelPZ55Keys.LEVER_GEAR_DOWN && switchPanelKey.IsOn)

--- a/Source/ProUsbPanels/Properties/AssemblyInfo.cs
+++ b/Source/ProUsbPanels/Properties/AssemblyInfo.cs
@@ -49,5 +49,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.561.7319")]
-[assembly: AssemblyFileVersion("2.1.561.7319")]
+[assembly: AssemblyVersion("2.1.562.1325")]
+[assembly: AssemblyFileVersion("2.1.562.1325")]


### PR DESCRIPTION
In a real aircraft, the lights are NOT illuminated when the gear is UP.
However in the 'Manual Mode' they stayed RED.

RED should only show when gear is 'transitioning', so now, when the
level is changed, the LEDS change instantly to RED, and the either go
GREEN or DARK depending on the levers position.

This has been tested and checked for correct operation even when the
level is changed mid-transition.

This solution means that people using this brilliant app, but with games
other than DCS, can now accurately simulate gear transitions e.g. Star
Citizen and Elite Dangerous.

Thanks go to jdahlblom for his fantastic efforts, very clean, readable
and elegant code.