### PR TITLE
Feature/small code cleanup

### DIFF
--- a/Source/DCSFlightpanels/DCSFlightpanels.csproj
+++ b/Source/DCSFlightpanels/DCSFlightpanels.csproj
@@ -168,9 +168,6 @@
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="Xceed.Wpf.Toolkit">
-      <HintPath>..\..\..\C# WPF Includes\Extended.WPF.Toolkit.Binaries.NET.4.x\Xceed.Wpf.Toolkit.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">

--- a/Source/NonVisuals/Radios/RadioPanelPZ69A10C.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69A10C.cs
@@ -225,8 +225,6 @@
 
         public RadioPanelPZ69A10C(HIDSkeleton hidSkeleton) : base(hidSkeleton)
         {
-            VendorId = 0x6A3;
-            ProductId = 0xD05;
             CreateRadioKnobs();
             Startup();
         }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69A10C.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69A10C.cs
@@ -20,7 +20,6 @@
 
     public class RadioPanelPZ69A10C : RadioPanelPZ69Base, IDCSBIOSStringListener, IRadioPanel
     {
-        private HashSet<RadioPanelKnobA10C> _radioPanelKnobs = new HashSet<RadioPanelKnobA10C>();
         private CurrentA10RadioMode _currentUpperRadioMode = CurrentA10RadioMode.UHF;
         private CurrentA10RadioMode _currentLowerRadioMode = CurrentA10RadioMode.UHF;
 

--- a/Source/NonVisuals/Radios/RadioPanelPZ69AJS37.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69AJS37.cs
@@ -78,8 +78,6 @@
 
         public RadioPanelPZ69AJS37(HIDSkeleton hidSkeleton) : base(hidSkeleton)
         {
-            VendorId = 0x6A3;
-            ProductId = 0xD05;
             CreateRadioKnobs();
             Startup();
         }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69AV8BNA.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69AV8BNA.cs
@@ -56,8 +56,6 @@
 
         public RadioPanelPZ69AV8BNA(HIDSkeleton hidSkeleton) : base(hidSkeleton)
         {
-            VendorId = 0x6A3;
-            ProductId = 0xD05;
             CreateRadioKnobs();
             Startup();
         }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
@@ -28,7 +28,6 @@
         private volatile byte _frequencySensitivitySkipper;
         protected readonly object LockLCDUpdateObject = new object();
         protected bool DataHasBeenReceivedFromDCSBIOS;
-        private Guid _guid = Guid.NewGuid();
         /*
                  * IMPORTANT WHEN SYNCHING DIALS
                  */

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
@@ -47,8 +47,6 @@
                 throw new ArgumentException();
             }
 
-            VendorId = 0x6A3;
-            ProductId = 0xD05;
             NumberFormatInfoFullDisplay = new NumberFormatInfo();
             NumberFormatInfoFullDisplay.NumberDecimalSeparator = ".";
             NumberFormatInfoFullDisplay.NumberDecimalDigits = 4;

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Bf109.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Bf109.cs
@@ -105,8 +105,6 @@
 
         public RadioPanelPZ69Bf109(HIDSkeleton hidSkeleton) : base(hidSkeleton)
         {
-            VendorId = 0x6A3;
-            ProductId = 0xD05;
             CreateRadioKnobs();
             Startup();
         }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Emulator.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Emulator.cs
