### PR TITLE
[Logging] Replace custom logger with Nlog

### DIFF
--- a/Source/ClassLibraryCommon/ClassLibraryCommon.csproj
+++ b/Source/ClassLibraryCommon/ClassLibraryCommon.csproj
@@ -58,6 +58,9 @@
     <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop, Version=1.0.168.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
     </Reference>
+    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLog.4.7.11\lib\net45\NLog.dll</HintPath>
+    </Reference>
     <Reference Include="Octokit, Version=0.50.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octokit.0.50.0\lib\net46\Octokit.dll</HintPath>
     </Reference>
@@ -70,12 +73,17 @@
       <HintPath>..\packages\StreamDeckSharp.3.0.0\lib\netstandard2.0\StreamDeckSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Drawing.Common, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Drawing.Common.6.0.0-preview.7.21377.19\lib\net461\System.Drawing.Common.dll</HintPath>
     </Reference>
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Windows" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />

--- a/Source/ClassLibraryCommon/DCSFPProfile.cs
+++ b/Source/ClassLibraryCommon/DCSFPProfile.cs
@@ -1,11 +1,13 @@
 ﻿namespace ClassLibraryCommon
 {
+    using NLog;
     using System;
     using System.Collections.Generic;
     using System.IO;
 
     public class DCSFPProfile
     {
+        internal static Logger logger = LogManager.GetCurrentClassLogger();
         private static readonly List<DCSFPProfile> ModulesList = new List<DCSFPProfile>();
 
         private DCSFPProfile(int id, string description, string jsonFilename)
@@ -96,19 +98,19 @@
                     return dcsfpModule;
                 }
             }
-
-            Common.Log("Failed to determine airplane/helicopter in your bindings file.\nPlease check file BIOS.lua and update your bindings file. Example a line in the file equal to Profile=5 equals A-10C.");
-            throw new Exception("Failed to determine airplane/helicopter in your bindings file.\nPlease check file BIOS.lua and update your bindings file. Example a line in the file equal to Profile=5 equals A-10C.");
+            string message = "Failed to determine airplane/helicopter in your bindings file. Please check file BIOS.lua and update your bindings file. Example a line in the file equal to Profile=5 equals A-10C.";
+            logger.Info(message);
+            throw new Exception(message);
         }
         
         public static bool IsNoFrameLoadedYet(DCSFPProfile dcsfpModule)
         {
             if (dcsfpModule == null)
             {
-                Common.LogError("DCSFPProfile : Parameter dcsfpModule is null.");
-                throw new Exception("DCSFPProfile : Parameter dcsfpModule is null.");
+                string message = "DCSFPProfile : Parameter dcsfpModule is null.";
+                logger.Error(message);
+                throw new Exception(message);
             }
-
             return dcsfpModule.ID == 1;
         }
 
@@ -121,9 +123,9 @@
                     return dcsfpModule;
                 }
             }
-
-            Common.LogError("DCSFPProfile : Failed to find internal module NoFrameLoadedYet. Modules loaded : " + Modules.Count);
-            throw new Exception("DCSFPProfile : Failed to find internal module NoFrameLoadedYet. Modules loaded : " + Modules.Count);
+            string message = $"DCSFPProfile : Failed to find internal module NoFrameLoadedYet. Modules loaded : {Modules.Count}";
+            logger.Error(message);
+            throw new Exception(message);
         }
 
         public static bool IsKeyEmulator(DCSFPProfile dcsfpModule)
@@ -140,9 +142,9 @@
                     return dcsfpModule;
                 }
             }
-
-            Common.LogError("DCSFPProfile : Failed to find internal module KeyEmulator. Modules loaded : " + Modules.Count);
-            throw new Exception("DCSFPProfile : Failed to find internal module KeyEmulator. Modules loaded : " + Modules.Count);
+            string message = $"DCSFPProfile : Failed to find internal module KeyEmulator. Modules loaded : {Modules.Count}";
+            logger.Error(message);
+            throw new Exception(message);
         }
         
         public static bool IsKeyEmulatorSRS(DCSFPProfile dcsfpModule)
@@ -159,9 +161,9 @@
                     return dcsfpModule;
                 }
             }
-
-            Common.LogError("DCSFPProfile : Failed to find internal module KeyEmulatorSRS. Modules loaded : " + Modules.Count);
-            throw new Exception("DCSFPProfile : Failed to find internal module KeyEmulatorSRS. Modules loaded : " + Modules.Count);
+            string message = $"DCSFPProfile : Failed to find internal module KeyEmulatorSRS. Modules loaded : {Modules.Count}";
+            logger.Error(message);
+            throw new Exception(message);
         }
         
         public static bool IsFlamingCliff(DCSFPProfile dcsfpModule)
@@ -178,7 +180,6 @@
                     return true;
                 }
             }
-
             return false;
         }
 
@@ -191,7 +192,6 @@
                     return dcsfpModule;
                 }
             }
-
             return null;
         }
 
@@ -566,8 +566,9 @@
             {
                 return Modules.Find(o => o.ID == 39);
             }
-
-            throw new Exception("Failed to determine airplane/helicopter in your bindings file.\nPlease check file BIOS.lua and update your bindings file. Example a line in the file equal to Profile=5 equals A-10C.");
+            string message = "Failed to determine airplane/ helicopter in your bindings file. Please check file BIOS.lua and update your bindings file. Example a line in the file equal to Profile = 5 equals A-10C.";
+            logger.Info(message);
+            throw new Exception(message);
         }
     }
 }

--- a/Source/ClassLibraryCommon/packages.config
+++ b/Source/ClassLibraryCommon/packages.config
@@ -6,6 +6,7 @@
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net472" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net472" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net472" />
+  <package id="NLog" version="4.7.11" targetFramework="net472" />
   <package id="Octokit" version="0.50.0" targetFramework="net472" />
   <package id="OpenMacroBoard.SDK" version="3.0.0" targetFramework="net472" />
   <package id="StreamDeckSharp" version="3.0.0" targetFramework="net472" />

--- a/Source/DCS-BIOS/DCS-BIOS.csproj
+++ b/Source/DCS-BIOS/DCS-BIOS.csproj
@@ -67,6 +67,9 @@
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLog.4.7.11\lib\net45\NLog.dll</HintPath>
+    </Reference>
     <Reference Include="Octokit, Version=0.50.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octokit.0.50.0\lib\net46\Octokit.dll</HintPath>
     </Reference>
@@ -94,6 +97,7 @@
     <Reference Include="System.Drawing.Common, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Drawing.Common.6.0.0-preview.7.21377.19\lib\net461\System.Drawing.Common.dll</HintPath>
     </Reference>
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System.Runtime, Version=4.1.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -130,6 +134,7 @@
     <Reference Include="System.Security.Principal.Windows, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Principal.Windows.6.0.0-preview.5.21301.5\lib\net461\System.Security.Principal.Windows.dll</HintPath>
     </Reference>
+    <Reference Include="System.ServiceModel" />
     <Reference Include="System.ServiceProcess" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/Source/DCS-BIOS/DCSBIOS.cs
+++ b/Source/DCS-BIOS/DCSBIOS.cs
@@ -4,6 +4,8 @@
  * Do not adhere to naming standard in DCS-BIOS code, standard are based on DCS-BIOS json files and byte streamnaming
  */
 
+using NLog;
+
 namespace DCS_BIOS
 {
     using System;
@@ -12,10 +14,6 @@ namespace DCS_BIOS
     using System.Net.Sockets;
     using System.Text;
     using System.Threading;
-    using System.Windows.Forms;
-
-    using ClassLibraryCommon;
-
     using DCS_BIOS.Interfaces;
 
     [Flags]
@@ -28,6 +26,7 @@ namespace DCS_BIOS
 
     public class DCSBIOS : IDisposable
     {
+        internal static Logger logger = LogManager.GetCurrentClassLogger();
         //public delegate void DcsDataReceivedEventHandler(byte[] bytes);
         //public event DcsDataReceivedEventHandler OnDcsDataReceived;
 
@@ -138,12 +137,12 @@ namespace DCS_BIOS
                 
             }
             catch (ThreadAbortException) { }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                if (!e.Message.Contains("WSACancelBlockingCall"))
+                if (!ex.Message.Contains("WSACancelBlockingCall"))
                 {
-                    SetLastException(e);
-                    Common.LogError(e, "DCSBIOS.ReceiveData()");
+                    SetLastException(ex);
+                    logger.Error(ex, "DCSBIOS.ReceiveData()");
                 }
             }
         }
@@ -161,10 +160,10 @@ namespace DCS_BIOS
                 _dcsProtocolParser.Startup();
                 _dcsbiosListeningThread.Start();
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                SetLastException(e);
-                Common.LogError(e, "DCSBIOS.Startup()");
+                SetLastException(ex);
+                logger.Error(ex, "DCSBIOS.Startup()");
                 if (_udpReceiveClient != null && _udpReceiveClient.Client.Connected)
                 {
                     _udpReceiveClient.Close();
@@ -195,7 +194,7 @@ namespace DCS_BIOS
             catch (Exception ex)
             {
                 SetLastException(ex);
-                Common.LogError(ex, "DCSBIOS.Shutdown()");
+                logger.Error(ex, "DCSBIOS.Shutdown()");
             }
         }
 
@@ -298,10 +297,10 @@ namespace DCS_BIOS
                     result = _udpSendClient.Send(asciiBytes.ToArray(), asciiBytes.ToArray().Length, _ipEndPointSenderUdp);
                     //result = _udpSendClient.Send(bytes, bytes.Length, _ipEndPointSender);
                 }
-                catch (Exception e)
+                catch (Exception ex)
                 {
-                    SetLastException(e);
-                    Common.LogError(e, "DCSBIOS.SendDataFunction()");
+                    SetLastException(ex);
+                    logger.Error(ex, "DCSBIOS.SendDataFunction()");
                 }
             }
             return result;
@@ -329,7 +328,7 @@ namespace DCS_BIOS
                 {
                     return;
                 }
-                Common.LogError(ex, "Via DCSBIOS.SetLastException()");
+                logger.Error(ex, "Via DCSBIOS.SetLastException()");
                 var message = ex.GetType() + Environment.NewLine + ex.Message + Environment.NewLine + ex.StackTrace;
                 lock (_lockExceptionObject)
                 {
@@ -393,8 +392,4 @@ namespace DCS_BIOS
             set { _dcsbiosReceiveFromIPUdp = value; }
         }
     }
-
-
-
-
 }

--- a/Source/DCS-BIOS/DCSBIOSControlLocator.cs
+++ b/Source/DCS-BIOS/DCSBIOSControlLocator.cs
@@ -4,13 +4,16 @@
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
-
+    using System.Text;
     using ClassLibraryCommon;
 
     using Newtonsoft.Json;
