### PR TITLE
[Unit tests] final radio unit tests

### DIFF
--- a/Source/NonVisuals/Radios/Misc/PZ69DisplayBytes.cs
+++ b/Source/NonVisuals/Radios/Misc/PZ69DisplayBytes.cs
@@ -198,7 +198,7 @@ namespace NonVisuals.Radios.Misc
             while (i < digits.Length && arrayPosition < maxArrayPosition + 1);
         }
 
-        public void DoubleWithForcedDecimals(ref byte[] bytes, double digits, int decimals, PZ69LCDPosition pz69LCDPosition)
+        public void DoubleWithSpecifiedDecimalsPlaces(ref byte[] bytes, double digits, int decimals, PZ69LCDPosition pz69LCDPosition)
         {
             var arrayPosition = GetArrayPosition(pz69LCDPosition);
             var maxArrayPosition = GetArrayPosition(pz69LCDPosition) + 4;

--- a/Source/NonVisuals/Radios/Misc/PZ69DisplayBytes.cs
+++ b/Source/NonVisuals/Radios/Misc/PZ69DisplayBytes.cs
@@ -237,7 +237,7 @@
             while (i < digitsAsString.Length && arrayPosition < maxArrayPosition + 1);
         }
 
-        public void Double(ref byte[] bytes, double digits, PZ69LCDPosition pz69LCDPosition)
+        public void DoubleJustifyLeft(ref byte[] bytes, double digits, PZ69LCDPosition pz69LCDPosition)
         {
             var arrayPosition = GetArrayPosition(pz69LCDPosition);
             var maxArrayPosition = GetArrayPosition(pz69LCDPosition) + 4;

--- a/Source/NonVisuals/Radios/Misc/PZ69DisplayBytes.cs
+++ b/Source/NonVisuals/Radios/Misc/PZ69DisplayBytes.cs
@@ -1,5 +1,6 @@
 ﻿
 using System;
+using System.Globalization;
 
 namespace NonVisuals.Radios.Misc
 {
@@ -195,6 +196,43 @@ namespace NonVisuals.Radios.Misc
                 i++;
             }
             while (i < digits.Length && arrayPosition < maxArrayPosition + 1);
+        }
+
+        public void DoubleWithForcedDecimals(ref byte[] bytes, double digits, int decimals, PZ69LCDPosition pz69LCDPosition)
+        {
+            var arrayPosition = GetArrayPosition(pz69LCDPosition);
+            var maxArrayPosition = GetArrayPosition(pz69LCDPosition) + 4;
+            var i = 0;
+            var formatString = "0.".PadRight(decimals + 2, '0');
+
+            var numberFormatInfoEmpty = new NumberFormatInfo()
+            {
+                NumberDecimalSeparator = ".",
+                NumberGroupSeparator = string.Empty
+            };
+
+            var digitsAsString = digits.ToString(formatString, numberFormatInfoEmpty).PadLeft(6);
+
+            do
+            {
+                if (digitsAsString[i] == '.')
+                {
+                    // skip to next position, this has already been dealt with
+                    i++;
+                }
+
+                byte b;
+                b = digitsAsString[i].ToString().Equals(" ") ? (byte)0xFF : byte.Parse(digitsAsString[i].ToString());
+                bytes[arrayPosition] = b;
+                if (digitsAsString.Length > i + 1 && digitsAsString[i + 1] == '.')
+                {
+                    bytes[arrayPosition] = (byte)(bytes[arrayPosition] + 0xd0);
+                }
+
+                arrayPosition++;
+                i++;
+            }
+            while (i < digitsAsString.Length && arrayPosition < maxArrayPosition + 1);
         }
 
         /// <summary>