@@ -21,8 +21,6 @@
     {
         private readonly HashSet<RadioPanelPZ69DisplayValue> _displayValues = new HashSet<RadioPanelPZ69DisplayValue>();
         private readonly HashSet<BIPLinkPZ69> _bipLinks = new HashSet<BIPLinkPZ69>();
-        private readonly byte[] _oldRadioPanelValue = { 0, 0, 0 };
-        private readonly byte[] _newRadioPanelValue = { 0, 0, 0 };
         private readonly object _dcsBiosDataReceivedLock = new object();
 
         private readonly List<RadioPanelPZ69KnobsEmulator> _panelPZ69DialModesUpper = new List<RadioPanelPZ69KnobsEmulator> { RadioPanelPZ69KnobsEmulator.UpperCOM1, RadioPanelPZ69KnobsEmulator.UpperCOM2, RadioPanelPZ69KnobsEmulator.UpperNAV1, RadioPanelPZ69KnobsEmulator.UpperNAV2, RadioPanelPZ69KnobsEmulator.UpperADF, RadioPanelPZ69KnobsEmulator.UpperDME, RadioPanelPZ69KnobsEmulator.UpperXPDR };

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Emulator.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Emulator.cs
@@ -39,8 +39,6 @@
 
         public RadioPanelPZ69Emulator(HIDSkeleton hidSkeleton) : base(hidSkeleton)
         {
-            VendorId = 0x6A3;
-            ProductId = 0xD05;
             CreateSwitchKeys();
             Startup();
         }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69F14B.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69F14B.cs
@@ -253,8 +253,6 @@
 
         public RadioPanelPZ69F14B(HIDSkeleton hidSkeleton) : base(hidSkeleton)
         {
-            VendorId = 0x6A3;
-            ProductId = 0xD05;
             CreateRadioKnobs();
             Startup();
         }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69F14B.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69F14B.cs
@@ -108,7 +108,6 @@
         private uint _vuhfCockpitDial2Frequency;
         private uint _vuhfCockpitDial3Frequency;
         private uint _vuhfCockpitDial4Frequency;
-        private uint _vuhfSavedCockpitBigFrequency;
         private uint _vuhfSavedCockpitDial1Frequency;
         private uint _vuhfSavedCockpitDial2Frequency;
         private uint _vuhfSavedCockpitDial3Frequency;

--- a/Source/NonVisuals/Radios/RadioPanelPZ69F5E.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69F5E.cs
@@ -118,8 +118,6 @@
 
         public RadioPanelPZ69F5E(HIDSkeleton hidSkeleton) : base(hidSkeleton)
         {
-            VendorId = 0x6A3;
-            ProductId = 0xD05;
             CreateRadioKnobs();
             Startup();
         }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69F86F.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69F86F.cs
@@ -92,8 +92,6 @@
 
         public RadioPanelPZ69F86F(HIDSkeleton hidSkeleton) : base(hidSkeleton)
         {
-            VendorId = 0x6A3;
-            ProductId = 0xD05;
             CreateRadioKnobs();
             Startup();
         }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69FA18C.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69FA18C.cs
@@ -105,8 +105,6 @@ namespace NonVisuals.Radios
 
         private long _comm2DialWaitingForFeedback;
 
-        private readonly ClickSpeedDetector _uhfChannelClickSpeedDetector = new ClickSpeedDetector(8);
-
         /*FA-18C ILS*/
         private uint _ilsChannelStandby = 10;
 
@@ -117,10 +115,6 @@ namespace NonVisuals.Radios
         private DCSBIOSOutput _ilsDcsbiosOutputChannel;
 
         private volatile uint _ilsCockpitChannel = 1;
-
-        private const string ILS_CHANNEL_INC = "COM_ILS_CHANNEL_SW INC\n";
-
-        private const string ILS_CHANNEL_DEC = "COM_ILS_CHANNEL_SW DEC\n";
 
         private const string ILS_CHANNEL_COMMAND = "COM_ILS_CHANNEL_SW ";
 

--- a/Source/NonVisuals/Radios/RadioPanelPZ69FA18C.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69FA18C.cs
@@ -137,9 +137,7 @@ namespace NonVisuals.Radios
         public RadioPanelPZ69FA18C(HIDSkeleton hidSkeleton)
             : base(hidSkeleton)
         {
-            VendorId = 0x6A3;
-            ProductId = 0xD05;
-            CreateRadioKnobs();
+             CreateRadioKnobs();
             Startup();
         }
 

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Fw190.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Fw190.cs
@@ -101,8 +101,6 @@
 
         public RadioPanelPZ69Fw190(HIDSkeleton hidSkeleton) : base(hidSkeleton)
         {
-            VendorId = 0x6A3;
-            ProductId = 0xD05;
             CreateRadioKnobs();
             Startup();
         }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Generic.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Generic.cs
@@ -54,8 +54,6 @@
 
         public RadioPanelPZ69Generic(HIDSkeleton hidSkeleton) : base(hidSkeleton)
         {
-            VendorId = 0x6A3;
-            ProductId = 0xD05;
             CreateSwitchKeys();
             Startup();
         }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Generic.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Generic.cs
@@ -38,8 +38,6 @@
         private HashSet<DCSBIOSOutputBindingPZ69> _dcsBiosLcdBindings = new HashSet<DCSBIOSOutputBindingPZ69>();
         private HashSet<DCSBIOSActionBindingPZ69> _dcsBiosBindings = new HashSet<DCSBIOSActionBindingPZ69>();
         private readonly HashSet<BIPLinkPZ69> _bipLinks = new HashSet<BIPLinkPZ69>();
-        private readonly byte[] _oldRadioPanelValue = { 0, 0, 0 };
-        private readonly byte[] _newRadioPanelValue = { 0, 0, 0 };
         private readonly object _lcdDataVariablesLockObject = new object();
 
         private readonly List<RadioPanelPZ69KnobsEmulator> _panelPZ69DialModesUpper = new List<RadioPanelPZ69KnobsEmulator> { RadioPanelPZ69KnobsEmulator.UpperCOM1, RadioPanelPZ69KnobsEmulator.UpperCOM2, RadioPanelPZ69KnobsEmulator.UpperNAV1, RadioPanelPZ69KnobsEmulator.UpperNAV2, RadioPanelPZ69KnobsEmulator.UpperADF, RadioPanelPZ69KnobsEmulator.UpperDME, RadioPanelPZ69KnobsEmulator.UpperXPDR };

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Ka50.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Ka50.cs
@@ -226,8 +226,6 @@
         public RadioPanelPZ69Ka50(HIDSkeleton hidSkeleton)
             : base(hidSkeleton)
         {
-            VendorId = 0x6A3;
-            ProductId = 0xD05;
             CreateRadioKnobs();
             Startup();
         }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69M2000C.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69M2000C.cs
@@ -103,8 +103,6 @@
 
         public RadioPanelPZ69M2000C(HIDSkeleton hidSkeleton) : base(hidSkeleton)
         {
-            VendorId = 0x6A3;
-            ProductId = 0xD05;
             CreateRadioKnobs();
             Startup();
         }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Mi24P.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Mi24P.cs
@@ -154,8 +154,6 @@
 
         public RadioPanelPZ69Mi24P(HIDSkeleton hidSkeleton) : base(hidSkeleton)
         {
-            VendorId = 0x6A3;
-            ProductId = 0xD05;
             CreateRadioKnobs();
             Startup();
         }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Mi8.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Mi8.cs
@@ -355,8 +355,6 @@
         public RadioPanelPZ69Mi8(HIDSkeleton hidSkeleton)
             : base(hidSkeleton)
         {
-            VendorId = 0x6A3;
-            ProductId = 0xD05;
             CreateRadioKnobs();
             Startup();
         }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69MiG21Bis.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69MiG21Bis.cs
@@ -72,8 +72,6 @@
 
         public RadioPanelPZ69MiG21Bis(HIDSkeleton hidSkeleton) : base(hidSkeleton)
         {
-            VendorId = 0x6A3;
-            ProductId = 0xD05;
             CreateRadioKnobs();
             Startup();
         }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69P51D.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69P51D.cs
@@ -40,8 +40,6 @@
 
         public RadioPanelPZ69P51D(HIDSkeleton hidSkeleton) : base(hidSkeleton)
         {
-            VendorId = 0x6A3;
-            ProductId = 0xD05;
             CreateRadioKnobs();
             Startup();
         }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69SA342.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69SA342.cs
@@ -250,8 +250,6 @@
         public RadioPanelPZ69SA342(HIDSkeleton hidSkeleton)
             : base(hidSkeleton)
         {
-            VendorId = 0x6A3;
-            ProductId = 0xD05;
             CreateRadioKnobs();
             Startup();
         }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69SRS.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69SRS.cs
@@ -67,8 +67,6 @@
         {
             SRSListenerFactory.SetParams(portFrom, ipAddressTo, portTo);
             SRSListenerFactory.GetSRSListener().Attach(this);
-            VendorId = 0x6A3;
-            ProductId = 0xD05;
             CreateRadioKnobs();
             Startup();
         }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69UH1H.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69UH1H.cs
@@ -289,8 +289,6 @@ namespace NonVisuals.Radios
         public RadioPanelPZ69UH1H(HIDSkeleton hidSkeleton)
             : base(hidSkeleton)
         {
-            VendorId = 0x6A3;
-            ProductId = 0xD05;
             CreateRadioKnobs();
             Startup();
         }

--- a/Source/NonVisuals/Radios/RadiopanelPZ69P47D.cs
+++ b/Source/NonVisuals/Radios/RadiopanelPZ69P47D.cs
@@ -98,8 +98,6 @@
         public RadioPanelPZ69P47D(HIDSkeleton hidSkeleton)
             : base(hidSkeleton)
         {
-            VendorId = 0x6A3;
-            ProductId = 0xD05;
             CreateRadioKnobs();
             Startup();
         }

--- a/Source/NonVisuals/Radios/RadiopanelSpitfireLFMkIX.cs
+++ b/Source/NonVisuals/Radios/RadiopanelSpitfireLFMkIX.cs
@@ -108,8 +108,6 @@
         public RadioPanelPZ69SpitfireLFMkIX(HIDSkeleton hidSkeleton)
             : base(hidSkeleton)
         {
-            VendorId = 0x6A3;
-            ProductId = 0xD05;
             CreateRadioKnobs();
             Startup();
         }

--- a/Source/Tests/Tests.csproj
+++ b/Source/Tests/Tests.csproj
@@ -6,6 +6,10 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
Just some quick code cleanup of 
* remove of some unused variables and properties.
* remove warning message when compiling
* remove unneeded VendorsId & ProductId in derived RadioPanelPZ69Base classes (assignation already made in the ctor) 
    * Thoses seems not used ? maybe by reflection ?, I Think it's nice to have vendorId & ProductId in the GaminPanel class  but can  it be stored as enum value `GamingPanelVendorEnum` & `GamingPanelEnum`  and not in int ? when reading the code of derived panels it'll be much clear imho. 