+    using NLog;
 
     public static class DCSBIOSControlLocator
     {
+        internal static Logger logger = LogManager.GetCurrentClassLogger();
+
         private static readonly List<DCSBIOSControl> DCSBIOSControls = new List<DCSBIOSControl>();
         private static readonly object LockObject = new object();
         private static DCSFPProfile _dcsfpProfile;
@@ -191,9 +194,9 @@
                         controlObject.identifier.Equals("_UPDATE_SKIP_COUNTER")));
                 }
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                throw new Exception(DCSBIOSNotFoundErrorMessage + " ==>[" + _jsonDirectory + "]<==", e);
+                throw new Exception($"{DCSBIOSNotFoundErrorMessage} ==>[{_jsonDirectory}]<==", ex);
             }
         }
 
@@ -231,16 +234,13 @@
 
             if (dupes.Count > 0)
             {
-                var message = "Below is a list of duplicate identifiers found in the " + Profile.JSONFilename + " profile (DCS-BIOS)\n";
-                message = message + "The identifier must be unique, please correct the profile " + Profile.JSONFilename + " in the DCS-BIOS lib folder\n";
-                message = message + "---------------------------------------------\n";
-                foreach (var dupe in dupes)
-                {
-                    message = message + dupe + "\n";
-                }
-
-                message = message + "---------------------------------------------\n";
-                Common.LogError(message);
+                var message = new StringBuilder();
+                message.AppendLine($"Below is a list of duplicate identifiers found in the {Profile.JSONFilename} profile (DCS-BIOS)");
+                message.AppendLine($"The identifier must be unique, please correct the profile {Profile.JSONFilename} in the DCS-BIOS lib folder");
+                message.AppendLine("---------------------------------------------");
+                dupes.ForEach(dupe => message.AppendLine(dupe));
+                message.AppendLine("---------------------------------------------");
+                logger.Error(message);
             }
         }
         

--- a/Source/DCS-BIOS/DCSBIOSInput.cs
+++ b/Source/DCS-BIOS/DCSBIOSInput.cs
@@ -6,9 +6,8 @@ namespace DCS_BIOS
     using System;
     using System.Collections.Generic;
 
-    using ClassLibraryCommon;
-
     using Newtonsoft.Json;
+    using NLog;
 
     public enum DCSBIOSFixedStepInput
     {
@@ -27,6 +26,7 @@ namespace DCS_BIOS
     [Serializable]
     public class DCSBIOSInput
     {
+        internal static Logger logger = LogManager.GetCurrentClassLogger();
         // These are loaded and saved, all the rest are fetched from DCS-BIOS
         private string _controlId;
 
@@ -163,7 +163,7 @@ namespace DCS_BIOS
             }
             catch (Exception ex)
             {
-                Common.LogError( ex, "Error in DCSBIOSInput.ToString(), ControlId = " + _controlId);
+                logger.Error(ex, $"Error in DCSBIOSInput.ToString(), ControlId = {_controlId}");
                 throw;
             }
 

--- a/Source/DCS-BIOS/DCSBIOSOutputFormula.cs
+++ b/Source/DCS-BIOS/DCSBIOSOutputFormula.cs
@@ -4,9 +4,11 @@
     using System.Collections.Generic;
 
     using ClassLibraryCommon;
+    using NLog;
 
     public class DCSBIOSOutputFormula
     {
+        internal static Logger logger = LogManager.GetCurrentClassLogger();
         private readonly List<DCSBIOSOutput> _dcsbiosOutputs = new List<DCSBIOSOutput>();
         private readonly Dictionary<string, double> _variables = new Dictionary<string, double>();
         private readonly JaceExtended _jaceExtended = new JaceExtended();
@@ -48,7 +50,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex, "ExtractDCSBIOSOutputsInFormula() function");
+                logger.Error(ex, "ExtractDCSBIOSOutputsInFormula() function");
                 throw;
             }
         }
@@ -78,7 +80,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex, "CheckForMatch() function");
+                logger.Error(ex, "CheckForMatch() function");
                 throw;
             }
         }
@@ -97,7 +99,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex, "Evaluate() function");
+                logger.Error(ex, "Evaluate() function");
             }
 
             return 99;

--- a/Source/DCS-BIOS/DCSBIOSProtocolParser.cs
+++ b/Source/DCS-BIOS/DCSBIOSProtocolParser.cs
@@ -11,10 +11,9 @@ namespace DCS_BIOS
     using System.Linq;
     using System.Threading;
 
-    using ClassLibraryCommon;
-
     using DCS_BIOS.EventArgs;
     using DCS_BIOS.Interfaces;
+    using NLog;
 
     public enum DCSBiosStateEnum
     {
@@ -29,6 +28,7 @@ namespace DCS_BIOS
 
     internal class DCSBIOSProtocolParser : IDisposable
     {
+        internal static Logger logger = LogManager.GetCurrentClassLogger();
         public delegate void DcsDataAddressValueEventHandler(object sender, DCSBIOSDataEventArgs e);
         public event DcsDataAddressValueEventHandler OnDcsDataAddressValue;
 
@@ -148,17 +148,17 @@ namespace DCS_BIOS
                         
                         interval++;
                     }
-                    catch (Exception e)
+                    catch (Exception ex)
                     {
-                        Common.LogError( e, "DCSBIOSProtocolParser.ProcessArrays(), arrays to process : " + _arraysToProcess.Count);
+                        logger.Error(ex, $"DCSBIOSProtocolParser.ProcessArrays(), arrays to process : {_arraysToProcess.Count}");
                     }
                     _autoResetEvent?.WaitOne();
                 }
             }
             catch (ThreadAbortException) { }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                Common.LogError( e, "DCSBIOSProtocolParser.ProcessArrays(), arrays to process : " + _arraysToProcess.Count);
+                logger.Error(ex, $"DCSBIOSProtocolParser.ProcessArrays(), arrays to process : {_arraysToProcess.Count}");
             }
         }
 
@@ -254,12 +254,12 @@ namespace DCS_BIOS
                                     Debug.WriteLine("OnDcsDataAddressValue : " + OnDcsDataAddressValue.GetInvocationList().Length);
                                 }*/
                             }
-                            catch (Exception e)
+                            catch (Exception ex)
                             {
-                                if (!_errorsLogged.Contains(e.Message))
+                                if (!_errorsLogged.Contains(ex.Message))
                                 {
-                                    Common.LogError(e, "Error in DCS-BIOS stream. This error will be logged *just once*.");
-                                    _errorsLogged.Add(e.Message);
+                                    logger.Error(ex, "Error in DCS-BIOS stream. This error will be logged *just once*.");
+                                    _errorsLogged.Add(ex.Message);
                                 }
                             }
                         }
@@ -288,9 +288,9 @@ namespace DCS_BIOS
                     _syncByteCount = 0;
                 }
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                Common.LogError( e, "DCSBIOSProtocolParser.ProcessByte()");
+                logger.Error(ex, "DCSBIOSProtocolParser.ProcessByte()");
             }
         }
     }

--- a/Source/DCS-BIOS/DCSBIOSStringListener.cs
+++ b/Source/DCS-BIOS/DCSBIOSStringListener.cs
@@ -8,13 +8,14 @@ namespace DCS_BIOS
     using System.Collections.Generic;
     using System.Text;
 
-    using ClassLibraryCommon;
-
     using DCS_BIOS.EventArgs;
     using DCS_BIOS.Interfaces;
+    using NLog;
 
     public class DCSBIOSStringListener : IDcsBiosDataListener
     {
+        internal static Logger logger = LogManager.GetCurrentClassLogger();
+
         public delegate void DCSBIOSStringReceived(object sender, DCSBIOSStringDataEventArgs e);
         public event DCSBIOSStringReceived OnDCSBIOSStringReceived;
 
@@ -164,7 +165,7 @@ namespace DCS_BIOS
                             }
                             catch (Exception ex)
                             {
-                                Common.LogError( "**********Received (0x" + data.ToString("x") + ") Exception = " + ex.Message + Environment.NewLine + ex.StackTrace);
+                                logger.Error(ex, $"**********Received (0x{data.ToString("x")})");
                             }
                         }
                     }

--- a/Source/DCS-BIOS/JaceExtended.cs
+++ b/Source/DCS-BIOS/JaceExtended.cs
@@ -1,11 +1,12 @@
 ﻿using System;
-using ClassLibraryCommon;
 using Jace;
+using NLog;
 
 namespace DCS_BIOS
 {
     public class JaceExtended
     {
+        internal static Logger logger = LogManager.GetCurrentClassLogger();
         private readonly CalculationEngine _calculationEngine = new CalculationEngine();
 
         public JaceExtended()
@@ -21,7 +22,7 @@ namespace DCS_BIOS
             }
             catch (Exception ex)
             {
-                Common.LogError( ex, "JaceExtended.Evaluate() function");
+                logger.Error(ex, "JaceExtended.Evaluate() function");
                 throw;
             }
         }

--- a/Source/DCS-BIOS/packages.config
+++ b/Source/DCS-BIOS/packages.config
@@ -8,6 +8,7 @@
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net472" />
   <package id="Microsoft.Bcl.HashCode" version="1.0.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net472" />
+  <package id="NLog" version="4.7.11" targetFramework="net472" />
   <package id="Octokit" version="0.50.0" targetFramework="net472" />
   <package id="OpenMacroBoard.SDK" version="3.0.0" targetFramework="net472" />
   <package id="StreamDeckSharp" version="3.0.0" targetFramework="net472" />

--- a/Source/DCSFlightpanels/DCSFlightpanels.csproj
+++ b/Source/DCSFlightpanels/DCSFlightpanels.csproj
@@ -85,6 +85,9 @@
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLog.4.7.11\lib\net45\NLog.dll</HintPath>
+    </Reference>
     <Reference Include="Octokit, Version=0.50.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octokit.0.50.0\lib\net46\Octokit.dll</HintPath>
     </Reference>
@@ -112,6 +115,7 @@
     <Reference Include="System.Drawing.Common, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Drawing.Common.6.0.0-preview.7.21377.19\lib\net461\System.Drawing.Common.dll</HintPath>
     </Reference>
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System.Runtime, Version=4.1.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -148,6 +152,7 @@
     <Reference Include="System.Security.Principal.Windows, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Principal.Windows.6.0.0-preview.5.21301.5\lib\net461\System.Security.Principal.Windows.dll</HintPath>
     </Reference>
+    <Reference Include="System.ServiceModel" />
     <Reference Include="System.ServiceProcess" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/Source/DCSFlightpanels/DCSFlightpanels.csproj
+++ b/Source/DCSFlightpanels/DCSFlightpanels.csproj
@@ -676,6 +676,9 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <None Include="app.config" />
+    <None Include="NLog.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>