--- a/Source/NonVisuals/Radios/Misc/PZ69DisplayBytes.cs
+++ b/Source/NonVisuals/Radios/Misc/PZ69DisplayBytes.cs
@@ -1,11 +1,13 @@
-﻿
-using System;
-using System.Globalization;
-
-namespace NonVisuals.Radios.Misc
+﻿namespace NonVisuals.Radios.Misc
 {
+    using NLog;
+    using System;
+    using System.Globalization;
+
     public class PZ69DisplayBytes
     {
+        internal static Logger logger = LogManager.GetCurrentClassLogger();
+
         /// <summary>
         /// Right justify, pad left with blanks.
         /// </summary>
@@ -227,6 +229,61 @@ namespace NonVisuals.Radios.Misc
                 if (digitsAsString.Length > i + 1 && digitsAsString[i + 1] == '.')
                 {
                     bytes[arrayPosition] = (byte)(bytes[arrayPosition] + 0xd0);
+                }
+
+                arrayPosition++;
+                i++;
+            }
+            while (i < digitsAsString.Length && arrayPosition < maxArrayPosition + 1);
+        }
+
+        public void Double(ref byte[] bytes, double digits, PZ69LCDPosition pz69LCDPosition)
+        {
+            var arrayPosition = GetArrayPosition(pz69LCDPosition);
+            var maxArrayPosition = GetArrayPosition(pz69LCDPosition) + 4;
+
+            // Debug.WriteLine("LCD position is " + pz69LCDPosition);
+            // Debug.WriteLine("Array position = " + arrayPosition);
+            // Debug.WriteLine("Max array position = " + (maxArrayPosition));
+            var i = 0;
+            NumberFormatInfo numberFormatInfoFullDisplay = new NumberFormatInfo()
+            {
+                NumberDecimalSeparator = ".",
+                NumberDecimalDigits = 4,
+                NumberGroupSeparator = string.Empty
+            };
+
+            var digitsAsString = digits.ToString("0.0000", numberFormatInfoFullDisplay);
+            // 116 should become 116.00!
+            do
+            {
+                // 5 digits can be displayed
+                // 1.00000011241 -> 1.0000
+                // 116.0434      -> 116.04 
+                // 1199330.12449 -> 11993
+                if (digitsAsString[i] == '.')
+                {
+                    // skip to next position, this has already been dealt with
+                    i++;
+                }
+
+                try
+                {
+                    var tmp = digitsAsString[i].ToString();
+                    var b = byte.Parse(tmp);
+                    bytes[arrayPosition] = b;
+                    // Debug.WriteLine("Current string char is " + tmp + " from i = " + i + ", writing byte " + b + " to array position " + arrayPosition);
+                }
+                catch (Exception ex)
+                {
+                    logger.Error(ex, $"SetPZ69DisplayBytesDefault() digitsAsString.Length = {digitsAsString.Length}");
+                }
+
+                if (digitsAsString.Length > i + 1 && digitsAsString[i + 1] == '.')
+                {
+                    // Add decimal marker
+                    bytes[arrayPosition] = (byte)(bytes[arrayPosition] + 0xd0);
+                    // Debug.WriteLine("Writing decimal marker to array position " + arrayPosition);
                 }
 
                 arrayPosition++;

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
@@ -22,7 +22,6 @@
     {
         private byte _ignoreSwitchButtonCounter = 3;
         protected NumberFormatInfo NumberFormatInfoFullDisplay;
-        protected NumberFormatInfo NumberFormatInfoEmpty;
         private int _frequencyKnobSensitivity;
         private volatile byte _frequencySensitivitySkipper;
         protected readonly object LockLCDUpdateObject = new object();
@@ -49,10 +48,6 @@
             NumberFormatInfoFullDisplay.NumberDecimalSeparator = ".";
             NumberFormatInfoFullDisplay.NumberDecimalDigits = 4;
             NumberFormatInfoFullDisplay.NumberGroupSeparator = string.Empty;
-
-            NumberFormatInfoEmpty = new NumberFormatInfo();
-            NumberFormatInfoEmpty.NumberDecimalSeparator = ".";
-            NumberFormatInfoEmpty.NumberGroupSeparator = string.Empty;
         }
 
         /*         
@@ -108,7 +103,13 @@
             var maxArrayPosition = GetArrayPosition(pz69LCDPosition) + 4;
             var i = 0;
             var formatString = "0.".PadRight(decimals + 2, '0');
-            var digitsAsString = digits.ToString(formatString, NumberFormatInfoEmpty).PadLeft(6);
+
+            var numberFormatInfoEmpty = new NumberFormatInfo() {
+                NumberDecimalSeparator = ".",
+                NumberGroupSeparator = string.Empty
+            };
+
+            var digitsAsString = digits.ToString(formatString, numberFormatInfoEmpty).PadLeft(6);
 
             do
             {

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
@@ -99,38 +99,7 @@
 
         protected void SetPZ69DisplayBytes(ref byte[] bytes, double digits, int decimals, PZ69LCDPosition pz69LCDPosition)
         {
-            var arrayPosition = GetArrayPosition(pz69LCDPosition);
-            var maxArrayPosition = GetArrayPosition(pz69LCDPosition) + 4;
-            var i = 0;
-            var formatString = "0.".PadRight(decimals + 2, '0');
-
-            var numberFormatInfoEmpty = new NumberFormatInfo() {
-                NumberDecimalSeparator = ".",
-                NumberGroupSeparator = string.Empty
-            };
-
-            var digitsAsString = digits.ToString(formatString, numberFormatInfoEmpty).PadLeft(6);
-
-            do
-            {
-                if (digitsAsString[i] == '.')
-                {
-                    // skip to next position, this has already been dealt with
-                    i++;
-                }
-
-                byte b;
-                b = digitsAsString[i].ToString().Equals(" ") ? (byte)0xFF : byte.Parse(digitsAsString[i].ToString());
-                bytes[arrayPosition] = b;
-                if (digitsAsString.Length > i + 1 && digitsAsString[i + 1] == '.')
-                {
-                    bytes[arrayPosition] = (byte)(bytes[arrayPosition] + 0xd0);
-                }
-
-                arrayPosition++;
-                i++;
-            }
-            while (i < digitsAsString.Length && arrayPosition < maxArrayPosition + 1);
+            _pZ69DisplayBytes.DoubleWithForcedDecimals(ref bytes, digits, decimals, pz69LCDPosition);
         }
 
         /// <summary>

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
@@ -211,57 +211,7 @@
 
         protected void SetPZ69DisplayBytesDefault(ref byte[] bytes, double digits, PZ69LCDPosition pz69LCDPosition)
         {
-            var arrayPosition = GetArrayPosition(pz69LCDPosition);
-            var maxArrayPosition = GetArrayPosition(pz69LCDPosition) + 4;
-
-            // Debug.WriteLine("LCD position is " + pz69LCDPosition);
-            // Debug.WriteLine("Array position = " + arrayPosition);
-            // Debug.WriteLine("Max array position = " + (maxArrayPosition));
-            var i = 0;
-            NumberFormatInfo numberFormatInfoFullDisplay = new NumberFormatInfo()
-            {
-                NumberDecimalSeparator = ".",
-                NumberDecimalDigits = 4,
-                NumberGroupSeparator = string.Empty
-            };
-
-            var digitsAsString = digits.ToString("0.0000", numberFormatInfoFullDisplay);
-            // 116 should become 116.00!
-            do
-            {
-                // 5 digits can be displayed
-                // 1.00000011241 -> 1.0000
-                // 116.0434      -> 116.04 
-                // 1199330.12449 -> 11993
-                if (digitsAsString[i] == '.')
-                {
-                    // skip to next position, this has already been dealt with
-                    i++;
-                }
-
-                try
-                {
-                    var tmp = digitsAsString[i].ToString();
-                    var b = byte.Parse(tmp);
-                    bytes[arrayPosition] = b;
-                    // Debug.WriteLine("Current string char is " + tmp + " from i = " + i + ", writing byte " + b + " to array position " + arrayPosition);
-                }
-                catch (Exception ex)
-                {
-                    logger.Error(ex, $"SetPZ69DisplayBytesDefault() digitsAsString.Length = {digitsAsString.Length}");
-                }
-
-                if (digitsAsString.Length > i + 1 && digitsAsString[i + 1] == '.')
-                {
-                    // Add decimal marker
-                    bytes[arrayPosition] = (byte)(bytes[arrayPosition] + 0xd0);
-                    // Debug.WriteLine("Writing decimal marker to array position " + arrayPosition);
-                }
-
-                arrayPosition++;
-                i++;
-            }
-            while (i < digitsAsString.Length && arrayPosition < maxArrayPosition + 1);
+            _pZ69DisplayBytes.Double(ref bytes, digits, pz69LCDPosition);
         }
 
         private int GetArrayPosition(PZ69LCDPosition pz69LCDPosition)

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
@@ -99,7 +99,7 @@
 
         protected void SetPZ69DisplayBytes(ref byte[] bytes, double digits, int decimals, PZ69LCDPosition pz69LCDPosition)
         {
-            _pZ69DisplayBytes.DoubleWithForcedDecimals(ref bytes, digits, decimals, pz69LCDPosition);
+            _pZ69DisplayBytes.DoubleWithSpecifiedDecimalsPlaces(ref bytes, digits, decimals, pz69LCDPosition);
         }
 
         /// <summary>

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
@@ -211,35 +211,7 @@
 
         protected void SetPZ69DisplayBytesDefault(ref byte[] bytes, double digits, PZ69LCDPosition pz69LCDPosition)
         {
-            _pZ69DisplayBytes.Double(ref bytes, digits, pz69LCDPosition);
-        }
-
-        private int GetArrayPosition(PZ69LCDPosition pz69LCDPosition)
-        {
-            switch (pz69LCDPosition)
-            {
-                case PZ69LCDPosition.UPPER_ACTIVE_LEFT:
-                    {
-                        return 1;
-                    }
-
-                case PZ69LCDPosition.UPPER_STBY_RIGHT:
-                    {
-                        return 6;
-                    }
-
-                case PZ69LCDPosition.LOWER_ACTIVE_LEFT:
-                    {
-                        return 11;
-                    }
-
-                case PZ69LCDPosition.LOWER_STBY_RIGHT:
-                    {
-                        return 16;
-                    }
-            }
-
-            return 1;
+            _pZ69DisplayBytes.DoubleJustifyLeft(ref bytes, digits, pz69LCDPosition);
         }
 
         public void SendLCDData(byte[] array)

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
@@ -21,7 +21,7 @@
     public abstract class RadioPanelPZ69Base : SaitekPanel
     {
         private byte _ignoreSwitchButtonCounter = 3;
-        protected NumberFormatInfo NumberFormatInfoFullDisplay;
+        private NumberFormatInfo _numberFormatInfoFullDisplay;
         private int _frequencyKnobSensitivity;
         private volatile byte _frequencySensitivitySkipper;
         protected readonly object LockLCDUpdateObject = new object();
@@ -44,10 +44,10 @@
                 throw new ArgumentException();
             }
 
-            NumberFormatInfoFullDisplay = new NumberFormatInfo();
-            NumberFormatInfoFullDisplay.NumberDecimalSeparator = ".";
-            NumberFormatInfoFullDisplay.NumberDecimalDigits = 4;
-            NumberFormatInfoFullDisplay.NumberGroupSeparator = string.Empty;
+            _numberFormatInfoFullDisplay = new NumberFormatInfo();
+            _numberFormatInfoFullDisplay.NumberDecimalSeparator = ".";
+            _numberFormatInfoFullDisplay.NumberDecimalDigits = 4;
+            _numberFormatInfoFullDisplay.NumberGroupSeparator = string.Empty;
         }
 
         /*         
@@ -218,7 +218,14 @@
             // Debug.WriteLine("Array position = " + arrayPosition);
             // Debug.WriteLine("Max array position = " + (maxArrayPosition));
             var i = 0;
-            var digitsAsString = digits.ToString("0.0000", NumberFormatInfoFullDisplay);
+            NumberFormatInfo numberFormatInfoFullDisplay = new NumberFormatInfo()
+            {
+                NumberDecimalSeparator = ".",
+                NumberDecimalDigits = 4,
+                NumberGroupSeparator = string.Empty
+            };
+
+            var digitsAsString = digits.ToString("0.0000", numberFormatInfoFullDisplay);
             // 116 should become 116.00!
             do
             {
@@ -455,10 +462,9 @@
             set => _syncOKDelayTimeout = value * 10000;
         }
 
-        public NumberFormatInfo NumberFormatInfo
+        public NumberFormatInfo NumberFormatInfoFullDisplay
         {
             get => NumberFormatInfoFullDisplay;
-            set => NumberFormatInfoFullDisplay = value;
         }
 
         public int FrequencyKnobSensitivity

--- a/Source/NonVisuals/Radios/RadioPanelPZ69M2000C.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69M2000C.cs
@@ -116,7 +116,7 @@
                     lock (_lockVUHFPresetFreqObject)
                     {
                         var tmp = _vhfPresetCockpitFrequency;
-                        _vhfPresetCockpitFrequency = (double.Parse(e.StringData) / 100).ToString(NumberFormatInfo);
+                        _vhfPresetCockpitFrequency = (double.Parse(e.StringData) / 100).ToString(NumberFormatInfoFullDisplay);
                         if (!string.IsNullOrEmpty(_vhfPresetCockpitFrequency) && tmp != _vhfPresetCockpitFrequency)
                         {
                             Interlocked.Add(ref _doUpdatePanelLCD, 5);
@@ -130,7 +130,7 @@
                     lock (_lockUHFPresetFreqObject)
                     {
                         var tmp = _uhfPresetCockpitFrequency;
-                        _uhfPresetCockpitFrequency = (double.Parse(e.StringData) / 100).ToString(NumberFormatInfo);
+                        _uhfPresetCockpitFrequency = (double.Parse(e.StringData) / 100).ToString(NumberFormatInfoFullDisplay);
                         if (!string.IsNullOrEmpty(_uhfPresetCockpitFrequency) && tmp != _uhfPresetCockpitFrequency)
                         {
                             Interlocked.Add(ref _doUpdatePanelLCD, 5);

--- a/Source/NonVisuals/Radios/RadioPanelPZ69UH1H.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69UH1H.cs
@@ -3102,11 +3102,6 @@ namespace NonVisuals.Radios
             {
                 StartupBase("UH-1H");
 
-                NumberFormatInfoFullDisplay = new NumberFormatInfo();
-                NumberFormatInfoFullDisplay.NumberDecimalSeparator = ".";
-                NumberFormatInfoFullDisplay.NumberDecimalDigits = 4;
-                NumberFormatInfoFullDisplay.NumberGroupSeparator = string.Empty;
-
                 // VHF COMM
                 _vhfCommDcsbiosOutputCockpitFrequency = DCSBIOSControlLocator.GetDCSBIOSOutput("VHFCOMM_FREQ");
                 DCSBIOSStringManager.AddListener(_vhfCommDcsbiosOutputCockpitFrequency, this);

--- a/Source/Tests/NonVisuals/RadiosPZ69DisplayBytesTests.cs
+++ b/Source/Tests/NonVisuals/RadiosPZ69DisplayBytesTests.cs
@@ -239,5 +239,70 @@ namespace Tests.NonVisuals
             _dp.BytesStringAsItOrPadLeftBlanks(ref bytes, inputString, lcdPosition);
             Assert.Equal(expected, BitConverter.ToString(bytes));
         }
+
+
+        public static IEnumerable<object[]> DoubleWithSpecifiedDecimalsPlacesData()
+        {
+            yield return new object[] { "00-FF-FF-FF-FF-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"     "*/, 1, 0, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //??
+            yield return new object[] { "00-FF-FF-FF-FF-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"    1"*/, 12, 0, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };//??
+            yield return new object[] { "00-FF-FF-FF-01-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"   12"*/, 123, 0, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };//??
+            yield return new object[] { "00-FF-FF-01-02-03-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"  123"*/, 1234, 0, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };//??
+            yield return new object[] { "00-FF-01-02-03-04-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*" 1234"*/, 12345, 0, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };//??
+            yield return new object[] { "00-01-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12345"*/, 123456, 0, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };//??
+            yield return new object[] { "00-01-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12345"*/, 1234567, 0, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };//??
+
+            yield return new object[] { "00-FF-FF-FF-D1-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"   1.0"*/, 1, 1, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-FF-01-D2-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"  12.0"*/, 12, 1, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-01-02-D3-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*" 123.0"*/, 123, 1, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-D4-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1234.0"*/, 1234, 1, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12345."*/, 12345, 1, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12345"*/, 123456, 1, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+
+            yield return new object[] { "00-FF-FF-FF-FF-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"      "*/, 1.2, 0, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //??
+            yield return new object[] { "00-FF-FF-FF-D1-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"   1.2"*/, 1.2, 1, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-FF-D1-02-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"  1.20"*/, 1.2, 2, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-D1-02-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*" 1.200"*/, 1.2, 3, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-D1-02-00-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2000"*/, 1.2, 4, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-D1-02-00-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2000"*/, 1.2, 5, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+
+            yield return new object[] { "00-FF-FF-FF-FF-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"      "*/, 1.23, 0, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //??
+            yield return new object[] { "00-FF-FF-FF-D1-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"   1.2"*/, 1.23, 1, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-FF-D1-02-03-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"  1.23"*/, 1.23, 2, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-D1-02-03-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*" 1.230"*/, 1.23, 3, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; 
+            yield return new object[] { "00-D1-02-03-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2300"*/, 1.23, 4, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; 
+            yield return new object[] { "00-D1-02-03-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2300"*/, 1.23, 5, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //??
+            
+            yield return new object[] { "00-FF-FF-FF-FF-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"      "*/, 1.01, 0, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //??
+            yield return new object[] { "00-FF-FF-FF-D1-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"   1.2"*/, 1.23456, 1, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; 
+            yield return new object[] { "00-FF-FF-D1-02-03-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"  1.23"*/, 1.23456, 2, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; 
+            yield return new object[] { "00-FF-D1-02-03-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*" 1.235"*/, 1.23456, 3, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //????
+            yield return new object[] { "00-D1-02-03-04-06-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2346"*/, 1.23456, 4, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //????
+            yield return new object[] { "00-D1-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2345"*/, 1.23456, 5, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-D1-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2345"*/, 1.23456, 6, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+
+            //More or less good frequencies to display with realistic number of digits and decimals
+            yield return new object[] { "00-01-02-D3-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"123.00"*/, 123.00, 2, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; 
+            yield return new object[] { "00-01-02-D3-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"123.00"*/, 123, 2, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; 
+            yield return new object[] { "00-01-D2-00-05-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.050"*/, 12.050, 3, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-D2-00-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.000"*/, 12, 3, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; 
+            yield return new object[] { "00-01-D2-00-00-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.005"*/, 12.005, 3, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-D2-00-05-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.050"*/, 12.05, 3, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-D2-05-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.500"*/, 12.5, 3, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-D3-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"123.45"*/, 123.45, 2, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-D3-04-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"123.40"*/, 123.40, 2, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-D3-04-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"123.40"*/, 123.4, 2, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; 
+            yield return new object[] { "00-01-D2-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.345"*/, 12.345, 3, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+
+            //  yield return new object[] { "00-FF-FF-01-D2-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", 12, 1, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+        }
+
+        [Theory]
+        [MemberData(nameof(DoubleWithSpecifiedDecimalsPlacesData))]
+        public void DoubleWithSpecifiedDecimalsPlaces_ShouldReturn_ExpectedValue(string expected, double digits, int decimals, string inputArray, PZ69LCDPosition lcdPosition)
+        {
+            var bytes = StringToBytes(inputArray);
+            _dp.DoubleWithSpecifiedDecimalsPlaces(ref bytes, digits, decimals, lcdPosition);
+            Assert.Equal(expected, BitConverter.ToString(bytes));
+        }
     }
 }

--- a/Source/Tests/NonVisuals/RadiosPZ69DisplayBytesTests.cs
+++ b/Source/Tests/NonVisuals/RadiosPZ69DisplayBytesTests.cs
@@ -292,8 +292,6 @@ namespace Tests.NonVisuals
             yield return new object[] { "00-01-02-D3-04-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"123.40"*/, 123.40, 2, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
             yield return new object[] { "00-01-02-D3-04-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"123.40"*/, 123.4, 2, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; 
             yield return new object[] { "00-01-D2-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.345"*/, 12.345, 3, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-
-            //  yield return new object[] { "00-FF-FF-01-D2-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", 12, 1, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
         }
 
         [Theory]
@@ -302,6 +300,20 @@ namespace Tests.NonVisuals
         {
             var bytes = StringToBytes(inputArray);
             _dp.DoubleWithSpecifiedDecimalsPlaces(ref bytes, digits, decimals, lcdPosition);
+            Assert.Equal(expected, BitConverter.ToString(bytes));
+        }
+
+        public static IEnumerable<object[]> DoubleData()
+        {
+            yield return new object[] { "00-D1-00-00-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.0000"*/, 1, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; 
+        }
+
+        [Theory]
+        [MemberData(nameof(DoubleData))]
+        public void Double_ShouldReturn_ExpectedValue(string expected, double digits, string inputArray, PZ69LCDPosition lcdPosition)
+        {
+            var bytes = StringToBytes(inputArray);
+            _dp.Double(ref bytes, digits, lcdPosition);
             Assert.Equal(expected, BitConverter.ToString(bytes));
         }
     }

--- a/Source/Tests/NonVisuals/RadiosPZ69DisplayBytesTests.cs
+++ b/Source/Tests/NonVisuals/RadiosPZ69DisplayBytesTests.cs
@@ -303,17 +303,42 @@ namespace Tests.NonVisuals
             Assert.Equal(expected, BitConverter.ToString(bytes));
         }
 
-        public static IEnumerable<object[]> DoubleData()
+        public static IEnumerable<object[]> DoubleJustifyLeftData()
         {
-            yield return new object[] { "00-D1-00-00-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.0000"*/, 1, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; 
+            yield return new object[] { "00-D1-00-00-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.0000"*/, 1, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-D2-00-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.000"*/, 12, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-D3-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"123.00"*/, 123, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-D4-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1234.0"*/, 1234, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12345."*/, 12345, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-D6-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12346."*/, 12346, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //??
+            yield return new object[] { "00-01-02-03-04-06-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12346"*/, 123467, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //??
+
+            yield return new object[] { "00-D1-02-00-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2000"*/, 1.2, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-D1-02-03-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2300"*/, 1.23, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-D1-02-03-04-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2340"*/, 1.234, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-D1-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2345"*/, 1.2345, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-D1-02-03-04-06-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2346"*/, 1.23456, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //??
+            yield return new object[] { "00-D1-02-03-04-06-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2346"*/, 1.234567, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //??
+
+            yield return new object[] { "00-01-D2-03-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.300"*/, 12.3, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-D2-03-04-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.340"*/, 12.34, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-D2-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.345"*/, 12.345, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-D2-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.346"*/, 12.3456, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-D2-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.346"*/, 12.34567, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+
+            yield return new object[] { "00-01-02-03-D4-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1234.5"*/, 1234.5, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-D4-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1234.5"*/, 1234.56, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12345"*/, 12345.6789, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-D3-04-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"123.40"*/, 123.40, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-D3-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"123.45"*/, 123.45, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
         }
 
         [Theory]
-        [MemberData(nameof(DoubleData))]
+        [MemberData(nameof(DoubleJustifyLeftData))]
         public void Double_ShouldReturn_ExpectedValue(string expected, double digits, string inputArray, PZ69LCDPosition lcdPosition)
         {
             var bytes = StringToBytes(inputArray);
-            _dp.Double(ref bytes, digits, lcdPosition);
+            _dp.DoubleJustifyLeft(ref bytes, digits, lcdPosition);
             Assert.Equal(expected, BitConverter.ToString(bytes));
         }
     }


### PR DESCRIPTION
Now all the pz69 radio display bytes manipulation functions should be covered by unit tests.
I had to move the `NumberFormatInfo` instances. I tested the Huey and it's working like before. But since I don't have the Mirage 2000 module, I'm not in the capacity to test the changes there.

This will be the base of rationalizing some functions, fixing bugs, removing code etc etc.

