### PR TITLE
pz69 unit tests

### DIFF
--- a/Source/DCSFlightpanels.local.sln
+++ b/Source/DCSFlightpanels.local.sln
@@ -19,6 +19,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MEF", "MEF\MEF.csproj", "{0
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{6CF35974-7D78-4027-BB40-76E724C4CE14}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "Tests\Tests.csproj", "{D80E361D-35C3-4DBD-855B-B6E5F93FC9A5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,6 +32,7 @@ Global
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{6459906E-71BE-4987-B128-B793B50EAD10}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{6459906E-71BE-4987-B128-B793B50EAD10}.Debug|Any CPU.Build.0 = Debug|x64
 		{6459906E-71BE-4987-B128-B793B50EAD10}.Debug|x64.ActiveCfg = Debug|x64
 		{6459906E-71BE-4987-B128-B793B50EAD10}.Debug|x64.Build.0 = Debug|x64
 		{6459906E-71BE-4987-B128-B793B50EAD10}.Debug|x86.ActiveCfg = Debug|x64
@@ -39,6 +42,7 @@ Global
 		{6459906E-71BE-4987-B128-B793B50EAD10}.Release|x64.Build.0 = Release|x64
 		{6459906E-71BE-4987-B128-B793B50EAD10}.Release|x86.ActiveCfg = Release|x64
 		{54C2DD8F-259C-41B7-94ED-88F51F698595}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{54C2DD8F-259C-41B7-94ED-88F51F698595}.Debug|Any CPU.Build.0 = Debug|x64
 		{54C2DD8F-259C-41B7-94ED-88F51F698595}.Debug|x64.ActiveCfg = Debug|x64
 		{54C2DD8F-259C-41B7-94ED-88F51F698595}.Debug|x64.Build.0 = Debug|x64
 		{54C2DD8F-259C-41B7-94ED-88F51F698595}.Debug|x86.ActiveCfg = Debug|x64
@@ -48,6 +52,7 @@ Global
 		{54C2DD8F-259C-41B7-94ED-88F51F698595}.Release|x64.Build.0 = Release|x64
 		{54C2DD8F-259C-41B7-94ED-88F51F698595}.Release|x86.ActiveCfg = Release|x64
 		{6EF4492F-D4B4-42BC-B209-98783098DB22}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{6EF4492F-D4B4-42BC-B209-98783098DB22}.Debug|Any CPU.Build.0 = Debug|x64
 		{6EF4492F-D4B4-42BC-B209-98783098DB22}.Debug|x64.ActiveCfg = Debug|x64
 		{6EF4492F-D4B4-42BC-B209-98783098DB22}.Debug|x64.Build.0 = Debug|x64
 		{6EF4492F-D4B4-42BC-B209-98783098DB22}.Debug|x86.ActiveCfg = Debug|x64
@@ -57,6 +62,7 @@ Global
 		{6EF4492F-D4B4-42BC-B209-98783098DB22}.Release|x64.Build.0 = Release|x64
 		{6EF4492F-D4B4-42BC-B209-98783098DB22}.Release|x86.ActiveCfg = Release|x64
 		{66514CA6-6E8E-407C-8CFE-E108A95FEBC2}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{66514CA6-6E8E-407C-8CFE-E108A95FEBC2}.Debug|Any CPU.Build.0 = Debug|x64
 		{66514CA6-6E8E-407C-8CFE-E108A95FEBC2}.Debug|x64.ActiveCfg = Debug|x64
 		{66514CA6-6E8E-407C-8CFE-E108A95FEBC2}.Debug|x64.Build.0 = Debug|x64
 		{66514CA6-6E8E-407C-8CFE-E108A95FEBC2}.Debug|x86.ActiveCfg = Debug|x64
@@ -88,6 +94,18 @@ Global
 		{0C0196B3-2442-4838-A587-C51660136F9C}.Release|x64.Build.0 = Release|Any CPU
 		{0C0196B3-2442-4838-A587-C51660136F9C}.Release|x86.ActiveCfg = Release|Any CPU
 		{0C0196B3-2442-4838-A587-C51660136F9C}.Release|x86.Build.0 = Release|Any CPU
+		{D80E361D-35C3-4DBD-855B-B6E5F93FC9A5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D80E361D-35C3-4DBD-855B-B6E5F93FC9A5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D80E361D-35C3-4DBD-855B-B6E5F93FC9A5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D80E361D-35C3-4DBD-855B-B6E5F93FC9A5}.Debug|x64.Build.0 = Debug|Any CPU
+		{D80E361D-35C3-4DBD-855B-B6E5F93FC9A5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D80E361D-35C3-4DBD-855B-B6E5F93FC9A5}.Debug|x86.Build.0 = Debug|Any CPU
+		{D80E361D-35C3-4DBD-855B-B6E5F93FC9A5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D80E361D-35C3-4DBD-855B-B6E5F93FC9A5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D80E361D-35C3-4DBD-855B-B6E5F93FC9A5}.Release|x64.ActiveCfg = Release|Any CPU
+		{D80E361D-35C3-4DBD-855B-B6E5F93FC9A5}.Release|x64.Build.0 = Release|Any CPU
+		{D80E361D-35C3-4DBD-855B-B6E5F93FC9A5}.Release|x86.ActiveCfg = Release|Any CPU
+		{D80E361D-35C3-4DBD-855B-B6E5F93FC9A5}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/DCSFlightpanels/formulas.txt
+++ b/Source/DCSFlightpanels/formulas.txt
@@ -1,0 +1,132 @@
+Listed here are example formulas that can be used to show cockpit data in the Multi Panel.
+
+A-10C
+--------------------------------------------------------------------
+Heading:
+truncate(HSI_HDG*360/65536)
+                
+Heading bug:
+truncate(HSI_HDG_KNOB*360/65536)
+
+Course needle to degrees:
+truncate(HSI_CRS_KNOB*360/65536)
+
+--------------------------------------------------------------------
+
+
+Mi-8
+--------------------------------------------------------------------
+
+Left Variometer:
+Ifless( VARIOMETER_L 56032 ( Ifless( VARIOMETER_L 46858 ( Ifless( VARIOMETER_L 40304 ( Ifless( VARIOMETER_L 35717 ( Ifless( VARIOMETER_L 34406 ( Ifless( VARIOMETER_L 32768 ( Ifless( VARIOMETER_L 31129 ( Ifless( VARIOMETER_L 29818 ( Ifless( VARIOMETER_L 25231 ( Ifless( VARIOMETER_L 18677 ( Ifless( VARIOMETER_L 9503 ( (VARIOMETER_L*0,00105)+-30) ((0,00109*(VARIOMETER_L-9503))+-20))) ((0,00076*(VARIOMETER_L-18677))+-10))) ((0,00065*(VARIOMETER_L-25231))+-5))) ((0,00076*(VARIOMETER_L-29818))+-2))) ((0,00061*(VARIOMETER_L-31129))+-1))) ((0,00061*(VARIOMETER_L-32768))+0))) ((0,00076*(VARIOMETER_L-34406))+1))) ((0,00065*(VARIOMETER_L-35717))+2))) ((0,00076*(VARIOMETER_L-40304))+5))) ((0,00109*(VARIOMETER_L-46858))+10))) ((0,00105*(VARIOMETER_L-56032))+20))
+
+Barometric Altitud:
+truncate((VD_10K_L_100/65536)*10000)
+
+QFE:
+truncate ((VD_10K_L_PRESS/508)+661)
+
+IAS:
+Ifless( IAS_L 63634 ( Ifless( IAS_L 56557 ( Ifless( IAS_L 49282 ( Ifless( IAS_L 41942 ( Ifless( IAS_L 34734 ( Ifless( IAS_L 27394 ( Ifless( IAS_L 20054 ( Ifless( IAS_L 13041 ( Ifless( IAS_L 4587 ( Ifless( IAS_L 2228 ( IAS_L*0,00449 ) ((0,0212*(IAS_L-2228))+0))) ((0,00591*(IAS_L-4587))+50))) ((0,00713*(IAS_L-13041))+100))) ((0,00681*(IAS_L-20054))+150))) ((0,00681*(IAS_L-27394))+200))) ((0,00694*(IAS_L-34734))+250))) ((0,00681*(IAS_L-41942))+300))) ((0,00687*(IAS_L-49282))+350))) ((0,00707*(IAS_L-56557))+400))) ((0,00789*(IAS_L-63634))+450))
+
+Variometer:
+Ifless( VARIOMETER_L 56032 ( Ifless( VARIOMETER_L 46858 ( Ifless( VARIOMETER_L 40304 ( Ifless( VARIOMETER_L 35717 ( Ifless( VARIOMETER_L 34406 ( Ifless( VARIOMETER_L 32768 ( Ifless( VARIOMETER_L 31129 ( Ifless( VARIOMETER_L 29818 ( Ifless( VARIOMETER_L 25231 ( Ifless( VARIOMETER_L 18677 ( Ifless( VARIOMETER_L 9503 ( (VARIOMETER_L*0,00105)+-30) ((0,00109*(VARIOMETER_L-9503))+-20))) ((0,00076*(VARIOMETER_L-18677))+-10))) ((0,00065*(VARIOMETER_L-25231))+-5))) ((0,00076*(VARIOMETER_L-29818))+-2))) ((0,00061*(VARIOMETER_L-31129))+-1))) ((0,00061*(VARIOMETER_L-32768))+0))) ((0,00076*(VARIOMETER_L-34406))+1))) ((0,00065*(VARIOMETER_L-35717))+2))) ((0,00076*(VARIOMETER_L-40304))+5))) ((0,00109*(VARIOMETER_L-46858))+10))) ((0,00105*(VARIOMETER_L-56032))+20))
+
+Radar Altimeter:
+Ifless ( A_036_RALT 40960 (Ifless ( A_036_RALT 29950  (A_036_RALT/299,5)  ((0,0181*(A_036_RALT-29950))+100)) )    ((0,02034*(A_036_RALT-40960))+300))
+
+Heading:
+((UGR_4K_HEADING_L*0,00009587)+0) * 57,282
+
+Course:
+ifmore (  (((UGR_4K_COMMANDED_COURSE_L/65536)*360)  +  ((UGR_4K_HEADING_L/65536)*360))  359 (((UGR_4K_COMMANDED_COURSE_L/65536)*360)  +  ((UGR_4K_HEADING_L/65536)*360)-360)  (((UGR_4K_COMMANDED_COURSE_L/65536)*360)  +  ((UGR_4K_HEADING_L/65536)*360))  )
+--------------------------------------------------------------------
+
+
+KA50
+--------------------------------------------------------------------
+Variometer:
+((VARIO_SPEED/65536)*60)-30
+
+Radar altimeter:
+Ifless ( RALT_ALT 61138 (Ifless ( RALT_ALT 54591 ( Ifless ( RALT_ALT 49420 ( Ifless ( RALT_ALT 30350 ( Ifless ( RALT_ALT 12045 (RALT_ALT/602,25)  ((0,00163*(RALT_ALT-12045))+20)) )  ((0,00524*(RALT_ALT-30350))+50)) )  ((0,00967*(RALT_ALT-49420))+150)) ) ((0,01527*(RALT_ALT-54591))+200)) )  300 )
+
+IAS:
+truncate((AIRSPEED*350)/65536)
+
+Heading:
+(HSI_HDG/65536)*360
+
+Barimetric Altitude:
+truncate((ALT_1000M/65536)*10000)
+
+QFE press:
+truncate(((ALT_QFE_PRESS/65536)*200)+600)
+
+Course:
+(HSI_DES_COURSE/65536)*360
+--------------------------------------------------------------------
+
+
+UH-1H
+--------------------------------------------------------------------
+Barometric Altitude:
+(PALT_10000/65535)*100000
+
+QFE (last digit is decimal):
+((PALT_PRESS*0,00004425)+28,1)*10
+
+Radar Altimeter:
+Ifless( RALT_NEEDLE 48916 ( Ifless( RALT_NEEDLE 42533 ( Ifless( RALT_NEEDLE 35822 ( Ifless( RALT_NEEDLE 31848 ( Ifless( RALT_NEEDLE 16118 ( (RALT_NEEDLE*0,006204)+0) ((0,006279*(RALT_NEEDLE-16118))+100))) ((0,07549*(RALT_NEEDLE-31848))+200))) ((0,07554*(RALT_NEEDLE-35822))+500))) ((0,07722*(RALT_NEEDLE-42441))+1000))) ((0*(RALT_NEEDLE-48916))+1500))
+
+Vertical Velocity:
+Ifless( VVI_P 59309 ( Ifless( VVI_P 50462 ( Ifless( VVI_P 44564 ( Ifless( VVI_P 20971 ( Ifless( VVI_P 15073 ( Ifless( VVI_P 6226 ( (VVI_P*0,16062)+-4000) ((0,16955*(VVI_P-6226))+-3000))) ((0,08477*(VVI_P-15073))+-1500))) ((0,08477*(VVI_P-20971))+-1000))) ((0,08477*(VVI_P-44564))+1000))) ((0,16955*(VVI_P-50462))+1500))) ((0,16062*(VVI_P-59309))+3000))
+
+IAS:
+Ifless( IAS_NOSE 54066 ( Ifless( IAS_NOSE 36044 ( Ifless( IAS_NOSE 28835 ( Ifless( IAS_NOSE 25886 ( Ifless( IAS_NOSE 20971 ( Ifless( IAS_NOSE 12452 ( Ifless( IAS_NOSE 4915 ( (IAS_NOSE*0,00407)+0) ((0,00133*(IAS_NOSE-4915))+20))) ((0,00117*(IAS_NOSE-12452))+30))) ((0,00203*(IAS_NOSE-20971))+40))) ((0,00339*(IAS_NOSE-25886))+50))) ((0,00277*(IAS_NOSE-28835))+60))) ((0,00222*(IAS_NOSE-36044))+80))) ((0,00262*(IAS_NOSE-54066))+120))
+
+Heading:
+(GMC_HDG/65535)*360
+
+Course Mark:
+ifmore (   ((360-((GMC_HDG_MARKER/65535)*360))+((GMC_HDG/65535)*360)) 359  (((360-((GMC_HDG_MARKER/65535)*360))+((GMC_HDG/65535)*360))-360)    ((360-((GMC_HDG_MARKER/65535)*360))+((GMC_HDG/65535)*360))   )
+--------------------------------------------------------------------
+
+
+F14 
+--------------------------------------------------------------------
+VSI:
+(PLT_VSI_NEEDLE-32767.5) * ifless (PLT_VSI_NEEDLE 32767.5 (ifmore(PLT_VSI_NEEDLE 16000((log10 1.1)*log10 55)(ifmore(PLT_VSI_NEEDLE 7500((log10 1.125)*log10 80)(ifmore(PLT_VSI_NEEDLE 2500(log10 1.4)(.185))))))) (ifless(PLT_VSI_NEEDLE 46800((log10 1.1)*log10 50)(ifless(PLT_VSI_NEEDLE 56000((log10 1.125)*log10 80)(ifless(PLT_VSI_NEEDLE 62000(log10 1.4)(.185))))))))
+--------------------------------------------------------------------
+
+
+M-2000C
+--------------------------------------------------------------------
+Speed Neddle:
+[SPEED_KTS_NEED * 0,01526]
+
+formula for selected altitude tumble on multi panel is :
+[((ALT_10K_FT_SEL)*10000)+((ALT_1K_FT_SEL)*1000)+((ALT_100_FT_SEL)*100)]
+
+formula for BINGO tumble on multi panel is :
+[(BINGO_FUEL_1K_KG_SEL*1000)+(BINGO_FUEL_100_KG_SEL*100)]
+
+formula for accurate FUEL DETOT tumble on multi panel is : 
+[((FUEL_DETOT_THOUS * 0,0001528) * 1000)+((FUEL_DETOT_CENTS * 0,0001528) * 100)+((FUEL_DETOT_TENS * 0,0001528) * 10)]
+
+formula for accurate AOA on multi panel is :
+[AOA_POS*0,00152]
+
+formula for accurate CALIBRATION PRESSURE tumble on multi panel is :
+[((ALT_BARO_THOUS*0,0001526)*1000)+((ALT_BARO_CENTS*0,0001526)*100)+((ALT_BARO_TENS*0,0001526)*10)+(ALT_BARO_ONES*0,0001526)]
+--------------------------------------------------------------------
+
+
+Some gauges' scales are not linear. The above formula handles that. To generate formulas
+like these you can use Capt Zeen's formula generator:
+http://www.captzeen.com/helios/create_formula.asp
+
+You will find the gauge values in the "mainpanel_init.lua":
+Variometer_L.input		= {-30,  -20,   -10,   -5,    -2,    -1,    0, 1,    2,    5,    10,   20,   30}
+Variometer_L.output		= {-1.0, -0.71, -0.43, -0.23, -0.09, -0.05, 0, 0.05, 0.09, 0.23, 0.43, 0.71, 1.0}
+--------------------------------------------------------------------

--- a/Source/NonVisuals/NonVisuals.csproj
+++ b/Source/NonVisuals/NonVisuals.csproj
@@ -183,6 +183,7 @@
     </Compile>
     <Compile Include="Radios\Knobs\RadioPanelKnobMi24P.cs" />
     <Compile Include="Radios\Knobs\RadiopanelKnobP47D.cs" />
+    <Compile Include="Radios\Misc\PZ69DisplayBytes.cs" />
     <Compile Include="Radios\RadioPanelPZ69Mi24P.cs" />
     <Compile Include="Radios\RadioPanelPZ69P47D.cs" />
     <Compile Include="RandomFactory.cs" />
@@ -364,7 +365,9 @@
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Folder Include="Tests\" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PreBuildEvent>cd "$(SolutionDir)..\BuildScripts"

--- a/Source/NonVisuals/Radios/Misc/PZ69DisplayBytes.cs
+++ b/Source/NonVisuals/Radios/Misc/PZ69DisplayBytes.cs
@@ -1,0 +1,97 @@
+﻿
+namespace NonVisuals.Radios.Misc
+{
+    public class PZ69DisplayBytes
+    {
+        public void UnsignedInteger(ref byte[] bytes, uint digits, PZ69LCDPosition pz69LCDPosition)
+        {
+            var arrayPosition = GetArrayPosition(pz69LCDPosition);
+            var maxArrayPosition = GetArrayPosition(pz69LCDPosition) + 4;
+            var i = 0;
+            var digitsAsString = digits.ToString().PadLeft(5);
+           
+            // D = DARK
+            // 116 should become DD116!
+            do
+            {
+                // 5 digits can be displayed
+                // 12345 -> 12345
+                // 116   -> DD116 
+                // 1     -> DDDD1
+                byte b;
+                b = digitsAsString[i].ToString().Equals(" ") ? (byte)0xFF : byte.Parse(digitsAsString[i].ToString());
+                bytes[arrayPosition] = b;
+
+                arrayPosition++;
+                i++;
+            }
+            while (i < digitsAsString.Length && arrayPosition < maxArrayPosition + 1);
+        }
+
+        public void Integer(ref byte[] bytes, int digits, PZ69LCDPosition pz69LCDPosition)
+        {
+            var arrayPosition = GetArrayPosition(pz69LCDPosition);
+            var maxArrayPosition = GetArrayPosition(pz69LCDPosition) + 5;
+            var i = 0;
+            var digitsAsString = digits.ToString().PadLeft(5);
+
+            // D = DARK
+            // 116 should become DD116!
+            do
+            {
+                // 5 digits can be displayed
+                // 12345 -> 12345
+                // 116   -> DD116 
+                // 1     -> DDDD1
+                byte b;
+                b = digitsAsString[i].ToString().Equals(" ") ? (byte)0xFF : byte.Parse(digitsAsString[i].ToString());
+                bytes[arrayPosition] = b;
+
+                arrayPosition++;
+                i++;
+            }
+            while (i < digitsAsString.Length && arrayPosition < maxArrayPosition + 1);
+        }
+
+        public void SetPositionBlank(ref byte[] bytes, PZ69LCDPosition pz69LCDPosition)
+        {
+            var arrayPosition = GetArrayPosition(pz69LCDPosition);
+            var i = 0;
+            do
+            {
+                bytes[arrayPosition] = 0xFF;
+                arrayPosition++;
+                i++;
+            }
+            while (i < 5);
+        }
+
+        private int GetArrayPosition(PZ69LCDPosition pz69LCDPosition)
+        {
+            switch (pz69LCDPosition)
+            {
+                case PZ69LCDPosition.UPPER_ACTIVE_LEFT:
+                    {
+                        return 1;
+                    }
+
+                case PZ69LCDPosition.UPPER_STBY_RIGHT:
+                    {
+                        return 6;
+                    }
+
+                case PZ69LCDPosition.LOWER_ACTIVE_LEFT:
+                    {
+                        return 11;
+                    }
+
+                case PZ69LCDPosition.LOWER_STBY_RIGHT:
+                    {
+                        return 16;
+                    }
+            }
+
+            return 1;
+        }
+    }
+}

--- a/Source/NonVisuals/Radios/Misc/PZ69DisplayBytes.cs
+++ b/Source/NonVisuals/Radios/Misc/PZ69DisplayBytes.cs
@@ -1,8 +1,13 @@
 ﻿
+using System;
+
 namespace NonVisuals.Radios.Misc
 {
     public class PZ69DisplayBytes
     {
+        /// <summary>
+        /// Right justify, pad left with blanks.
+        /// </summary>
         public void UnsignedInteger(ref byte[] bytes, uint digits, PZ69LCDPosition pz69LCDPosition)
         {
             var arrayPosition = GetArrayPosition(pz69LCDPosition);
@@ -27,7 +32,10 @@ namespace NonVisuals.Radios.Misc
             }
             while (i < digitsAsString.Length && arrayPosition < maxArrayPosition + 1);
         }
-
+        
+        /// <summary>
+        /// Right justify, pad left with blanks.
+        /// </summary>
         public void Integer(ref byte[] bytes, int digits, PZ69LCDPosition pz69LCDPosition)
         {
             var arrayPosition = GetArrayPosition(pz69LCDPosition);
@@ -52,7 +60,146 @@ namespace NonVisuals.Radios.Misc
             }
             while (i < digitsAsString.Length && arrayPosition < maxArrayPosition + 1);
         }
+        
+        /// <summary>
+        /// Inject the preformatted 5 bytes at position in the array.
+        /// </summary>
+        public void Custom5Bytes(ref byte[] bytes, byte[] bytesToBeInjected, PZ69LCDPosition pz69LCDPosition)
+        {
+            var arrayPosition = GetArrayPosition(pz69LCDPosition);
+            var i = 0;
+            do
+            {
+                // 5 digits can be displayed
+                // 12345 -> 12345
+                // 116   -> DD116 
+                // 1     -> DDDD1
+                bytes[arrayPosition] = bytesToBeInjected[i];
 
+                arrayPosition++;
+                i++;
+            }
+            while (i < bytesToBeInjected.Length && i < 5);
+        }
+
+        /// <summary>
+        /// Expect a string of 5 chars that are going to be dispaleyd as it.
+        /// Can deal with multiple '.' chars.
+        /// If size does not match 5, it will NOT replace previous characters in the array (no padding left or right).
+        /// </summary>
+        public void DefaultStringAsIt(ref byte[] bytes, string digits, PZ69LCDPosition pz69LCDPosition)
+        {
+            var arrayPosition = GetArrayPosition(pz69LCDPosition);
+            var maxArrayPosition = GetArrayPosition(pz69LCDPosition) + 4;
+            var i = 0;
+            do
+            {
+                if (digits[i] == '.')
+                {
+                    // skip to next position, this has already been dealt with
+                    i++;
+                }
+
+                if (digits[i] == ' ')
+                {
+                    bytes[arrayPosition] = 0xff;
+                }
+                else
+                {
+                    var b = byte.Parse(digits[i].ToString());
+                    bytes[arrayPosition] = b;
+                }
+
+                if (digits.Length > i + 1 && digits[i + 1] == '.')
+                {
+                    // Add decimal marker
+                    bytes[arrayPosition] = (byte)(bytes[arrayPosition] + 0xd0);
+                }
+
+                arrayPosition++;
+                i++;
+            }
+            while (i < digits.Length && arrayPosition < maxArrayPosition + 1);
+        }
+
+        /// <summary>
+        /// Expect a string of max 5 chars that are going to be dispaleyd as it.
+        /// If size does not match 5, justify the value right and pad left with blanks.
+        /// </summary>
+        public void BytesStringAsItOrPadLeftBlanks(ref byte[] bytes, string digitString, PZ69LCDPosition pz69LCDPosition)
+        {
+            var arrayPosition = GetArrayPosition(pz69LCDPosition);
+            var maxArrayPosition = GetArrayPosition(pz69LCDPosition) + 4;
+            var i = 0;
+            var digits = string.Empty;
+            if (digitString.Length > 5)
+            {
+                if (digitString.Contains("."))
+                {
+                    digits = digitString.Substring(0, 6);
+                }
+                else
+                {
+                    digits = digitString.Substring(0, 5);
+                }
+            }
+            else if (digitString.Length < 5)
+            {
+                if (digitString.Contains("."))
+                {
+                    digits = digitString.PadLeft(6, ' ');
+                }
+                else
+                {
+                    digits = digitString.PadLeft(5, ' ');
+                }
+            }
+            else if (digitString.Length == 5)
+            {
+                if (digitString.Contains("."))
+                {
+                    digits = digitString.PadLeft(1, ' ');
+                }
+                else
+                {
+                    digits = digitString;
+                }
+            }
+
+            do
+            {
+                if (digits[i] == '.')
+                {
+                    // skip to next position, this has already been dealt with
+                    i++;
+                }
+
+                if (digits[i] == ' ')
+                {
+                    bytes[arrayPosition] = 0xff;
+                }
+                else
+                {
+                    var b = byte.Parse(digits[i].ToString());
+                    bytes[arrayPosition] = b;
+                }
+
+
+                if (digits.Length > i + 1 && digits[i + 1] == '.')
+                {
+                    // Add decimal marker
+                    bytes[arrayPosition] = (byte)(bytes[arrayPosition] + 0xd0);
+                }
+
+                arrayPosition++;
+                i++;
+            }
+            while (i < digits.Length && arrayPosition < maxArrayPosition + 1);
+        }
+
+        /// <summary>
+        /// Sets the given position to blank without modifying the other positions in the array
+        /// </summary>
         public void SetPositionBlank(ref byte[] bytes, PZ69LCDPosition pz69LCDPosition)
         {
             var arrayPosition = GetArrayPosition(pz69LCDPosition);

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
@@ -8,6 +8,7 @@
     using ClassLibraryCommon;
 
     using NonVisuals.EventArgs;
+    using NonVisuals.Radios.Misc;
     using NonVisuals.Saitek.Panels;
 
     public enum PZ69LCDPosition
@@ -46,6 +47,8 @@
         private long _resetSyncTimeout = 35000000;
 
         private long _syncOKDelayTimeout = 50000000; // 5s
+
+        private PZ69DisplayBytes _pZ69DisplayBytes = new PZ69DisplayBytes();
 
         protected RadioPanelPZ69Base(HIDSkeleton hidSkeleton)
             : base(GamingPanelEnum.PZ69RadioPanel, hidSkeleton)
@@ -87,40 +90,12 @@
         */
         protected void SetPZ69DisplayBytesInteger(ref byte[] bytes, int digits, PZ69LCDPosition pz69LCDPosition)
         {
-            var arrayPosition = GetArrayPosition(pz69LCDPosition);
-            var maxArrayPosition = GetArrayPosition(pz69LCDPosition) + 5;
-            var i = 0;
-            var digitsAsString = digits.ToString().PadLeft(5);
-
-            // D = DARK
-            // 116 should become DD116!
-            do
-            {
-                // 5 digits can be displayed
-                // 12345 -> 12345
-                // 116   -> DD116 
-                // 1     -> DDDD1
-                byte b;
-                b = digitsAsString[i].ToString().Equals(" ") ? (byte)0xFF : byte.Parse(digitsAsString[i].ToString());
-                bytes[arrayPosition] = b;
-
-                arrayPosition++;
-                i++;
-            }
-            while (i < digitsAsString.Length && arrayPosition < maxArrayPosition + 1);
+            _pZ69DisplayBytes.Integer(ref bytes, digits, pz69LCDPosition);
         }
 
         protected void SetPZ69DisplayBlank(ref byte[] bytes, PZ69LCDPosition pz69LCDPosition)
         {
-            var arrayPosition = GetArrayPosition(pz69LCDPosition);
-            var i = 0;
-            do
-            {
-                bytes[arrayPosition] = 0xFF;
-                arrayPosition++;
-                i++;
-            }
-            while (i < 5);
+            _pZ69DisplayBytes.SetPositionBlank(ref bytes, pz69LCDPosition);
         }
 
         public override void SavePanelSettingsJSON(object sender, ProfileHandlerEventArgs e)
@@ -129,31 +104,7 @@
 
         protected void SetPZ69DisplayBytesUnsignedInteger(ref byte[] bytes, uint digits, PZ69LCDPosition pz69LCDPosition)
         {
-            var arrayPosition = GetArrayPosition(pz69LCDPosition);
-            var maxArrayPosition = GetArrayPosition(pz69LCDPosition) + 4;
-            var i = 0;
-            var digitsAsString = digits.ToString().PadLeft(5);
-
-            // Debug.WriteLine("LCD position is " + pz69LCDPosition);
-            // Debug.WriteLine("Array position = " + arrayPosition);
-            // Debug.WriteLine("Max array position = " + (maxArrayPosition));
-            // Debug.WriteLine("digitsAsString = >" + digitsAsString + "< length=" + digitsAsString.Length);
-            // D = DARK
-            // 116 should become DD116!
-            do
-            {
-                // 5 digits can be displayed
-                // 12345 -> 12345
-                // 116   -> DD116 
-                // 1     -> DDDD1
-                byte b;
-                b = digitsAsString[i].ToString().Equals(" ") ? (byte)0xFF : byte.Parse(digitsAsString[i].ToString());
-                bytes[arrayPosition] = b;
-
-                arrayPosition++;
-                i++;
-            }
-            while (i < digitsAsString.Length && arrayPosition < maxArrayPosition + 1);
+            _pZ69DisplayBytes.UnsignedInteger(ref bytes, digits, pz69LCDPosition);
         }
 
         protected void SetPZ69DisplayBytes(ref byte[] bytes, double digits, int decimals, PZ69LCDPosition pz69LCDPosition)

--- a/Source/Tests/NonVisuals/RadiosPZ69DisplayBytesTests.cs
+++ b/Source/Tests/NonVisuals/RadiosPZ69DisplayBytesTests.cs
@@ -1,0 +1,98 @@
+﻿using NonVisuals.Radios;
+using NonVisuals.Radios.Misc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Tests.NonVisuals
+{
+    public class RadiosPZ69DisplayBytesTests
+    {
+        PZ69DisplayBytes _dp = new PZ69DisplayBytes();
+        private const string _zeroes = "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00";
+        private const string _eights = "00-08-08-08-08-08-08-08-08-08-08-08-08-08-08-08-08-08-08-08-08";
+        private const string _blank  = "00-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF";
+        private const string _values = "00-01-02-03-04-05-06-07-08-09-01-02-03-04-05-06-07-08-09-01-02";
+
+        private byte[] StringToBytes(string text)
+        {
+            byte[] data = text.Split('-').Select(b => Convert.ToByte(b, 16)).ToArray();
+            return data;
+        }
+
+        public static IEnumerable<object[]> SetPositionBlankData()
+        {
+            yield return new object[] { PZ69LCDPosition.UPPER_ACTIVE_LEFT, _zeroes, "00-FF-FF-FF-FF-FF-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00" };
+            yield return new object[] { PZ69LCDPosition.UPPER_STBY_RIGHT, _zeroes, "00-00-00-00-00-00-FF-FF-FF-FF-FF-00-00-00-00-00-00-00-00-00-00" };
+            yield return new object[] { PZ69LCDPosition.LOWER_ACTIVE_LEFT, _zeroes, "00-00-00-00-00-00-00-00-00-00-00-FF-FF-FF-FF-FF-00-00-00-00-00" };
+            yield return new object[] { PZ69LCDPosition.LOWER_STBY_RIGHT, _zeroes, "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-FF-FF-FF-FF-FF" };
+
+            yield return new object[] { PZ69LCDPosition.UPPER_ACTIVE_LEFT, _values, "00-FF-FF-FF-FF-FF-06-07-08-09-01-02-03-04-05-06-07-08-09-01-02" };
+            yield return new object[] { PZ69LCDPosition.UPPER_STBY_RIGHT, _values, "00-01-02-03-04-05-FF-FF-FF-FF-FF-02-03-04-05-06-07-08-09-01-02" };
+            yield return new object[] { PZ69LCDPosition.LOWER_ACTIVE_LEFT, _values, "00-01-02-03-04-05-06-07-08-09-01-FF-FF-FF-FF-FF-07-08-09-01-02" };
+            yield return new object[] { PZ69LCDPosition.LOWER_STBY_RIGHT, _values, "00-01-02-03-04-05-06-07-08-09-01-02-03-04-05-06-FF-FF-FF-FF-FF" };
+        }
+
+        [Theory]
+        [MemberData(nameof(SetPositionBlankData))]
+        public void SetPositionBlank_ShouldSet_5_Blank_Chars_At_Position(PZ69LCDPosition lcdPosition, string inputBytes, string expected)
+        {
+            var bytes = StringToBytes(inputBytes);
+            _dp.SetPositionBlank(ref bytes, lcdPosition);
+            Assert.Equal(expected, BitConverter.ToString(bytes));
+        }
+
+        public static IEnumerable<object[]> UnsignedIntegerData()
+        {
+            yield return new object[] { 1, PZ69LCDPosition.UPPER_ACTIVE_LEFT, _zeroes, "00-FF-FF-FF-FF-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00" };
+            yield return new object[] { 10000, PZ69LCDPosition.UPPER_ACTIVE_LEFT, _zeroes, "00-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00" };
+            yield return new object[] { 12345, PZ69LCDPosition.UPPER_ACTIVE_LEFT, _zeroes, "00-01-02-03-04-05-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00" };
+            yield return new object[] { 612345, PZ69LCDPosition.UPPER_ACTIVE_LEFT, _zeroes, "00-06-01-02-03-04-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00" };
+
+            yield return new object[] { 1, PZ69LCDPosition.UPPER_STBY_RIGHT, _zeroes, "00-00-00-00-00-00-FF-FF-FF-FF-01-00-00-00-00-00-00-00-00-00-00" };
+            yield return new object[] { 10000, PZ69LCDPosition.UPPER_STBY_RIGHT, _zeroes, "00-00-00-00-00-00-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00" };
+            yield return new object[] { 12345, PZ69LCDPosition.UPPER_STBY_RIGHT, _zeroes, "00-00-00-00-00-00-01-02-03-04-05-00-00-00-00-00-00-00-00-00-00" };
+            yield return new object[] { 612345, PZ69LCDPosition.UPPER_STBY_RIGHT, _zeroes, "00-00-00-00-00-00-06-01-02-03-04-00-00-00-00-00-00-00-00-00-00" };
+
+            yield return new object[] { 1, PZ69LCDPosition.LOWER_ACTIVE_LEFT, _zeroes, "00-00-00-00-00-00-00-00-00-00-00-FF-FF-FF-FF-01-00-00-00-00-00" };
+            yield return new object[] { 10000, PZ69LCDPosition.LOWER_ACTIVE_LEFT, _zeroes, "00-00-00-00-00-00-00-00-00-00-00-01-00-00-00-00-00-00-00-00-00" };
+            yield return new object[] { 12345, PZ69LCDPosition.LOWER_ACTIVE_LEFT, _zeroes, "00-00-00-00-00-00-00-00-00-00-00-01-02-03-04-05-00-00-00-00-00" };
+            yield return new object[] { 612345, PZ69LCDPosition.LOWER_ACTIVE_LEFT, _zeroes, "00-00-00-00-00-00-00-00-00-00-00-06-01-02-03-04-00-00-00-00-00" };
+
+            yield return new object[] { 1, PZ69LCDPosition.LOWER_STBY_RIGHT, _zeroes, "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-FF-FF-FF-FF-01" };
+            yield return new object[] { 10000, PZ69LCDPosition.LOWER_STBY_RIGHT, _zeroes, "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-01-00-00-00-00" };
+            yield return new object[] { 12345, PZ69LCDPosition.LOWER_STBY_RIGHT, _zeroes, "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-01-02-03-04-05" };
+            yield return new object[] { 612345, PZ69LCDPosition.LOWER_STBY_RIGHT, _zeroes, "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-06-01-02-03-04" };
+        }
+
+        [Theory]
+        [MemberData(nameof(UnsignedIntegerData))]
+        public void UnsignedInteger_ShouldReturn_ExpectedValue(uint input, PZ69LCDPosition lcdPosition, string inputBytes, string expected)
+        {
+            var bytes = StringToBytes(inputBytes);
+            _dp.UnsignedInteger(ref bytes, input, lcdPosition);
+            Assert.Equal(expected, BitConverter.ToString(bytes));
+        }
+
+        public static IEnumerable<object[]> IntegerData()
+        {
+            yield return new object[] { 1, PZ69LCDPosition.UPPER_ACTIVE_LEFT, _zeroes, "00-FF-FF-FF-FF-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00" };
+            yield return new object[] { -1, PZ69LCDPosition.UPPER_ACTIVE_LEFT, _zeroes, "00-FF-FF-FF-FF-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00" };
+            yield return new object[] { 10000, PZ69LCDPosition.UPPER_ACTIVE_LEFT, _zeroes, "00-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00" };
+            yield return new object[] { 12345, PZ69LCDPosition.UPPER_ACTIVE_LEFT, _zeroes, "00-01-02-03-04-05-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00" };
+            yield return new object[] { -12345, PZ69LCDPosition.UPPER_ACTIVE_LEFT, _zeroes, "00-06-01-02-03-04-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00" };
+            yield return new object[] { 612345, PZ69LCDPosition.UPPER_ACTIVE_LEFT, _zeroes, "00-06-01-02-03-04-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00" };
+        }
+
+        [Theory]
+        [MemberData(nameof(IntegerData))]
+        public void Integer_ShouldReturn_ExpectedValue(int input, PZ69LCDPosition lcdPosition, string inputBytes, string expected)
+        {
+            var bytes = StringToBytes(inputBytes);
+            _dp.Integer(ref bytes, input, lcdPosition);
+            Assert.Equal(expected, BitConverter.ToString(bytes));
+        }
+
+    }
+}

--- a/Source/Tests/NonVisuals/RadiosPZ69DisplayBytesTests.cs
+++ b/Source/Tests/NonVisuals/RadiosPZ69DisplayBytesTests.cs
@@ -9,10 +9,11 @@ namespace Tests.NonVisuals
 {
     public class RadiosPZ69DisplayBytesTests
     {
-        PZ69DisplayBytes _dp = new PZ69DisplayBytes();
+        PZ69DisplayBytes _dp = new();
         private const string _zeroes = "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00";
         private const string _eights = "00-08-08-08-08-08-08-08-08-08-08-08-08-08-08-08-08-08-08-08-08";
-        private const string _blank  = "00-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF";
+        private const string _deights = "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8";
+        private const string _blank = "00-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF";
         private const string _values = "00-01-02-03-04-05-06-07-08-09-01-02-03-04-05-06-07-08-09-01-02";
 
         private byte[] StringToBytes(string text)
@@ -23,76 +24,220 @@ namespace Tests.NonVisuals
 
         public static IEnumerable<object[]> SetPositionBlankData()
         {
-            yield return new object[] { PZ69LCDPosition.UPPER_ACTIVE_LEFT, _zeroes, "00-FF-FF-FF-FF-FF-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00" };
-            yield return new object[] { PZ69LCDPosition.UPPER_STBY_RIGHT, _zeroes, "00-00-00-00-00-00-FF-FF-FF-FF-FF-00-00-00-00-00-00-00-00-00-00" };
-            yield return new object[] { PZ69LCDPosition.LOWER_ACTIVE_LEFT, _zeroes, "00-00-00-00-00-00-00-00-00-00-00-FF-FF-FF-FF-FF-00-00-00-00-00" };
-            yield return new object[] { PZ69LCDPosition.LOWER_STBY_RIGHT, _zeroes, "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-FF-FF-FF-FF-FF" };
+            yield return new object[] { "00-FF-FF-FF-FF-FF-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", _zeroes, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-00-00-00-00-00-FF-FF-FF-FF-FF-00-00-00-00-00-00-00-00-00-00", _zeroes, PZ69LCDPosition.UPPER_STBY_RIGHT };
+            yield return new object[] { "00-00-00-00-00-00-00-00-00-00-00-FF-FF-FF-FF-FF-00-00-00-00-00", _zeroes, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
+            yield return new object[] { "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-FF-FF-FF-FF-FF", _zeroes, PZ69LCDPosition.LOWER_STBY_RIGHT };
 
-            yield return new object[] { PZ69LCDPosition.UPPER_ACTIVE_LEFT, _values, "00-FF-FF-FF-FF-FF-06-07-08-09-01-02-03-04-05-06-07-08-09-01-02" };
-            yield return new object[] { PZ69LCDPosition.UPPER_STBY_RIGHT, _values, "00-01-02-03-04-05-FF-FF-FF-FF-FF-02-03-04-05-06-07-08-09-01-02" };
-            yield return new object[] { PZ69LCDPosition.LOWER_ACTIVE_LEFT, _values, "00-01-02-03-04-05-06-07-08-09-01-FF-FF-FF-FF-FF-07-08-09-01-02" };
-            yield return new object[] { PZ69LCDPosition.LOWER_STBY_RIGHT, _values, "00-01-02-03-04-05-06-07-08-09-01-02-03-04-05-06-FF-FF-FF-FF-FF" };
+            yield return new object[] { "00-FF-FF-FF-FF-FF-06-07-08-09-01-02-03-04-05-06-07-08-09-01-02", _values, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-05-FF-FF-FF-FF-FF-02-03-04-05-06-07-08-09-01-02", _values, PZ69LCDPosition.UPPER_STBY_RIGHT };
+            yield return new object[] { "00-01-02-03-04-05-06-07-08-09-01-FF-FF-FF-FF-FF-07-08-09-01-02", _values, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-05-06-07-08-09-01-02-03-04-05-06-FF-FF-FF-FF-FF", _values, PZ69LCDPosition.LOWER_STBY_RIGHT };
         }
 
         [Theory]
         [MemberData(nameof(SetPositionBlankData))]
-        public void SetPositionBlank_ShouldSet_5_Blank_Chars_At_Position(PZ69LCDPosition lcdPosition, string inputBytes, string expected)
+        public void SetPositionBlank_ShouldSet_5_Blank_Chars_At_Position(string expected, string inputArray, PZ69LCDPosition lcdPosition)
         {
-            var bytes = StringToBytes(inputBytes);
+            var bytes = StringToBytes(inputArray);
             _dp.SetPositionBlank(ref bytes, lcdPosition);
             Assert.Equal(expected, BitConverter.ToString(bytes));
         }
 
         public static IEnumerable<object[]> UnsignedIntegerData()
         {
-            yield return new object[] { 1, PZ69LCDPosition.UPPER_ACTIVE_LEFT, _zeroes, "00-FF-FF-FF-FF-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00" };
-            yield return new object[] { 10000, PZ69LCDPosition.UPPER_ACTIVE_LEFT, _zeroes, "00-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00" };
-            yield return new object[] { 12345, PZ69LCDPosition.UPPER_ACTIVE_LEFT, _zeroes, "00-01-02-03-04-05-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00" };
-            yield return new object[] { 612345, PZ69LCDPosition.UPPER_ACTIVE_LEFT, _zeroes, "00-06-01-02-03-04-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00" };
+            yield return new object[] { "00-FF-FF-FF-FF-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 1, _zeroes, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 10000, _zeroes, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-05-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 12345, _zeroes, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-06-01-02-03-04-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 612345, _zeroes, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
 
-            yield return new object[] { 1, PZ69LCDPosition.UPPER_STBY_RIGHT, _zeroes, "00-00-00-00-00-00-FF-FF-FF-FF-01-00-00-00-00-00-00-00-00-00-00" };
-            yield return new object[] { 10000, PZ69LCDPosition.UPPER_STBY_RIGHT, _zeroes, "00-00-00-00-00-00-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00" };
-            yield return new object[] { 12345, PZ69LCDPosition.UPPER_STBY_RIGHT, _zeroes, "00-00-00-00-00-00-01-02-03-04-05-00-00-00-00-00-00-00-00-00-00" };
-            yield return new object[] { 612345, PZ69LCDPosition.UPPER_STBY_RIGHT, _zeroes, "00-00-00-00-00-00-06-01-02-03-04-00-00-00-00-00-00-00-00-00-00" };
+            yield return new object[] { "00-00-00-00-00-00-FF-FF-FF-FF-01-00-00-00-00-00-00-00-00-00-00", 1, _zeroes, PZ69LCDPosition.UPPER_STBY_RIGHT };
+            yield return new object[] { "00-00-00-00-00-00-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 10000, _zeroes, PZ69LCDPosition.UPPER_STBY_RIGHT };
+            yield return new object[] { "00-00-00-00-00-00-01-02-03-04-05-00-00-00-00-00-00-00-00-00-00", 12345, _zeroes, PZ69LCDPosition.UPPER_STBY_RIGHT };
+            yield return new object[] { "00-00-00-00-00-00-06-01-02-03-04-00-00-00-00-00-00-00-00-00-00", 612345, _zeroes, PZ69LCDPosition.UPPER_STBY_RIGHT };
 
-            yield return new object[] { 1, PZ69LCDPosition.LOWER_ACTIVE_LEFT, _zeroes, "00-00-00-00-00-00-00-00-00-00-00-FF-FF-FF-FF-01-00-00-00-00-00" };
-            yield return new object[] { 10000, PZ69LCDPosition.LOWER_ACTIVE_LEFT, _zeroes, "00-00-00-00-00-00-00-00-00-00-00-01-00-00-00-00-00-00-00-00-00" };
-            yield return new object[] { 12345, PZ69LCDPosition.LOWER_ACTIVE_LEFT, _zeroes, "00-00-00-00-00-00-00-00-00-00-00-01-02-03-04-05-00-00-00-00-00" };
-            yield return new object[] { 612345, PZ69LCDPosition.LOWER_ACTIVE_LEFT, _zeroes, "00-00-00-00-00-00-00-00-00-00-00-06-01-02-03-04-00-00-00-00-00" };
+            yield return new object[] { "00-00-00-00-00-00-00-00-00-00-00-FF-FF-FF-FF-01-00-00-00-00-00", 1, _zeroes, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
+            yield return new object[] { "00-00-00-00-00-00-00-00-00-00-00-01-00-00-00-00-00-00-00-00-00", 10000, _zeroes, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
+            yield return new object[] { "00-00-00-00-00-00-00-00-00-00-00-01-02-03-04-05-00-00-00-00-00", 12345, _zeroes, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
+            yield return new object[] { "00-00-00-00-00-00-00-00-00-00-00-06-01-02-03-04-00-00-00-00-00", 612345, _zeroes, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
 
-            yield return new object[] { 1, PZ69LCDPosition.LOWER_STBY_RIGHT, _zeroes, "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-FF-FF-FF-FF-01" };
-            yield return new object[] { 10000, PZ69LCDPosition.LOWER_STBY_RIGHT, _zeroes, "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-01-00-00-00-00" };
-            yield return new object[] { 12345, PZ69LCDPosition.LOWER_STBY_RIGHT, _zeroes, "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-01-02-03-04-05" };
-            yield return new object[] { 612345, PZ69LCDPosition.LOWER_STBY_RIGHT, _zeroes, "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-06-01-02-03-04" };
+            yield return new object[] { "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-FF-FF-FF-FF-01", 1, _zeroes, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-01-00-00-00-00", 10000, _zeroes, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-01-02-03-04-05", 12345, _zeroes, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-06-01-02-03-04", 612345, _zeroes, PZ69LCDPosition.LOWER_STBY_RIGHT };
         }
 
         [Theory]
         [MemberData(nameof(UnsignedIntegerData))]
-        public void UnsignedInteger_ShouldReturn_ExpectedValue(uint input, PZ69LCDPosition lcdPosition, string inputBytes, string expected)
+        public void UnsignedInteger_ShouldReturn_ExpectedValue(string expected, uint inputUint, string inputArray, PZ69LCDPosition lcdPosition)
         {
-            var bytes = StringToBytes(inputBytes);
-            _dp.UnsignedInteger(ref bytes, input, lcdPosition);
+            var bytes = StringToBytes(inputArray);
+            _dp.UnsignedInteger(ref bytes, inputUint, lcdPosition);
             Assert.Equal(expected, BitConverter.ToString(bytes));
         }
 
         public static IEnumerable<object[]> IntegerData()
         {
-            yield return new object[] { 1, PZ69LCDPosition.UPPER_ACTIVE_LEFT, _zeroes, "00-FF-FF-FF-FF-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00" };
-            yield return new object[] { -1, PZ69LCDPosition.UPPER_ACTIVE_LEFT, _zeroes, "00-FF-FF-FF-FF-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00" };
-            yield return new object[] { 10000, PZ69LCDPosition.UPPER_ACTIVE_LEFT, _zeroes, "00-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00" };
-            yield return new object[] { 12345, PZ69LCDPosition.UPPER_ACTIVE_LEFT, _zeroes, "00-01-02-03-04-05-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00" };
-            yield return new object[] { -12345, PZ69LCDPosition.UPPER_ACTIVE_LEFT, _zeroes, "00-06-01-02-03-04-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00" };
-            yield return new object[] { 612345, PZ69LCDPosition.UPPER_ACTIVE_LEFT, _zeroes, "00-06-01-02-03-04-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00" };
+            yield return new object[] { "00-FF-FF-FF-FF-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 1, _zeroes, PZ69LCDPosition.UPPER_ACTIVE_LEFT};
+            yield return new object[] { "00-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 10000, _zeroes, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-05-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 12345, _zeroes, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            
+            //no sign managed?
+            //yield return new object[] { "00-FF-FF-FF-FF-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", -1, _zeroes, PZ69LCDPosition.UPPER_ACTIVE_LEFT  };
+            
+            //no sign managed ?
+            //yield return new object[] { "00-06-01-02-03-04-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", -12345, _zeroes, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            
+            //Overflow of 1 char to the right (looks like a bug)
+            yield return new object[] { "00-01-02-03-04-05-06-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 123456, _zeroes, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+
+            //Overflow of 1 char to the right (not 2) (looks like a bug)
+            yield return new object[] { "00-01-02-03-04-05-06-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 1234567, _zeroes, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+
+            //IndexOutOfRangeException. Overflow of 1 char to the right (looks like a bug)
+            //yield return new object[] { "00-01-02-03-04-05-06-00-00-00-00-00-00-00-00-00-01-02-03-04-05", 123456, _zeroes, PZ69LCDPosition.LOWER_STBY_RIGHT };
         }
 
+        /// <summary>
+        /// Todo: Replace Integer by UnsignedInteger since they seems to react the same way. Is there a use for sign ?
+        /// </summary>
         [Theory]
         [MemberData(nameof(IntegerData))]
-        public void Integer_ShouldReturn_ExpectedValue(int input, PZ69LCDPosition lcdPosition, string inputBytes, string expected)
+        public void Integer_ShouldReturn_ExpectedValue(string expected, int inputInt, string inputArray, PZ69LCDPosition lcdPosition)
         {
-            var bytes = StringToBytes(inputBytes);
-            _dp.Integer(ref bytes, input, lcdPosition);
+            var bytes = StringToBytes(inputArray);
+            _dp.Integer(ref bytes, inputInt, lcdPosition);
             Assert.Equal(expected, BitConverter.ToString(bytes));
         }
 
+        public static IEnumerable<object[]> CustomData()
+        {
+            yield return new object[] { "00-D1-D2-D3-D4-D5-06-07-08-09-01-02-03-04-05-06-07-08-09-01-02", "D1-D2-D3-D4-D5", _values, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-D1-D2-D3-D4-05-06-07-08-09-01-02-03-04-05-06-07-08-09-01-02", "D1-D2-D3-D4", _values, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-D1-D2-D3-D4-D5-06-07-08-09-01-02-03-04-05-06-07-08-09-01-02", "D1-D2-D3-D4-D5-D6", _values, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-05-D1-D2-D3-D4-D5-02-03-04-05-06-07-08-09-01-02", "D1-D2-D3-D4-D5", _values, PZ69LCDPosition.UPPER_STBY_RIGHT };
+            yield return new object[] { "00-01-02-03-04-05-06-07-08-09-01-D1-D2-D3-D4-D5-07-08-09-01-02", "D1-D2-D3-D4-D5", _values, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-05-06-07-08-09-01-02-03-04-05-06-D1-D2-D3-D4-D5", "D1-D2-D3-D4-D5", _values, PZ69LCDPosition.LOWER_STBY_RIGHT };
+        }
+
+        [Theory]
+        [MemberData(nameof(CustomData))]
+        public void Custom5Bytes_ShouldInject_TheGiven5BytesMax_AtPosition(string expected, string inputBytes, string inputArray, PZ69LCDPosition lcdPosition)
+        {
+            var bytes = StringToBytes(inputArray);
+            var bytesToInject = StringToBytes(inputBytes);
+            _dp.Custom5Bytes(ref bytes, bytesToInject, lcdPosition);
+            Assert.Equal(expected, BitConverter.ToString(bytes));
+        }
+
+        public static IEnumerable<object[]> DefaultStringAsItData()
+        {
+            yield return new object[] { "00-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "123", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12345", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "123456", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-FF-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1 2", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-FF-02-FF-03-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1 2 3", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-01-FF-02-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", " 1 2 3", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-FF-02-FF-03-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1 2 34", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-FF-FF-FF-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "     ", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-FF-FF-FF-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "    1", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-FF-FF-FF-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1   2", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            
+            //IndexOutOfRangeException. Should maybe return D1-FF-FF-FF-FF ?
+            //yield return new object[] { "00-D1-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1.", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            
+            yield return new object[] { "00-D1-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1. ", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-FF-FF-FF-D1-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "    1.", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-00-00-00-00-D1-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "00001.", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-00-00-00-D2-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "0002.1", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-D1-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1.2345", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12345.", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12345.6", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-FF-FF-D0-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "   0.1", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-D1-D2-D3-D4-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1.2.3.4.5.", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-D1-02-03-D4-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1.234.5.", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-D2-D3-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12.3.45", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-D8-D8-D8-D8", "1", _deights, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-02-D8-D8-D8", "12", _deights, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-02-03-D8-D8", "123", _deights, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-02-03-04-05", "12345", _deights, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-02-03-04-05", "123456", _deights, PZ69LCDPosition.LOWER_STBY_RIGHT };
+        }
+
+        [Theory]
+        [MemberData(nameof(DefaultStringAsItData))]
+        public void DefaultStringAsIt_ShouldReturn_ExpectedValue(string expected, string inputString, string inputArray, PZ69LCDPosition lcdPosition)
+        {
+            var bytes = StringToBytes(inputArray);
+            _dp.DefaultStringAsIt(ref bytes, inputString, lcdPosition);
+            Assert.Equal(expected, BitConverter.ToString(bytes));
+        }
+
+        [Theory]
+        [InlineData("12a45")]
+        [InlineData("a")]
+        [InlineData("something")]
+        [InlineData(" _ ")]
+        [InlineData("/")]
+        [InlineData(".....")] //For me this should not throw but perhaps return FF-FF-FF-FF-FF ?
+        [InlineData("1..2345")]
+        public void DefaultStringAsIt_InvalidChars_OrCombination_ShouldThrow_FormatException(string inputString)
+        {
+            var bytes = StringToBytes(_deights);
+            Assert.Throws<FormatException>(() => _dp.DefaultStringAsIt(ref bytes, inputString, PZ69LCDPosition.UPPER_ACTIVE_LEFT));            
+        }
+
+        public static IEnumerable<object[]> BytesStringData()
+        {
+            yield return new object[] { "00-FF-FF-FF-FF-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //diff. than DefaultStringAsIt
+            yield return new object[] { "00-FF-FF-FF-01-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //diff. than DefaultStringAsIt
+            yield return new object[] { "00-FF-FF-01-02-03-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "123", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //diff. than DefaultStringAsIt
+            yield return new object[] { "00-01-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12345", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "123456", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-FF-01-FF-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1 2", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //diff. than DefaultStringAsIt
+            yield return new object[] { "00-01-FF-02-FF-03-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1 2 3", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-01-FF-02-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", " 1 2 3", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-FF-02-FF-03-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1 2 34", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-FF-FF-FF-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "     ", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-FF-FF-FF-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "    1", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-FF-FF-FF-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1   2", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+           
+            yield return new object[] { "00-FF-FF-FF-FF-D1-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1.", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-FF-FF-D1-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1. ", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //diff. than DefaultStringAsIt
+            yield return new object[] { "00-FF-FF-FF-FF-D1-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "    1.", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-00-00-00-00-D1-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "00001.", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-00-00-00-D2-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "0002.1", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-D1-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1.2345", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12345.", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12345.6", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-FF-FF-D0-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "   0.1", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            
+            //IndexOutOfRangeException
+            //yield return new object[] { "00-D1-D2-D3-D4-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1.2.3.4.5.", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            
+            //IndexOutOfRangeException
+            //yield return new object[] { "00-D1-02-03-D4-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1.234.5.", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            
+            //Not what I expect, should return 01-D2-D3-04-05
+            yield return new object[] { "00-01-D2-D3-04-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12.3.45", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-FF-FF-FF-01", "1", _deights, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-FF-FF-01-02", "12", _deights, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-FF-01-02-03", "123", _deights, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-02-03-04-05", "12345", _deights, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-02-03-04-05", "123456", _deights, PZ69LCDPosition.LOWER_STBY_RIGHT };
+        }
+
+        [Theory]
+        [MemberData(nameof(BytesStringData))]
+        public void BytesStringAsItOrPadLeftBlanks_ShouldReturn_ExpectedValue(string expected, string inputString, string inputArray, PZ69LCDPosition lcdPosition)
+        {
+            var bytes = StringToBytes(inputArray);
+            _dp.BytesStringAsItOrPadLeftBlanks(ref bytes, inputString, lcdPosition);
+            Assert.Equal(expected, BitConverter.ToString(bytes));
+        }
     }
 }

--- a/Source/Tests/Tests.csproj
+++ b/Source/Tests/Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NonVisuals\NonVisuals.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
First step of unit testing the different bytes array functions used in the Pz69 radio.

This PR should be safe, I just exported the functions in another class and cover them with unit tests.
I tested the 3 modules that I have that have radios and everything is working fine.

At first sight it look to add complexity but it's not the case, we can now easily track unwanted behavior in functions, bugs and fix them or refactor without risking breaking everything. It's easy to add new cases to test functions limits. By doing this job I think in the future we can merge multiple functions into one and reduce complexity.

I wanted to also test `SetPZ69DisplayBytes` and `SetPZ69DisplayBytesDefault` but I need to find a proper way to deal with the `NumberFormatInfo` class.

One step a a time :-)

* I also moved the file `formulas.txt` that was missing in the correct folder.