--- a/Source/DCSFlightpanels/MainWindow.xaml
+++ b/Source/DCSFlightpanels/MainWindow.xaml
@@ -37,6 +37,7 @@
             </MenuItem>
             <MenuItem Header="Options">
                 <MenuItem Name ="MenuItemErrorLog" Header="Open error log" Click="MenuItemErrorLog_OnClick" />
+                <MenuItem Name ="MenuItemDebugLog" Header="Open debug log" Click="MenuItemDebugLog_OnClick" />
                 <MenuItem Name ="MenuItemFormulaSandbox" Header="Formula sandbox" Click="MenuItemFormulaSandbox_OnClick" />
                 <Separator/>
                 <MenuItem Name ="MenuItemUSBPowerManagement" Header="Disable USB Power Management" Click="MenuItemUSBPowerManagement_OnClick" />

--- a/Source/DCSFlightpanels/NLog.config
+++ b/Source/DCSFlightpanels/NLog.config
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      throwConfigExceptions="true">
+
+  <targets>
+    <target name="error_logfile"
+            type="File"
+            fileName="${basedir}/DCSFlightpanels_error_log.txt"
+            layout="${longdate} ${level} ${message} ${exception:format=Message,StackTrace}"/>
+    <target name="debug_logfile"
+            type="File"
+            fileName="${basedir}/DCSFlightpanels_debug_log.txt"
+            layout="${longdate} ${level} ${message} ${exception:format=Message,StackTrace}"/>
+  </targets>
+  
+  <rules>
+    <logger name="*" minlevel="Info" writeTo="logconsole" />
+    <logger name="*" minlevel="Debug" writeTo="debug_logfile" />
+    <logger name="*" minlevel="Error" writeTo="error_logfile" />	
+  </rules>
+</nlog>

--- a/Source/DCSFlightpanels/NLog.config
+++ b/Source/DCSFlightpanels/NLog.config
@@ -6,17 +6,16 @@
   <targets>
     <target name="error_logfile"
             type="File"
-            fileName="${basedir}/DCSFlightpanels_error_log.txt"
-            layout="${longdate} ${level} ${message} ${exception:format=Message,StackTrace}"/>
+            fileName="${basedir}DCSFlightpanels_error_log.txt"
+            layout="${longdate}|${level}|${message}|${exception:format=Message,StackTrace}"/>
     <target name="debug_logfile"
             type="File"
-            fileName="${basedir}/DCSFlightpanels_debug_log.txt"
-            layout="${longdate} ${level} ${message} ${exception:format=Message,StackTrace}"/>
+            fileName="${basedir}DCSFlightpanels_debug_log.txt"
+            layout="${longdate}|${level}|${message}|${exception:format=Message,StackTrace}"/>
   </targets>
   
   <rules>
-    <logger name="*" minlevel="Info" writeTo="logconsole" />
     <logger name="*" minlevel="Debug" writeTo="debug_logfile" />
-    <logger name="*" minlevel="Error" writeTo="error_logfile" />	
+    <logger name="*" minlevel="Error" writeTo="error_logfile" />
   </rules>
 </nlog>

--- a/Source/DCSFlightpanels/PanelUserControls/MultiPanelUserControl.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/MultiPanelUserControl.xaml.cs
@@ -19,7 +19,6 @@
 
 
     using MEF;
-
     using NonVisuals;
     using NonVisuals.DCSBIOSBindings;
     using NonVisuals.EventArgs;

--- a/Source/DCSFlightpanels/PanelUserControls/StreamDeck/UserControlStreamDeckButtonAction.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/StreamDeck/UserControlStreamDeckButtonAction.xaml.cs
@@ -14,7 +14,7 @@
     using DCSFlightpanels.Windows;
 
     using MEF;
-
+    using NLog;
     using NonVisuals;
     using NonVisuals.Interfaces;
     using NonVisuals.Saitek;
@@ -26,6 +26,7 @@
     /// </summary>
     public partial class UserControlStreamDeckButtonAction : UserControlBase, IIsDirty, INvStreamDeckListener
     {
+        internal static Logger logger = LogManager.GetCurrentClassLogger();
         private List<StreamDeckActionTextBox> _textBoxes = new List<StreamDeckActionTextBox>();
 
         private StreamDeckButton _streamDeckButton;
@@ -1079,7 +1080,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -1094,7 +1095,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -1110,7 +1111,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -1127,7 +1128,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -1142,7 +1143,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -1158,7 +1159,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -1177,7 +1178,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -1205,7 +1206,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -1218,7 +1219,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 

--- a/Source/DCSFlightpanels/PanelUserControls/StreamDeck/UserControlStreamDeckButtonFace.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/StreamDeck/UserControlStreamDeckButtonFace.xaml.cs
@@ -16,7 +16,7 @@
     using DCSFlightpanels.Windows.StreamDeck;
 
     using MEF;
-
+    using NLog;
     using NonVisuals;
     using NonVisuals.Interfaces;
     using NonVisuals.StreamDeck;
@@ -30,6 +30,7 @@
     /// </summary>
     public partial class UserControlStreamDeckButtonFace : UserControlStreamDeckButtonAction.IStreamDeckButtonActionListener, IIsDirty, INvStreamDeckListener
     {
+        internal static Logger logger = LogManager.GetCurrentClassLogger();
         private readonly List<StreamDeckFaceTextBox> _textBoxList = new List<StreamDeckFaceTextBox>();
         private readonly List<RadioButton> _radioButtonList = new List<RadioButton>();
         private bool _isDirty = false;
@@ -700,7 +701,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -715,7 +716,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -731,7 +732,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -748,7 +749,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -763,7 +764,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -784,7 +785,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 

--- a/Source/DCSFlightpanels/PanelUserControls/StreamDeck/UserControlStreamDeckUIBase.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/StreamDeck/UserControlStreamDeckUIBase.cs
@@ -15,13 +15,14 @@
     using DCSFlightpanels.Shared;
 
     using MEF;
-
+    using NLog;
     using NonVisuals.Interfaces;
     using NonVisuals.StreamDeck;
     using NonVisuals.StreamDeck.Events;
 
     public abstract class UserControlStreamDeckUIBase : UserControl, IIsDirty, INvStreamDeckListener, IStreamDeckConfigListener, IOledImageListener
     {
+        internal static Logger logger = LogManager.GetCurrentClassLogger();
         protected readonly List<StreamDeckImage> ButtonImages = new List<StreamDeckImage>();
         protected readonly List<System.Windows.Controls.Image> DotImages = new List<System.Windows.Controls.Image>();
         protected bool UserControlLoaded;
@@ -455,7 +456,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -473,7 +474,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -490,7 +491,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -505,7 +506,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -520,7 +521,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -535,7 +536,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -550,7 +551,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -565,7 +566,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
     }

--- a/Source/DCSFlightpanels/PanelUserControls/StreamDeckUserControl.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/StreamDeckUserControl.xaml.cs
@@ -11,8 +11,7 @@
     using DCSFlightpanels.Interfaces;
     using DCSFlightpanels.PanelUserControls.StreamDeck;
     using DCSFlightpanels.Windows.StreamDeck;
-
-
+    using NLog;
     using NonVisuals;
     using NonVisuals.EventArgs;
     using NonVisuals.Interfaces;
@@ -24,6 +23,7 @@
     /// </summary>
     public partial class StreamDeckUserControl : UserControlBase, IGamingPanelListener, IProfileHandlerListener, IGamingPanelUserControl, INvStreamDeckListener
     {
+        internal static Logger logger = LogManager.GetCurrentClassLogger();
         private readonly StreamDeckPanel _streamDeckPanel;
         private readonly UserControlStreamDeckUIBase _uiButtonGrid;
         
@@ -563,7 +563,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -578,7 +578,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -593,7 +593,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -608,7 +608,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -623,7 +623,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -645,7 +645,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -659,7 +659,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
         
@@ -674,7 +674,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 

--- a/Source/DCSFlightpanels/Windows/BipLightWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/BipLightWindow.xaml.cs
@@ -70,9 +70,9 @@ namespace DCSFlightpanels.Windows
                 _bipLight.DelayBefore = (BIPLightDelays)ComboBoxDelay.SelectedValue;
                 _bipLight.BindingHash = (string)ComboBoxBIPPanel.SelectedValue;
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                throw new Exception("1003351 Error in CopyValues() : " + e.Message);
+                throw new Exception($"1003351 Error in CopyValues() : {ex.Message}");
             }
         }
 

--- a/Source/DCSFlightpanels/Windows/DCSBiosInputWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/DCSBiosInputWindow.xaml.cs
@@ -296,9 +296,9 @@ namespace DCSFlightpanels.Windows
                         }
                 }
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                throw new Exception("1003351 Error in CopyValues() : " + e.Message);
+                throw new Exception($"1003351 Error in CopyValues() : {ex.Message}");
             }
         }
 

--- a/Source/DCSFlightpanels/Windows/DCSBiosOutputFormulaWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/DCSBiosOutputFormulaWindow.xaml.cs
@@ -141,9 +141,9 @@
                 {
                     _dcsbiosOutputFormula = new DCSBIOSOutputFormula(TextBoxFormula.Text);
                 }
-                catch (Exception e)
+                catch (Exception ex)
                 {
-                    throw new Exception("Error while creating formula object : " + e.Message);
+                    throw new Exception($"Error while creating formula object : {ex.Message}");
                 }
             }
             else
@@ -158,9 +158,9 @@
                         _dcsBiosOutput.Consume(_dcsbiosControl);
                     }
                 }
-                catch (Exception e)
+                catch (Exception ex)
                 {
-                    throw new Exception("Error while creating DCSBIOSOutput object : " + e.Message);
+                    throw new Exception($"Error while creating DCSBIOSOutput object : {ex.Message}");
                 }
             }
         }

--- a/Source/DCSFlightpanels/Windows/DCSBiosOutputTriggerWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/DCSBiosOutputTriggerWindow.xaml.cs
@@ -166,9 +166,9 @@
                         {
                             var f = int.Parse(TextBoxTriggerValue.Text);
                         }
-                        catch (Exception e)
+                        catch (Exception ex)
                         {
-                            throw new Exception("Error while checking Trigger value. Only integers are allowed : " + e.Message);
+                            throw new Exception($"Error while checking Trigger value. Only integers are allowed : {ex.Message}");
                         }
                         if (_dcsBiosOutput.DCSBiosOutputType == DCSBiosOutputType.INTEGER_TYPE)
                         {
@@ -176,18 +176,18 @@
                         }
                         else
                         {
-                            throw new Exception("Error, DCSBIOSOutput can only have a Integer type output. This has String : " + _dcsBiosOutput.ControlId);
+                            throw new Exception($"Error, DCSBIOSOutput can only have a Integer type output. This has String : {_dcsBiosOutput.ControlId}");
                         }
                     }
                 }
-                catch (Exception e)
+                catch (Exception ex)
                 {
-                    throw new Exception("Error while checking Value format : " + e.Message);
+                    throw new Exception($"Error while checking Value format : {ex.Message}");
                 }
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                Common.ShowErrorMessageBox( e, "Error in CopyValues() : ");
+                Common.ShowErrorMessageBox(ex, "Error in CopyValues()");
             }
         }
 

--- a/Source/DCSFlightpanels/Windows/DCSBiosOutputWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/DCSBiosOutputWindow.xaml.cs
@@ -119,9 +119,9 @@ namespace DCSFlightpanels.Windows
                     _dcsBiosOutput.Consume(_dcsbiosControl);
                 }
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                throw new Exception("Error while creating DCSBIOSOutput object : " + e.Message);
+                throw new Exception($"Error while creating DCSBIOSOutput object : {ex.Message}");
             }
         }
 

--- a/Source/DCSFlightpanels/Windows/JaceSandboxWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/JaceSandboxWindow.xaml.cs
@@ -159,12 +159,12 @@
                                         LabelResult.Content = "Result : " + result;
                                     });
                             }
-                            catch (Exception e)
+                            catch (Exception ex)
                             {
                                 Dispatcher?.BeginInvoke(
                                     (Action)delegate
                                     {
-                                        LabelErrors.Content = e.Message;
+                                        LabelErrors.Content = ex.Message;
                                     });
                             }
                         }

--- a/Source/DCSFlightpanels/Windows/SettingsWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/SettingsWindow.xaml.cs
@@ -349,9 +349,9 @@ namespace DCSFlightpanels.Windows
                     }
                     IpAddressFromDCSBIOS = TextBoxDCSBIOSFromIP.Text;
                 }
-                catch (Exception e)
+                catch (Exception ex)
                 {
-                    throw new Exception("DCS-BIOS Error while checking IP from : " + e.Message);
+                    throw new Exception($"DCS-BIOS Error while checking IP from : {ex.Message}");
                 }
                 try
                 {
@@ -361,41 +361,41 @@ namespace DCSFlightpanels.Windows
                     }
                     IpAddressToDCSBIOS = TextBoxDCSBIOSToIP.Text;
                 }
-                catch (Exception e)
+                catch (Exception ex)
                 {
-                    throw new Exception("DCS-BIOS Error while checking IP to : " + e.Message);
+                    throw new Exception($"DCS-BIOS Error while checking IP to : {ex.Message}");
                 }
                 try
                 {
                     var test = Convert.ToInt32(TextBoxDCSBIOSFromPort.Text);
                     PortFromDCSBIOS = TextBoxDCSBIOSFromPort.Text;
                 }
-                catch (Exception e)
+                catch (Exception ex)
                 {
-                    throw new Exception("DCS-BIOS Error while Port from : " + e.Message);
+                    throw new Exception($"DCS-BIOS Error while Port from : {ex.Message}");
                 }
                 try
                 {
                     var test = Convert.ToInt32(TextBoxDCSBIOSFromPort.Text);
                     PortToDCSBIOS = TextBoxDCSBIOSToPort.Text;
                 }
-                catch (Exception e)
+                catch (Exception ex)
                 {
-                    throw new Exception("DCS-BIOS Error while Port to : " + e.Message);
+                    throw new Exception($"DCS-BIOS Error while Port to : {ex.Message}");
                 }
                 try
                 {
                     var directoryInfo = new DirectoryInfo(TextBoxDcsBiosJSONLocation.Text);
                     DcsBiosJSONLocation = TextBoxDcsBiosJSONLocation.Text;
                 }
-                catch (Exception e)
+                catch (Exception ex)
                 {
-                    throw new Exception("DCS-BIOS Error while checking DCS-BIOS location : " + e.Message);
+                    throw new Exception($"DCS-BIOS Error while checking DCS-BIOS location : {ex.Message}");
                 }
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                throw new Exception("DCS-BIOS Error checking values : " + Environment.NewLine + e.Message);
+                throw new Exception($"DCS-BIOS Error checking values : {Environment.NewLine}{ex.Message}");
             }
         }
 
@@ -428,9 +428,9 @@ namespace DCSFlightpanels.Windows
                     }
                     IpAddressFromSRS = TextBoxSRSFromIP.Text;
                 }
-                catch (Exception e)
+                catch (Exception ex)
                 {
-                    throw new Exception("SRS Error while checking IP from : " + e.Message);
+                    throw new Exception($"SRS Error while checking IP from : {ex.Message}");
                 }
                 try
                 {
@@ -440,32 +440,32 @@ namespace DCSFlightpanels.Windows
                     }
                     IpAddressToSRS = TextBoxSRSToIP.Text;
                 }
-                catch (Exception e)
+                catch (Exception ex)
                 {
-                    throw new Exception("SRS Error while checking IP to : " + e.Message);
+                    throw new Exception($"SRS Error while checking IP to : {ex.Message}");
                 }
                 try
                 {
                     var test = Convert.ToInt32(TextBoxSRSFromPort.Text);
                     PortFromSRS = TextBoxSRSFromPort.Text;
                 }
-                catch (Exception e)
+                catch (Exception ex)
                 {
-                    throw new Exception("SRS Error while Port from : " + e.Message);
+                    throw new Exception($"SRS Error while Port from : {ex.Message}");
                 }
                 try
                 {
                     var test = Convert.ToInt32(TextBoxSRSFromPort.Text);
                     PortToSRS = TextBoxSRSToPort.Text;
                 }
-                catch (Exception e)
+                catch (Exception ex)
                 {
-                    throw new Exception("SRS Error while Port to : " + e.Message);
+                    throw new Exception($"SRS Error while Port to : {ex.Message}");
                 }
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                throw new Exception("SRS Error checking values : " + Environment.NewLine + e.Message);
+                throw new Exception($"SRS Error checking values : {Environment.NewLine}{ex.Message}");
             }
         }
 

--- a/Source/DCSFlightpanels/Windows/StreamDeck/StreamDeckDCSBIOSDecoderWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/StreamDeck/StreamDeckDCSBIOSDecoderWindow.xaml.cs
@@ -252,9 +252,9 @@
                                 SetRawDCSBIOSValue(_dcsbiosDecoder.StringDcsBiosValue);
                             }
                         }
-                        catch (Exception e)
+                        catch (Exception ex)
                         {
-                            SetFormulaError(e.Message);
+                            SetFormulaError(ex.Message);
                         }
                     }
                     Thread.Sleep(10);

--- a/Source/DCSFlightpanels/packages.config
+++ b/Source/DCSFlightpanels/packages.config
@@ -8,6 +8,7 @@
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net472" />
   <package id="Microsoft.Bcl.HashCode" version="1.0.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net472" />
+  <package id="NLog" version="4.7.11" targetFramework="net472" />
   <package id="Octokit" version="0.50.0" targetFramework="net472" />
   <package id="OpenMacroBoard.SDK" version="3.0.0" targetFramework="net472" />
   <package id="StreamDeckSharp" version="3.0.0" targetFramework="net472" />

--- a/Source/NonVisuals/DCSBIOSBindings/DCSBIOSActionBindingBase.cs
+++ b/Source/NonVisuals/DCSBIOSBindings/DCSBIOSActionBindingBase.cs
@@ -4,15 +4,14 @@
     using System.Collections.Generic;
     using System.Threading;
 
-    using ClassLibraryCommon;
-
     using DCS_BIOS;
-
     using Newtonsoft.Json;
+    using NLog;
 
     [Serializable]
     public abstract class DCSBIOSActionBindingBase
     {
+        internal static Logger logger = LogManager.GetCurrentClassLogger();
         private bool _whenOnTurnedOn = true;
         private string _description;
         [NonSerialized] private Thread _sendDCSBIOSCommandsThread;
@@ -103,7 +102,7 @@
             { }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
         }
 

--- a/Source/NonVisuals/GamingPanel.cs
+++ b/Source/NonVisuals/GamingPanel.cs
@@ -9,12 +9,13 @@
     using DCS_BIOS;
     using DCS_BIOS.EventArgs;
     using DCS_BIOS.Interfaces;
-
+    using NLog;
     using NonVisuals.EventArgs;
     using NonVisuals.Interfaces;
 
     public abstract class GamingPanel : IProfileHandlerListener, IDcsBiosDataListener, IIsDirty
     {
+        internal static Logger logger = LogManager.GetCurrentClassLogger();
         private readonly DCSBIOSOutput _updateCounterDCSBIOSOutput;
         private readonly Guid _guid = Guid.NewGuid();
         private static readonly object UpdateCounterLockObject = new object();
@@ -193,7 +194,7 @@
                     return;
                 }
 
-                Common.LogError(ex, "Via GamingPanel.SetLastException()");
+                logger.Error(ex, "Via GamingPanel.SetLastException()");
                 lock (_exceptionLockObject)
                 {
                     _lastException = new Exception(ex.GetType() + Environment.NewLine + ex.Message + Environment.NewLine + ex.StackTrace);

--- a/Source/NonVisuals/NonVisuals.csproj
+++ b/Source/NonVisuals/NonVisuals.csproj
@@ -64,6 +64,9 @@
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLog.4.7.11\lib\net45\NLog.dll</HintPath>
+    </Reference>
     <Reference Include="Octokit, Version=0.50.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octokit.0.50.0\lib\net46\Octokit.dll</HintPath>
     </Reference>
@@ -131,6 +134,7 @@
     <Reference Include="System.Security.Principal.Windows, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Principal.Windows.6.0.0-preview.5.21301.5\lib\net461\System.Security.Principal.Windows.dll</HintPath>
     </Reference>
+    <Reference Include="System.ServiceModel" />
     <Reference Include="System.ServiceProcess" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/Source/NonVisuals/OSCommand.cs
+++ b/Source/NonVisuals/OSCommand.cs
@@ -4,14 +4,14 @@
     using System.Diagnostics;
     using System.Media;
     using System.Threading;
-
-    using ClassLibraryCommon;
-
+    using NLog;
     using NonVisuals.Saitek;
 
     [Serializable]
     public class OSCommand
     {
+        internal static Logger logger = LogManager.GetCurrentClassLogger();
+
         private string _file;
         private string _arguments;
         private string _name;
@@ -112,8 +112,8 @@
             catch (Exception ex)
             {
                 SystemSounds.Beep.Play();
-                result = "Failed to start " + _file + " with arguments " + _arguments + "." + ex.Message + "\n" + ex.StackTrace;
-                Common.LogError(result);
+                result = $"Failed to start {_file} with arguments {_arguments}.{ex.Message}\n{ex.StackTrace}";
+                logger.Error(ex, result);
             }
 
             return result;

--- a/Source/NonVisuals/ProfileHandler.cs
+++ b/Source/NonVisuals/ProfileHandler.cs
@@ -363,16 +363,16 @@
                         {
                             OnSettingsReadFromFile(this, new PanelBindingReadFromFileEventArgs { PanelBinding = genericPanelBinding });
                         }
-                        catch (Exception e)
+                        catch (Exception ex)
                         {
-                            Common.ShowErrorMessageBox(e, "Error reading settings. Panel : " + genericPanelBinding.PanelType);
+                            Common.ShowErrorMessageBox(ex, $"Error reading settings. Panel : {genericPanelBinding.PanelType}");
                         }
                     }
                 }
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                Common.ShowErrorMessageBox(e);
+                Common.ShowErrorMessageBox(ex);
             }
         }
 
@@ -391,16 +391,16 @@
                                 OnSettingsReadFromFile(this, new PanelBindingReadFromFileEventArgs { PanelBinding = genericPanelBinding });
                             }
                         }
-                        catch (Exception e)
+                        catch (Exception ex)
                         {
-                            Common.ShowErrorMessageBox(e, "Error reading settings. Panel : " + genericPanelBinding.PanelType);
+                            Common.ShowErrorMessageBox(ex, $"Error reading settings. Panel : {genericPanelBinding.PanelType}");
                         }
                     }
                 }
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                Common.ShowErrorMessageBox(e);
+                Common.ShowErrorMessageBox(ex);
             }
         }
 

--- a/Source/NonVisuals/Radios/Misc/RadioPanelPZ69DisplayValue.cs
+++ b/Source/NonVisuals/Radios/Misc/RadioPanelPZ69DisplayValue.cs
@@ -52,9 +52,9 @@
                 _radioPanelPZ69Display = (RadioPanelPZ69Display)Enum.Parse(typeof(RadioPanelPZ69Display), array[1]);
                 _radioPanelPZ69Knob = (RadioPanelPZ69KnobsEmulator)Enum.Parse(typeof(RadioPanelPZ69KnobsEmulator), array[0]);
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                throw new Exception("Failed to import setting for RadioPanelPZ69Display \n" + e.Message + "\n " + e.StackTrace);
+                throw new Exception($"Failed to import setting for RadioPanelPZ69Display{Environment.NewLine}{ex.Message}{Environment.NewLine}{ex.StackTrace}");
             }
         }
 

--- a/Source/NonVisuals/Radios/RadioPanelPZ69A10C.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69A10C.cs
@@ -4088,9 +4088,9 @@
             {
                 ShutdownBase();
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                SetLastException(e);
+                SetLastException(ex);
             }
         }
 

--- a/Source/NonVisuals/Radios/RadioPanelPZ69AJS37.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69AJS37.cs
@@ -11,7 +11,6 @@
     using DCS_BIOS.Interfaces;
 
     using MEF;
-
     using NonVisuals.Interfaces;
     using NonVisuals.Plugin;
     using NonVisuals.Radios.Knobs;
@@ -897,7 +896,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
         }
 
@@ -907,9 +906,9 @@
             {
                 ShutdownBase();
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                SetLastException(e);
+                SetLastException(ex);
             }
         }
 
@@ -937,7 +936,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
         }
 
@@ -952,7 +951,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
         }
 
@@ -974,7 +973,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
 
             return false;
@@ -998,7 +997,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
 
             return false;

--- a/Source/NonVisuals/Radios/RadioPanelPZ69AV8BNA.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69AV8BNA.cs
@@ -715,9 +715,9 @@
             {
                 ShutdownBase();
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                SetLastException(e);
+                SetLastException(ex);
             }
         }
 

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
@@ -6,7 +6,6 @@
     using System.Threading;
 
     using ClassLibraryCommon;
-
     using NonVisuals.EventArgs;
     using NonVisuals.Radios.Misc;
     using NonVisuals.Saitek.Panels;
@@ -217,9 +216,9 @@
             {
                 _pZ69DisplayBytes.BytesStringAsItOrPadLeftBlanks(ref bytes, digitString, pz69LCDPosition);
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                Common.LogError(e, "SetPZ69DisplayBytesString()");
+                logger.Error(ex, "SetPZ69DisplayBytesString()");
             }
         }
 
@@ -234,9 +233,9 @@
             {
                 _pZ69DisplayBytes.DefaultStringAsIt(ref bytes, digits, pz69LCDPosition);
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                Common.LogError(e, "SetPZ69DisplayBytesDefault()");
+                logger.Error(ex, "SetPZ69DisplayBytesDefault()");
             }
         }
 
@@ -270,9 +269,9 @@
                     bytes[arrayPosition] = b;
                     // Debug.WriteLine("Current string char is " + tmp + " from i = " + i + ", writing byte " + b + " to array position " + arrayPosition);
                 }
-                catch (Exception e)
+                catch (Exception ex)
                 {
-                    Common.LogError(e, "SetPZ69DisplayBytesDefault() digitsAsString.Length = " + digitsAsString.Length);
+                    logger.Error(ex, $"SetPZ69DisplayBytesDefault() digitsAsString.Length = {digitsAsString.Length}");
                 }
 
                 if (digitsAsString.Length > i + 1 && digitsAsString[i + 1] == '.')
@@ -326,9 +325,9 @@
 
                 // }
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                SetLastException(e);
+                SetLastException(ex);
             }
         }
 
@@ -407,9 +406,9 @@
                 thread.Start();
                 Thread.Sleep(200);
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                SetLastException(e);
+                SetLastException(ex);
             }
         }
 
@@ -419,9 +418,9 @@
             {
                 // HIDSkeletonBase = null;
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                SetLastException(e);
+                SetLastException(ex);
             }
         }
 

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Bf109.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Bf109.cs
@@ -11,7 +11,6 @@
     using DCS_BIOS.Interfaces;
 
     using MEF;
-
     using NonVisuals.Interfaces;
     using NonVisuals.Plugin;
     using NonVisuals.Radios.Knobs;
@@ -197,7 +196,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
         }
 
@@ -368,7 +367,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
         }
 
@@ -700,7 +699,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
         }
 
@@ -850,7 +849,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
 
             Interlocked.Add(ref _doUpdatePanelLCD, -1);
@@ -883,7 +882,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
         }
 
@@ -893,9 +892,9 @@
             {
                 ShutdownBase();
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                SetLastException(e);
+                SetLastException(ex);
             }
         }
 
@@ -923,7 +922,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
         }
 
@@ -938,7 +937,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
         }
 
@@ -960,7 +959,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
 
             return false;
@@ -984,7 +983,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
 
             return false;
@@ -1008,7 +1007,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
 
             return false;

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Emulator.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Emulator.cs
@@ -59,9 +59,9 @@
             {
                 Closed = true;
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                SetLastException(e);
+                SetLastException(ex);
             }
         }
 

--- a/Source/NonVisuals/Radios/RadioPanelPZ69F14B.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69F14B.cs
@@ -3295,9 +3295,9 @@
             {
                 ShutdownBase();
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                SetLastException(e);
+                SetLastException(ex);
             }
         }
 

--- a/Source/NonVisuals/Radios/RadioPanelPZ69F5E.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69F5E.cs
@@ -1962,9 +1962,9 @@
             {
                 ShutdownBase();
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                SetLastException(e);
+                SetLastException(ex);
             }
         }
 

--- a/Source/NonVisuals/Radios/RadioPanelPZ69F86F.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69F86F.cs
@@ -11,7 +11,6 @@
     using DCS_BIOS.Interfaces;
 
     using MEF;
-
     using NonVisuals.Interfaces;
     using NonVisuals.Plugin;
     using NonVisuals.Radios.Knobs;
@@ -1222,7 +1221,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
         }
 
@@ -1232,9 +1231,9 @@
             {
                 ShutdownBase();
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                SetLastException(e);
+                SetLastException(ex);
             }
         }
 
@@ -1262,7 +1261,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
         }
 
@@ -1277,7 +1276,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
         }
 
@@ -1300,7 +1299,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
 
             return false;
@@ -1324,7 +1323,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
 
             return false;
@@ -1348,7 +1347,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
 
             return false;
@@ -1372,7 +1371,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
 
             return false;
@@ -1396,7 +1395,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
 
             return false;

--- a/Source/NonVisuals/Radios/RadioPanelPZ69FA18C.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69FA18C.cs
@@ -1351,9 +1351,9 @@ namespace NonVisuals.Radios
             {
                 ShutdownBase();
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                SetLastException(e);
+                SetLastException(ex);
             }
         }
 

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Fw190.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Fw190.cs
@@ -11,7 +11,6 @@
     using DCS_BIOS.Interfaces;
 
     using MEF;
-
     using NonVisuals.Interfaces;
     using NonVisuals.Plugin;
     using NonVisuals.Radios.Knobs;
@@ -193,7 +192,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
         }
 
@@ -364,7 +363,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
         }
 
@@ -664,7 +663,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
         }
 
@@ -814,7 +813,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
 
             Interlocked.Add(ref _doUpdatePanelLCD, -1);
@@ -849,7 +848,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
         }
 
@@ -859,9 +858,9 @@
             {
                 ShutdownBase();
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                SetLastException(e);
+                SetLastException(ex);
             }
         }
 
@@ -889,7 +888,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
         }
 
@@ -904,7 +903,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
         }
 
@@ -926,7 +925,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
 
             return false;
@@ -950,7 +949,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
 
             return false;
@@ -974,7 +973,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
 
             return false;

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Generic.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Generic.cs
@@ -74,9 +74,9 @@
             {
                 Closed = true;
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                SetLastException(e);
+                SetLastException(ex);
             }
         }
 

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Ka50.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Ka50.cs
@@ -11,7 +11,6 @@
     using DCS_BIOS.EventArgs;
 
     using MEF;
-
     using NonVisuals.Interfaces;
     using NonVisuals.Plugin;
     using NonVisuals.Radios.Knobs;
@@ -20,7 +19,6 @@
     public class RadioPanelPZ69Ka50 : RadioPanelPZ69Base, IRadioPanel
     {
         private CurrentKa50RadioMode _currentUpperRadioMode = CurrentKa50RadioMode.VHF1_R828;
-
         private CurrentKa50RadioMode _currentLowerRadioMode = CurrentKa50RadioMode.VHF1_R828;
 
         /*COM1 Ka-50 VHF 1 R-828*/
@@ -400,7 +398,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -495,7 +493,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -516,7 +514,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -751,7 +749,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             // Refresh panel once this debacle is finished
@@ -767,7 +765,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -1032,7 +1030,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -1591,7 +1589,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -1626,7 +1624,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -1648,7 +1646,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             return false;
@@ -1672,7 +1670,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             return false;
@@ -1696,7 +1694,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             return false;
@@ -1720,7 +1718,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             return false;
@@ -1773,11 +1771,13 @@
                                     {
                                         frequencyAsString = _r800L1Freq1DialValues[_r800L1CockpitFreq1DialPos].ToString();
                                     }
-                                    catch (Exception e)
+                                    catch (Exception ex)
                                     {
                                         throw new Exception(
-                                            "Failed to get dial position from array _r800l1Freq1DialValues based on index " + _r800L1CockpitFreq1DialPos + ". Max array pos is "
-                                            + _r800L1Freq1DialValues.Length + "\n" + e.Message + "\n" + e.StackTrace);
+                                            $"Failed to get dial position from array _r800l1Freq1DialValues based on index {_r800L1CockpitFreq1DialPos}. " +
+                                            $"Max array pos is {_r800L1Freq1DialValues.Length}" +
+                                            $"{Environment.NewLine}{ex.Message}{Environment.NewLine}{ex.StackTrace}"
+                                            );
                                     }
                                 }
 
@@ -2020,7 +2020,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             Interlocked.Add(ref _doUpdatePanelLCD, -1);
@@ -2061,7 +2061,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -2071,9 +2071,9 @@
             {
                 ShutdownBase();
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                SetLastException(e);
+                SetLastException(ex);
             }
         }
 
@@ -2103,7 +2103,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -2118,7 +2118,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -2184,7 +2184,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -2247,7 +2247,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             return inc;
@@ -2604,7 +2604,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             throw new Exception(
@@ -2642,7 +2642,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             return string.Empty;

--- a/Source/NonVisuals/Radios/RadioPanelPZ69M2000C.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69M2000C.cs
@@ -12,7 +12,6 @@
     using DCS_BIOS.Interfaces;
 
     using MEF;
-
     using NonVisuals.Interfaces;
     using NonVisuals.Plugin;
     using NonVisuals.Radios.Knobs;
@@ -1228,7 +1227,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -1238,9 +1237,9 @@
             {
                 ShutdownBase();
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                SetLastException(e);
+                SetLastException(ex);
             }
         }
 
@@ -1268,7 +1267,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -1283,7 +1282,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -1306,7 +1305,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             return false;
@@ -1330,7 +1329,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             return false;
@@ -1354,7 +1353,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             return false;
@@ -1378,7 +1377,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             return false;

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Mi24P.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Mi24P.cs
@@ -525,7 +525,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -705,7 +705,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
             //Refresh panel once this debacle is finished
             Interlocked.Add(ref _doUpdatePanelLCD, 1);
@@ -720,7 +720,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -1849,7 +1849,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -1859,9 +1859,9 @@
             {
                 ShutdownBase();
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                SetLastException(e);
+                SetLastException(ex);
             }
         }
 
@@ -1889,7 +1889,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -1903,7 +1903,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -1952,7 +1952,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -1995,7 +1995,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
             throw new Exception("Should not reach this code. private String GetCommandDirectionFor0To9Dials(uint desiredDialPosition, uint actualDialPosition) -> " + desiredDialPosition + "   " + actualDialPosition);
         }
@@ -2017,7 +2017,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
             return false;
         }
@@ -2039,7 +2039,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
             return false;
         }
@@ -2061,7 +2061,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
             return false;
         }
@@ -2083,7 +2083,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
             return false;
         }
@@ -2105,7 +2105,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
             return false;
         }
@@ -2127,7 +2127,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
             return false;
         }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Mi8.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Mi8.cs
@@ -13,7 +13,6 @@
     using DCS_BIOS.Interfaces;
 
     using MEF;
-
     using NonVisuals.Interfaces;
     using NonVisuals.Plugin;
     using NonVisuals.Radios.Knobs;
@@ -22,7 +21,6 @@
     public class RadioPanelPZ69Mi8 : RadioPanelPZ69Base, IRadioPanel, IDCSBIOSStringListener
     {
         private CurrentMi8RadioMode _currentUpperRadioMode = CurrentMi8RadioMode.R863_MANUAL;
-
         private CurrentMi8RadioMode _currentLowerRadioMode = CurrentMi8RadioMode.R863_MANUAL;
 
         /*
@@ -867,7 +865,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -1089,7 +1087,7 @@
                     }
                     catch (ThreadAbortException ex)
                     {
-                        Common.LogError(ex);
+                        logger.Error(ex);
                     }
                     catch (Exception ex)
                     {
@@ -1103,7 +1101,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             // Refresh panel once this debacle is finished
@@ -1121,7 +1119,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -1142,7 +1140,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -1347,7 +1345,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             // Refresh panel once this debacle is finished
@@ -1363,7 +1361,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -2467,7 +2465,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -2956,7 +2954,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -2966,9 +2964,9 @@
             {
                 ShutdownBase();
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                SetLastException(e);
+                SetLastException(ex);
             }
         }
 
@@ -2998,7 +2996,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -3013,7 +3011,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -3068,7 +3066,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -3111,7 +3109,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -3179,7 +3177,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             return inc;
@@ -3235,7 +3233,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             throw new Exception(
@@ -3300,7 +3298,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             return false;
@@ -3324,7 +3322,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             return false;
@@ -3348,7 +3346,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             return false;
@@ -3372,7 +3370,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             return false;
@@ -3396,7 +3394,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             return false;
@@ -3420,7 +3418,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             return false;
@@ -3444,7 +3442,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             return false;

--- a/Source/NonVisuals/Radios/RadioPanelPZ69MiG21Bis.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69MiG21Bis.cs
@@ -4,14 +4,11 @@
     using System.Collections.Generic;
     using System.Threading;
 
-    using ClassLibraryCommon;
-
     using DCS_BIOS;
     using DCS_BIOS.EventArgs;
     using DCS_BIOS.Interfaces;
 
     using MEF;
-
     using NonVisuals.Interfaces;
     using NonVisuals.Plugin;
     using NonVisuals.Radios.Knobs;
@@ -783,7 +780,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
         }
 
@@ -793,9 +790,9 @@
             {
                 ShutdownBase();
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                SetLastException(e);
+                SetLastException(ex);
             }
         }
 

--- a/Source/NonVisuals/Radios/RadioPanelPZ69P51D.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69P51D.cs
@@ -4,13 +4,10 @@
     using System.Collections.Generic;
     using System.Threading;
 
-    using ClassLibraryCommon;
-
     using DCS_BIOS;
     using DCS_BIOS.EventArgs;
 
     using MEF;
-
     using NonVisuals.Interfaces;
     using NonVisuals.Plugin;
     using NonVisuals.Radios.Knobs;
@@ -159,7 +156,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
         }
 
@@ -276,7 +273,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
         }
 
@@ -424,7 +421,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
         }
 
@@ -447,7 +444,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
 
             return false;
@@ -525,7 +522,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
 
             Interlocked.Add(ref _doUpdatePanelLCD, -1);
@@ -633,7 +630,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
         }
 
@@ -643,9 +640,9 @@
             {
                 ShutdownBase();
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                SetLastException(e);
+                SetLastException(ex);
             }
         }
 
@@ -673,7 +670,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
         }
 
@@ -688,7 +685,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
         }
 

--- a/Source/NonVisuals/Radios/RadioPanelPZ69SA342.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69SA342.cs
@@ -12,7 +12,6 @@
     using DCS_BIOS.Interfaces;
 
     using MEF;
-
     using NonVisuals.Interfaces;
     using NonVisuals.Plugin;
     using NonVisuals.Radios.Knobs;
@@ -21,7 +20,6 @@
     public class RadioPanelPZ69SA342 : RadioPanelPZ69Base, IDCSBIOSStringListener, IRadioPanel
     {
         private CurrentSA342RadioMode _currentUpperRadioMode = CurrentSA342RadioMode.VHFAM;
-
         private CurrentSA342RadioMode _currentLowerRadioMode = CurrentSA342RadioMode.VHFAM;
 
         // 118.175
@@ -1889,7 +1887,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -1899,9 +1897,9 @@
             {
                 ShutdownBase();
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                SetLastException(e);
+                SetLastException(ex);
             }
         }
 
@@ -2166,7 +2164,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             return false;
@@ -2190,7 +2188,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             return false;
@@ -2214,7 +2212,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             return false;
@@ -2238,7 +2236,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             return false;
@@ -2313,7 +2311,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             return false;
@@ -2337,7 +2335,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             return false;
@@ -2361,7 +2359,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             return false;

--- a/Source/NonVisuals/Radios/RadioPanelPZ69SRS.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69SRS.cs
@@ -11,7 +11,6 @@
     using DCS_BIOS.EventArgs;
 
     using MEF;
-
     using NonVisuals.Interfaces;
     using NonVisuals.Plugin;
     using NonVisuals.Radios.Knobs;
@@ -93,9 +92,9 @@
                 ShutdownBase();
                 SRSListenerFactory.Shutdown();
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                SetLastException(e);
+                SetLastException(ex);
             }
         }
 
@@ -116,9 +115,9 @@
                 Interlocked.Add(ref _doUpdatePanelLCD, 1);
                 ShowFrequenciesOnPanel();
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                Common.LogError( e);
+                logger.Error(ex);
             }
         }
 
@@ -337,7 +336,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
         }
 
@@ -578,7 +577,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
         }
 
@@ -654,7 +653,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
 
             Interlocked.Add(ref _doUpdatePanelLCD, -1);
@@ -690,7 +689,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
         }
 
@@ -705,7 +704,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
         }
 
@@ -724,7 +723,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
 
             return false;
@@ -745,7 +744,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
 
             return false;
@@ -770,7 +769,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
         }
 

--- a/Source/NonVisuals/Radios/RadioPanelPZ69UH1H.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69UH1H.cs
@@ -13,7 +13,6 @@ namespace NonVisuals.Radios
     using DCS_BIOS.Interfaces;
 
     using MEF;
-
     using NonVisuals.Interfaces;
     using NonVisuals.Plugin;
     using NonVisuals.Radios.Knobs;
@@ -22,7 +21,6 @@ namespace NonVisuals.Radios
     public class RadioPanelPZ69UH1H : RadioPanelPZ69Base, IDCSBIOSStringListener, IRadioPanel
     {
         private CurrentUH1HRadioMode _currentUpperRadioMode = CurrentUH1HRadioMode.UHF;
-
         private CurrentUH1HRadioMode _currentLowerRadioMode = CurrentUH1HRadioMode.UHF;
 
         /*UH-1H INTERCOMM*/
@@ -876,7 +874,7 @@ namespace NonVisuals.Radios
             { }
             catch (Exception ex)
             {
-                Common.LogError( ex);
+                logger.Error(ex);
             }
         }
         */
@@ -998,7 +996,7 @@ namespace NonVisuals.Radios
                 }
                 catch (Exception ex)
                 {
-                    Common.LogError(ex);
+                    logger.Error(ex);
                 }
             }
             finally
@@ -1171,7 +1169,7 @@ namespace NonVisuals.Radios
                 }
                 catch (Exception ex)
                 {
-                    Common.LogError(ex);
+                    logger.Error(ex);
                 }
             }
             finally
@@ -1302,7 +1300,7 @@ namespace NonVisuals.Radios
                 }
                 catch (Exception ex)
                 {
-                    Common.LogError(ex);
+                    logger.Error(ex);
                 }
             }
             finally
@@ -1680,7 +1678,7 @@ namespace NonVisuals.Radios
                 }
                 catch (Exception ex)
                 {
-                    Common.LogError(ex);
+                    logger.Error(ex);
                 }
             }
             finally
@@ -1720,7 +1718,7 @@ namespace NonVisuals.Radios
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -3140,7 +3138,7 @@ namespace NonVisuals.Radios
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -3150,9 +3148,9 @@ namespace NonVisuals.Radios
             {
                 ShutdownBase();
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                SetLastException(e);
+                SetLastException(ex);
             }
         }
 

--- a/Source/NonVisuals/Radios/RadiopanelPZ69P47D.cs
+++ b/Source/NonVisuals/Radios/RadiopanelPZ69P47D.cs
@@ -11,7 +11,6 @@
     using DCS_BIOS.Interfaces;
 
     using MEF;
-
     using NonVisuals.Interfaces;
     using NonVisuals.Plugin;
     using NonVisuals.Radios.Knobs;
@@ -20,7 +19,6 @@
     public class RadioPanelPZ69P47D : RadioPanelPZ69Base, IRadioPanel, IDCSBIOSStringListener
     {
         private CurrentP47DRadioMode _currentUpperRadioMode = CurrentP47DRadioMode.HFRADIO;
-
         private CurrentP47DRadioMode _currentLowerRadioMode = CurrentP47DRadioMode.HFRADIO;
 
         /*
@@ -244,7 +242,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -384,7 +382,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -671,7 +669,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -817,7 +815,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             Interlocked.Add(ref _doUpdatePanelLCD, -1);
@@ -849,7 +847,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -859,9 +857,9 @@
             {
                 ShutdownBase();
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                SetLastException(e);
+                SetLastException(ex);
             }
         }
 
@@ -896,7 +894,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -910,7 +908,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -932,7 +930,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             return false;
@@ -956,7 +954,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
             return false;
         }
@@ -978,7 +976,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
             return false;
         }
@@ -1001,7 +999,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             return false;

--- a/Source/NonVisuals/Radios/RadiopanelSpitfireLFMkIX.cs
+++ b/Source/NonVisuals/Radios/RadiopanelSpitfireLFMkIX.cs
@@ -11,7 +11,6 @@
     using DCS_BIOS.Interfaces;
 
     using MEF;
-
     using NonVisuals.Interfaces;
     using NonVisuals.Plugin;
     using NonVisuals.Radios.Knobs;
@@ -20,7 +19,6 @@
     public class RadioPanelPZ69SpitfireLFMkIX : RadioPanelPZ69Base, IRadioPanel, IDCSBIOSStringListener
     {
         private CurrentSpitfireLFMkIXRadioMode _currentUpperRadioMode = CurrentSpitfireLFMkIXRadioMode.HFRADIO;
-
         private CurrentSpitfireLFMkIXRadioMode _currentLowerRadioMode = CurrentSpitfireLFMkIXRadioMode.HFRADIO;
 
         /*
@@ -254,7 +252,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -396,7 +394,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -692,7 +690,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -840,7 +838,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             Interlocked.Add(ref _doUpdatePanelLCD, -1);
@@ -873,7 +871,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -883,9 +881,9 @@
             {
                 ShutdownBase();
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                SetLastException(e);
+                SetLastException(ex);
             }
         }
 
@@ -920,7 +918,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -934,7 +932,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -956,7 +954,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             return false;
@@ -980,7 +978,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             return false;
@@ -1004,7 +1002,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             return false;
@@ -1028,7 +1026,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             return false;

--- a/Source/NonVisuals/Radios/SRS/SRSPlayerRadioInfo.cs
+++ b/Source/NonVisuals/Radios/SRS/SRSPlayerRadioInfo.cs
@@ -148,5 +148,9 @@ namespace NonVisuals.Radios.SRS
             return LastUpdate > Environment.TickCount - 10000;
         }
 
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(name, pos, radios, control, unit, unitId);
+        }
     }
 }

--- a/Source/NonVisuals/Radios/SRS/SRSRadio.cs
+++ b/Source/NonVisuals/Radios/SRS/SRSRadio.cs
@@ -8,11 +8,10 @@
     using System.Text;
     using System.Threading;
 
-    using ClassLibraryCommon;
-
     using MEF;
 
     using Newtonsoft.Json;
+    using NLog;
 
     public enum SRSRadioMode
     {
@@ -31,9 +30,6 @@
         private static string _srsSendToIPUdp = "127.0.0.1";
         private static int _srsReceivePortUdp = 7082;
         private static int _srsSendPortUdp = 9040;
-
-
-
 
         public static void SetParams(int portFrom, string ipAddressTo, int portTo)
         {
@@ -68,13 +64,11 @@
         }
 
         public static bool IsRunning => _srsListener != null && _srsListener.IsRunning;
-
-
-
     }
 
     public class SRSRadio
     {
+        internal static Logger logger = LogManager.GetCurrentClassLogger();
         private UdpClient _udpReceiveClient;
         private UdpClient _udpSendClient;
         private Thread _srsListeningThread;
@@ -87,17 +81,6 @@
         private readonly object _sendSRSDataLockObject = new object();
         private readonly object _readSRSDataLockObject = new object();
         public bool IsRunning;
-
-
-
-
-
-
-
-
-
-
-
 
 
         public SRSRadio(int portFrom, string ipAddressTo, int portTo)
@@ -134,16 +117,16 @@
                             OnSRSDataReceived?.Invoke(this);
                         }
                     }
-                    catch (Exception e)
+                    catch (Exception ex)
                     {
-                        Common.LogError( e, "SRSListener.ReceiveDataUdp()");
+                        logger.Error(ex, "SRSListener.ReceiveDataUdp()");
                     }
                 }
             }
             catch (ThreadAbortException) { }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                Common.LogError( e, "SRSListener.ReceiveDataUdp()");
+                logger.Error(ex, "SRSListener.ReceiveDataUdp()");
             }
 
             IsRunning = false;
@@ -162,9 +145,9 @@
                     asciiBytes.AddRange(Encoding.Convert(Encoding.Unicode, Encoding.ASCII, unicodeBytes));
                     result = _udpSendClient.Send(asciiBytes.ToArray(), asciiBytes.ToArray().Length, ipEndPointSenderUdp);
                 }
-                catch (Exception e)
+                catch (Exception ex)
                 {
-                    Common.LogError( e, "Error sending data to SRS. " + e.Message + Environment.NewLine + e.StackTrace);
+                    logger.Error(ex, $"Error sending data to SRS. {ex.Message}{Environment.NewLine}{ex.StackTrace}");
                 }
             }
 
@@ -206,9 +189,9 @@
 
                 _started = true;
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                Common.LogError( e, "SRSListener.StartupRP()");
+                logger.Error(ex, "SRSListener.StartupRP()");
                 if (_udpReceiveClient != null && _udpReceiveClient.Client.Connected)
                 {
                     _udpReceiveClient.Close();
@@ -724,7 +707,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError( ex, "SRSListener.ShutdownRP()");
+                logger.Error(ex, "SRSListener.ShutdownRP()");
             }
         }
 

--- a/Source/NonVisuals/Radios/SRS/SRSRadioInformation.cs
+++ b/Source/NonVisuals/Radios/SRS/SRSRadioInformation.cs
@@ -1,4 +1,6 @@
-﻿namespace NonVisuals.Radios.SRS
+﻿using System;
+
+namespace NonVisuals.Radios.SRS
 {
     // ReSharper disable All
     /*
@@ -120,6 +122,11 @@
             // return false;
             // }
             return true;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(name, freq, modulation, secFreq);
         }
     }
 }

--- a/Source/NonVisuals/Saitek/PZ70LCDButtonByteList.cs
+++ b/Source/NonVisuals/Saitek/PZ70LCDButtonByteList.cs
@@ -2,14 +2,14 @@
 {
     using System;
 
-    using ClassLibraryCommon;
-
     using MEF;
-
+    using NLog;
     using NonVisuals.Saitek.Panels;
 
     public class PZ70LCDButtonByteList
     {
+        internal static Logger logger = LogManager.GetCurrentClassLogger();
+
         /*
             LCD Button Byte
             00000000
@@ -61,9 +61,9 @@
             {
                 return FlipButton(GetMaskForDialPosition(pz70DialPosition), GetMaskForButton(multiPanelPZ70Knob));
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                Common.LogError(e, "Flipbutton()");
+                logger.Error(ex, "Flipbutton()");
                 throw;
             }
         }
@@ -84,9 +84,9 @@
 
                 throw new Exception("Multipanel IsOn : Failed to find Mask for dial position " + pz70DialPosition + " knob " + multiPanelPZ70Knobs);
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                Common.LogError(e, "IsOn()");
+                logger.Error(ex, "IsOn()");
                 throw;
             }
         }
@@ -125,9 +125,9 @@
                 }
                 throw new Exception("Multipanel : Failed to find Mask for dial position " + pz70DialPosition);
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                Common.LogError(e);
+                logger.Error(ex);
                 throw;
             }
         }
@@ -180,9 +180,9 @@
                 }
                 throw new Exception("Multipanel : Failed to find Mask for button " + multiPanelPZ70Knob);
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                Common.LogError(e);
+                logger.Error(ex);
                 throw;
             }
         }
@@ -202,9 +202,9 @@
 
                 throw new Exception("Multipanel FlipButton : Failed to find Mask for dial " + buttonDialMask + " button " + buttonMask);
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                Common.LogError(e);
+                logger.Error(ex);
                 throw;
             }
         }
@@ -244,9 +244,9 @@
 
                 throw new Exception("Multipanel ButtonOff : Failed to find Mask for dial " + buttonDialMask + " button " + buttonMask);
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                Common.LogError(e);
+                logger.Error(ex);
                 throw;
             }
         }
@@ -271,9 +271,9 @@
 
                 throw new Exception("Multipanel ButtonOn : Failed to find Mask for dial " + buttonDialMask + " button " + buttonMask);
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                Common.LogError(e);
+                logger.Error(ex);
                 throw;
             }
         }
@@ -294,9 +294,9 @@
 
                 throw new Exception("Multipanel : Failed to find button byte for " + pz70DialPosition);
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                Common.LogError(e);
+                logger.Error(ex);
                 throw;
             }
         }
@@ -315,9 +315,9 @@
 
                 throw new Exception("Multipanel GetButtonByte : Failed to find Mask for dial " + buttonDialMask);
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                Common.LogError(e);
+                logger.Error(ex);
                 throw;
             }
         }

--- a/Source/NonVisuals/Saitek/Panels/BacklitPanelBIP.cs
+++ b/Source/NonVisuals/Saitek/Panels/BacklitPanelBIP.cs
@@ -11,7 +11,6 @@
     using DCS_BIOS.EventArgs;
 
     using MEF;
-
     using NonVisuals.EventArgs;
 
     public class BacklitPanelBIP : SaitekPanel
@@ -95,9 +94,9 @@
                 BipFactory.DeRegisterBip(this);
                 Closed = true;
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                SetLastException(e);
+                SetLastException(ex);
             }
         }
 
@@ -316,7 +315,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
 
             return PanelLEDColor.RED;
@@ -598,9 +597,9 @@
             {
                 HIDSkeletonBase.HIDWriteDevice?.WriteFeatureData(array);
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                SetLastException(e);
+                SetLastException(ex);
             }
         }
 

--- a/Source/NonVisuals/Saitek/Panels/FarmingSidePanel.cs
+++ b/Source/NonVisuals/Saitek/Panels/FarmingSidePanel.cs
@@ -10,7 +10,6 @@
     using DCS_BIOS.EventArgs;
 
     using MEF;
-
     using NonVisuals.DCSBIOSBindings;
     using NonVisuals.EventArgs;
     using NonVisuals.Plugin;
@@ -46,7 +45,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -56,9 +55,9 @@
             {
                 Closed = true;
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                SetLastException(e);
+                SetLastException(ex);
             }
         }
 

--- a/Source/NonVisuals/Saitek/Panels/MultiPanelPZ70.cs
+++ b/Source/NonVisuals/Saitek/Panels/MultiPanelPZ70.cs
@@ -84,9 +84,9 @@
             {
                 Closed = true;
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                SetLastException(e);
+                SetLastException(ex);
             }
         }
 
@@ -1359,9 +1359,9 @@
                 // Common.DebugP("HIDWriteDevice writing feature data " + TypeOfSaitekPanel + " " + GuidString);
                 HIDSkeletonBase.HIDWriteDevice?.WriteFeatureData(array);
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                SetLastException(e);
+                SetLastException(ex);
             }
         }
 

--- a/Source/NonVisuals/Saitek/Panels/SwitchPanelPZ55.cs
+++ b/Source/NonVisuals/Saitek/Panels/SwitchPanelPZ55.cs
@@ -12,7 +12,6 @@
     using DCS_BIOS.EventArgs;
 
     using MEF;
-
     using NonVisuals.DCSBIOSBindings;
     using NonVisuals.EventArgs;
     using NonVisuals.Plugin;
@@ -61,7 +60,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -71,9 +70,9 @@
             {
                 Closed = true;
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                SetLastException(e);
+                SetLastException(ex);
             }
         }
 
@@ -334,7 +333,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex, "SetLandingGearLedsManually");
+                logger.Error(ex, "SetLandingGearLedsManually");
                 throw;
             }
         }
@@ -492,7 +491,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex, "CheckDcsDataForColorChangeHook(uint address, uint data)");
+                logger.Error(ex, "CheckDcsDataForColorChangeHook(uint address, uint data)");
                 throw;
             }
         }
@@ -865,9 +864,9 @@
                 this.LedLightChanged(new SaitekPanelLEDPosition(switchPanelPZ55LEDPosition), switchPanelPZ55LEDColor);
                 SetLandingGearLED(_ledUpperColor | _ledLeftColor | _ledRightColor);
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                SetLastException(e);
+                SetLastException(ex);
             }
         }
 
@@ -890,9 +889,9 @@
                 // Common.DebugP("Write ending");
                 // }
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                SetLastException(e);
+                SetLastException(ex);
             }
         }
 

--- a/Source/NonVisuals/Saitek/Panels/TPMPanel.cs
+++ b/Source/NonVisuals/Saitek/Panels/TPMPanel.cs
@@ -10,7 +10,6 @@
     using DCS_BIOS.EventArgs;
 
     using MEF;
-
     using NonVisuals.DCSBIOSBindings;
     using NonVisuals.EventArgs;
     using NonVisuals.Plugin;
@@ -47,7 +46,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -57,9 +56,9 @@
             {
                 Closed = true;
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                SetLastException(e);
+                SetLastException(ex);
             }
         }
 

--- a/Source/NonVisuals/StreamDeck/BitMapCreator.cs
+++ b/Source/NonVisuals/StreamDeck/BitMapCreator.cs
@@ -9,15 +9,14 @@
     using System.Windows.Media;
     using System.Windows.Media.Imaging;
 
-    using ClassLibraryCommon;
-
     using MEF;
-
+    using NLog;
     using Color = System.Drawing.Color;
     using PixelFormat = System.Drawing.Imaging.PixelFormat;
 
     public static class BitMapCreator
     {
+        internal static Logger logger = LogManager.GetCurrentClassLogger();
         public static Bitmap BitmapImage2Bitmap(BitmapImage bitmapImage)
         {
             using (var outStream = new MemoryStream())
@@ -191,9 +190,9 @@
                     return bitmapimage;
                 }
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                Common.LogError(e, "Failed to convert bitmap to bitmapimage.");
+                logger.Error(ex, "Failed to convert bitmap to bitmapimage.");
             }
 
             return null;

--- a/Source/NonVisuals/StreamDeck/DCSBIOSDecoder.cs
+++ b/Source/NonVisuals/StreamDeck/DCSBIOSDecoder.cs
@@ -9,19 +9,18 @@
     using System.Threading;
     using System.Windows.Media.Imaging;
 
-    using ClassLibraryCommon;
-
     using DCS_BIOS;
     using DCS_BIOS.EventArgs;
     using DCS_BIOS.Interfaces;
 
     using Newtonsoft.Json;
-
+    using NLog;
     using NonVisuals.StreamDeck.Events;
 
     [Serializable]
     public class DCSBIOSDecoder : FaceTypeDCSBIOS, IDcsBiosDataListener, IDCSBIOSStringListener, IDisposable
     {
+        internal static Logger logger = LogManager.GetCurrentClassLogger();
         private DCSBIOSOutput _dcsbiosOutput;
         private string _formula = string.Empty;
         private bool _useFormula;
@@ -167,7 +166,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex, "DcsBiosDataReceived()");
+                logger.Error(ex, "DcsBiosDataReceived()");
             }
         }
 
@@ -217,7 +216,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex, "DCSBIOSStringReceived()");
+                logger.Error(ex, "DCSBIOSStringReceived()");
             }
         }
 

--- a/Source/NonVisuals/StreamDeck/StreamDeckLayerHandler.cs
+++ b/Source/NonVisuals/StreamDeck/StreamDeckLayerHandler.cs
@@ -9,13 +9,11 @@
     using System.Reflection;
     using System.Text;
 
-    using ClassLibraryCommon;
-
     using MEF;
 
     using Newtonsoft.Json;
     using Newtonsoft.Json.Serialization;
-
+    using NLog;
     using NonVisuals.StreamDeck.Events;
 
     using OpenMacroBoard.SDK;
@@ -24,6 +22,8 @@
 
     public class StreamDeckLayerHandler
     {
+        internal static Logger logger = LogManager.GetCurrentClassLogger();
+
         private readonly StreamDeckPanel _streamDeckPanel;
         private volatile List<StreamDeckLayer> _layerList = new List<StreamDeckLayer>();
         private const string HOME_LAYER_ID = "*";
@@ -47,7 +47,7 @@
                                                                         ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
                                                                         Error = (sender, args) =>
                                                                             {
-                                                                                Common.LogError("JSON Error.\n" + args.ErrorContext.Error.Message);
+                                                                                logger.Error($"JSON Error.{args.ErrorContext.Error.Message}");
                                                                             }
                                                                     };
 

--- a/Source/NonVisuals/StreamDeck/StreamDeckPanel.cs
+++ b/Source/NonVisuals/StreamDeck/StreamDeckPanel.cs
@@ -14,7 +14,6 @@
     using DCS_BIOS.EventArgs;
 
     using MEF;
-
     using NonVisuals.EventArgs;
     using NonVisuals.Interfaces;
     using NonVisuals.Saitek;
@@ -44,10 +43,6 @@
         private readonly IStreamDeckBoard _streamDeckBoard;
         private int _lcdKnobSensitivity;
         private GamingPanelEnum _panelType;
-
-
-
-
 
         public StreamDeckPanel(GamingPanelEnum panelType, HIDSkeleton hidSkeleton) : base(panelType, hidSkeleton)
         {
@@ -203,7 +198,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -572,7 +567,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -587,7 +582,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -600,7 +595,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -613,7 +608,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -626,7 +621,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -639,7 +634,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -653,7 +648,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
 
@@ -668,7 +663,7 @@
             }
             catch (Exception ex)
             {
-                Common.LogError(ex);
+                logger.Error(ex);
             }
         }
     }

--- a/Source/NonVisuals/packages.config
+++ b/Source/NonVisuals/packages.config
@@ -8,6 +8,7 @@
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net472" />
   <package id="Microsoft.Bcl.HashCode" version="1.0.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net472" />
+  <package id="NLog" version="4.7.11" targetFramework="net472" />
   <package id="Octokit" version="0.50.0" targetFramework="net472" />
   <package id="OpenMacroBoard.SDK" version="3.0.0" targetFramework="net472" />
   <package id="StreamDeckSharp" version="3.0.0" targetFramework="net472" />


### PR DESCRIPTION
Replace custom logger with Nlog.
Replacement was pretty straightforward and should not break anything.
There are currently 2 file logs configured `Debug` and `Error` Only error is used right now afaik.
Log presentation, target configuration, log levels is all done in the `NLog.config` file. Currently it's all very basic but should mimic the previous custom logger.

To use the logger anywhere in the program , just declare the static in the class:
`internal static Logger logger = LogManager.GetCurrentClassLogger();`
then use something like `logger.Debug("message"); or logger.Debug(ex,"message")`

What is in this PR:
* Replaced custom log system with NLog
* Standardized ...catch (Exception e) to ...catch (Exception ex)
* Used string interpolation instead of string concatenation for some messages
* Added an "Open debug log" MenuItem in the main menu. Could be handy
* Implemented 2 missing GetHashCode() to avoid compilation warning

What could be improved:
* Logs could grow pretty fast (especially trace/debug logs catching events). There is an option to automatically archive logs, never used it, but I doubt that outside of debug purpose the logs are precious. Maybe an alternative would be to present the user with a message "looks like your log files are pretty big, do you want to delete them ?" or something like that.
* Better tweak of min/max log levels and targets to easily place logger.Trace() or logger.Debug() for debugging purpose only
* Maybe put the logs in a subdirectory `\Logs\`