### PR TITLE
[Radio Display] Replace function SetPZ69DisplayBytesString

### DIFF
--- a/Source/NonVisuals/Radios/Misc/PZ69DisplayBytes.cs
+++ b/Source/NonVisuals/Radios/Misc/PZ69DisplayBytes.cs
@@ -126,7 +126,8 @@
         }
 
         /// <summary>
-        /// Expect a string of max 5 chars that are going to be dispaleyd as it.
+        /// THIS FUNCTION WILL BE REMOVED
+        /// Expect a string of max 5 chars that are going to be displayed as it.
         /// If size does not match 5, justify the value right and pad left with blanks.
         /// </summary>
         public void BytesStringAsItOrPadLeftBlanks(ref byte[] bytes, string digitString, PZ69LCDPosition pz69LCDPosition)

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
@@ -132,15 +132,15 @@
                 bytes[0] = 0x0;
                 var random = new Random();
                 var lcdPositionArray = Enum.GetValues(typeof(PZ69LCDPosition));
-                var lcdValueArray = new[] { "00000", "11111", "22222", "33333", "44444", "55555", "66666", "77777", "88888", "99999" };
-                var spins = 8;
+                var lcdValueArray = new[] { "00000", "11111", "22222", "33333", "44444", "55555", "66666", "77777", "88888", "99999", "12345", "1.2.3.4.5." };
+                var spins = 12;
 
                 while (spins > 0)
                 {
                     var position = (PZ69LCDPosition)lcdPositionArray.GetValue(random.Next(lcdPositionArray.Length));
                     var value = (string)lcdValueArray.GetValue(random.Next(lcdValueArray.Length));
 
-                    SetPZ69DisplayBytesString(ref bytes, value, position);
+                    SetPZ69DisplayBytesDefault(ref bytes, value, position);
                     SendLCDData(bytes);
 
                     Thread.Sleep(500);

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
@@ -176,7 +176,8 @@
         }
 
         /// <summary>
-        /// Expect a string of max 5 chars that are going to be dispaleyd as it.
+        /// THIS FUNCTION WILL BE REMOVED
+        /// Expect a string of max 5 chars that are going to be displayed as it.
         /// If size does not match 5, justify the value right and pad left with blanks.
         /// </summary>        
         protected void SetPZ69DisplayBytesString(ref byte[] bytes, string digitString, PZ69LCDPosition pz69LCDPosition)

--- a/Source/NonVisuals/Radios/RadioPanelPZ69F14B.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69F14B.cs
@@ -1773,15 +1773,15 @@
                                         lock (_lockRioLink4OnesDial)
                                         {
                                             frequencyAsString =
-                                                this._rioLink4HundredsCockpitFrequency +
+                                                _rioLink4HundredsCockpitFrequency +
                                                 _rioLink4TensCockpitFrequency.ToString() +
                                                 _rioLink4OnesCockpitFrequency;
                                         }
                                     }
                                 }
 
-                                SetPZ69DisplayBytesString(ref bytes, frequencyAsString, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
-                                SetPZ69DisplayBytesString(ref bytes, this._rioLink4HundredsFrequencyStandby + _rioLink4TensAndOnesFrequencyStandby.ToString().PadLeft(2, '0'), PZ69LCDPosition.UPPER_STBY_RIGHT);
+                                SetPZ69DisplayBytesDefault(ref bytes, frequencyAsString.PadLeft(5,' '), PZ69LCDPosition.UPPER_ACTIVE_LEFT);
+                                SetPZ69DisplayBytesDefault(ref bytes, _rioLink4HundredsFrequencyStandby + _rioLink4TensAndOnesFrequencyStandby.ToString().PadLeft(2, '0'), PZ69LCDPosition.UPPER_STBY_RIGHT);
                             }
 
                             break;
@@ -1923,15 +1923,15 @@
                                         lock (_lockRioLink4OnesDial)
                                         {
                                             frequencyAsString =
-                                                this._rioLink4HundredsCockpitFrequency +
+                                                _rioLink4HundredsCockpitFrequency +
                                                 _rioLink4TensCockpitFrequency.ToString() +
                                                 _rioLink4OnesCockpitFrequency;
                                         }
                                     }
                                 }
 
-                                SetPZ69DisplayBytesString(ref bytes, frequencyAsString, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
-                                SetPZ69DisplayBytesString(ref bytes, this._rioLink4HundredsFrequencyStandby + _rioLink4TensAndOnesFrequencyStandby.ToString().PadLeft(2, '0'), PZ69LCDPosition.LOWER_STBY_RIGHT);
+                                SetPZ69DisplayBytesDefault(ref bytes, frequencyAsString.PadLeft(5, ' '), PZ69LCDPosition.LOWER_ACTIVE_LEFT);
+                                SetPZ69DisplayBytesDefault(ref bytes, _rioLink4HundredsFrequencyStandby + _rioLink4TensAndOnesFrequencyStandby.ToString().PadLeft(2, '0'), PZ69LCDPosition.LOWER_STBY_RIGHT);
                             }
 
                             break;

--- a/Source/Tests/NonVisuals/RadiosPZ69DisplayBytesTests.cs
+++ b/Source/Tests/NonVisuals/RadiosPZ69DisplayBytesTests.cs
@@ -188,6 +188,9 @@ namespace Tests.NonVisuals
             Assert.Throws<FormatException>(() => _dp.DefaultStringAsIt(ref bytes, inputString, PZ69LCDPosition.UPPER_ACTIVE_LEFT));            
         }
 
+        /// <summary>
+        /// THIS FUNCTION WILL BE REMOVED
+        /// </summary>
         public static IEnumerable<object[]> BytesStringData()
         {
             yield return new object[] { "00-FF-FF-FF-FF-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //diff. than DefaultStringAsIt
@@ -229,6 +232,9 @@ namespace Tests.NonVisuals
             yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-02-03-04-05", "123456", DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
         }
 
+        /// <summary>
+        /// THIS FUNCTION WILL BE REMOVED
+        /// </summary>
         [Theory]
         [MemberData(nameof(BytesStringData))]
         public void BytesStringAsItOrPadLeftBlanks_ShouldReturn_ExpectedValue(string expected, string inputString, string inputArray, PZ69LCDPosition lcdPosition)
@@ -338,6 +344,34 @@ namespace Tests.NonVisuals
             var bytes = StringToBytes(inputArray);
             _dp.DoubleJustifyLeft(ref bytes, digits, lcdPosition);
             Assert.Equal(expected, BitConverter.ToString(bytes));
+        }
+
+        public static IEnumerable<object[]> ReplaceTestData()
+        {
+            yield return new object[] { "1", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "12", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "123", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00000", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00001", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "10001", DEIGHTS, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
+            yield return new object[] { "12345", DEIGHTS, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
+            yield return new object[] { "123.45", DEIGHTS, PZ69LCDPosition.UPPER_STBY_RIGHT };
+            yield return new object[] { "0123.4", DEIGHTS, PZ69LCDPosition.UPPER_STBY_RIGHT };
+            yield return new object[] { "00123", DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00123", DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { " 0123", DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
+        }
+
+        [Theory]
+        [MemberData(nameof(ReplaceTestData))]
+        public void ReplaceTest_NewFunctionShouldBehaveLikeOld(string value, string inputArray, PZ69LCDPosition lcdPosition)
+        {
+            var oldBytes = StringToBytes(inputArray);
+            var newBytes = StringToBytes(inputArray);
+            _dp.BytesStringAsItOrPadLeftBlanks(ref oldBytes, value, lcdPosition); //this function will be removed
+            _dp.DefaultStringAsIt(ref newBytes, value.PadLeft(5, ' '), lcdPosition);
+          
+            Assert.Equal(oldBytes, newBytes);
         }
     }
 }

--- a/Source/Tests/NonVisuals/RadiosPZ69DisplayBytesTests.cs
+++ b/Source/Tests/NonVisuals/RadiosPZ69DisplayBytesTests.cs
@@ -9,12 +9,10 @@ namespace Tests.NonVisuals
 {
     public class RadiosPZ69DisplayBytesTests
     {
-        PZ69DisplayBytes _dp = new();
-        private const string _zeroes = "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00";
-        private const string _eights = "00-08-08-08-08-08-08-08-08-08-08-08-08-08-08-08-08-08-08-08-08";
-        private const string _deights = "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8";
-        private const string _blank = "00-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF";
-        private const string _values = "00-01-02-03-04-05-06-07-08-09-01-02-03-04-05-06-07-08-09-01-02";
+        private readonly PZ69DisplayBytes _dp = new();
+        private const string ZEROES = "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00";
+        private const string DEIGHTS = "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8";
+        private const string VALUES = "00-01-02-03-04-05-06-07-08-09-01-02-03-04-05-06-07-08-09-01-02";
 
         private byte[] StringToBytes(string text)
         {
@@ -24,15 +22,15 @@ namespace Tests.NonVisuals
 
         public static IEnumerable<object[]> SetPositionBlankData()
         {
-            yield return new object[] { "00-FF-FF-FF-FF-FF-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", _zeroes, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-00-00-00-00-00-FF-FF-FF-FF-FF-00-00-00-00-00-00-00-00-00-00", _zeroes, PZ69LCDPosition.UPPER_STBY_RIGHT };
-            yield return new object[] { "00-00-00-00-00-00-00-00-00-00-00-FF-FF-FF-FF-FF-00-00-00-00-00", _zeroes, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
-            yield return new object[] { "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-FF-FF-FF-FF-FF", _zeroes, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-FF-FF-FF-FF-FF-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", ZEROES, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-00-00-00-00-00-FF-FF-FF-FF-FF-00-00-00-00-00-00-00-00-00-00", ZEROES, PZ69LCDPosition.UPPER_STBY_RIGHT };
+            yield return new object[] { "00-00-00-00-00-00-00-00-00-00-00-FF-FF-FF-FF-FF-00-00-00-00-00", ZEROES, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
+            yield return new object[] { "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-FF-FF-FF-FF-FF", ZEROES, PZ69LCDPosition.LOWER_STBY_RIGHT };
 
-            yield return new object[] { "00-FF-FF-FF-FF-FF-06-07-08-09-01-02-03-04-05-06-07-08-09-01-02", _values, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-03-04-05-FF-FF-FF-FF-FF-02-03-04-05-06-07-08-09-01-02", _values, PZ69LCDPosition.UPPER_STBY_RIGHT };
-            yield return new object[] { "00-01-02-03-04-05-06-07-08-09-01-FF-FF-FF-FF-FF-07-08-09-01-02", _values, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-03-04-05-06-07-08-09-01-02-03-04-05-06-FF-FF-FF-FF-FF", _values, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-FF-FF-FF-FF-FF-06-07-08-09-01-02-03-04-05-06-07-08-09-01-02", VALUES, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-05-FF-FF-FF-FF-FF-02-03-04-05-06-07-08-09-01-02", VALUES, PZ69LCDPosition.UPPER_STBY_RIGHT };
+            yield return new object[] { "00-01-02-03-04-05-06-07-08-09-01-FF-FF-FF-FF-FF-07-08-09-01-02", VALUES, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-05-06-07-08-09-01-02-03-04-05-06-FF-FF-FF-FF-FF", VALUES, PZ69LCDPosition.LOWER_STBY_RIGHT };
         }
 
         [Theory]
@@ -46,25 +44,25 @@ namespace Tests.NonVisuals
 
         public static IEnumerable<object[]> UnsignedIntegerData()
         {
-            yield return new object[] { "00-FF-FF-FF-FF-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 1, _zeroes, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 10000, _zeroes, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-03-04-05-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 12345, _zeroes, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-06-01-02-03-04-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 612345, _zeroes, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-FF-FF-FF-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 1, ZEROES, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 10000, ZEROES, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-05-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 12345, ZEROES, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-06-01-02-03-04-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 612345, ZEROES, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
 
-            yield return new object[] { "00-00-00-00-00-00-FF-FF-FF-FF-01-00-00-00-00-00-00-00-00-00-00", 1, _zeroes, PZ69LCDPosition.UPPER_STBY_RIGHT };
-            yield return new object[] { "00-00-00-00-00-00-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 10000, _zeroes, PZ69LCDPosition.UPPER_STBY_RIGHT };
-            yield return new object[] { "00-00-00-00-00-00-01-02-03-04-05-00-00-00-00-00-00-00-00-00-00", 12345, _zeroes, PZ69LCDPosition.UPPER_STBY_RIGHT };
-            yield return new object[] { "00-00-00-00-00-00-06-01-02-03-04-00-00-00-00-00-00-00-00-00-00", 612345, _zeroes, PZ69LCDPosition.UPPER_STBY_RIGHT };
+            yield return new object[] { "00-00-00-00-00-00-FF-FF-FF-FF-01-00-00-00-00-00-00-00-00-00-00", 1, ZEROES, PZ69LCDPosition.UPPER_STBY_RIGHT };
+            yield return new object[] { "00-00-00-00-00-00-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 10000, ZEROES, PZ69LCDPosition.UPPER_STBY_RIGHT };
+            yield return new object[] { "00-00-00-00-00-00-01-02-03-04-05-00-00-00-00-00-00-00-00-00-00", 12345, ZEROES, PZ69LCDPosition.UPPER_STBY_RIGHT };
+            yield return new object[] { "00-00-00-00-00-00-06-01-02-03-04-00-00-00-00-00-00-00-00-00-00", 612345, ZEROES, PZ69LCDPosition.UPPER_STBY_RIGHT };
 
-            yield return new object[] { "00-00-00-00-00-00-00-00-00-00-00-FF-FF-FF-FF-01-00-00-00-00-00", 1, _zeroes, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
-            yield return new object[] { "00-00-00-00-00-00-00-00-00-00-00-01-00-00-00-00-00-00-00-00-00", 10000, _zeroes, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
-            yield return new object[] { "00-00-00-00-00-00-00-00-00-00-00-01-02-03-04-05-00-00-00-00-00", 12345, _zeroes, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
-            yield return new object[] { "00-00-00-00-00-00-00-00-00-00-00-06-01-02-03-04-00-00-00-00-00", 612345, _zeroes, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
+            yield return new object[] { "00-00-00-00-00-00-00-00-00-00-00-FF-FF-FF-FF-01-00-00-00-00-00", 1, ZEROES, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
+            yield return new object[] { "00-00-00-00-00-00-00-00-00-00-00-01-00-00-00-00-00-00-00-00-00", 10000, ZEROES, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
+            yield return new object[] { "00-00-00-00-00-00-00-00-00-00-00-01-02-03-04-05-00-00-00-00-00", 12345, ZEROES, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
+            yield return new object[] { "00-00-00-00-00-00-00-00-00-00-00-06-01-02-03-04-00-00-00-00-00", 612345, ZEROES, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
 
-            yield return new object[] { "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-FF-FF-FF-FF-01", 1, _zeroes, PZ69LCDPosition.LOWER_STBY_RIGHT };
-            yield return new object[] { "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-01-00-00-00-00", 10000, _zeroes, PZ69LCDPosition.LOWER_STBY_RIGHT };
-            yield return new object[] { "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-01-02-03-04-05", 12345, _zeroes, PZ69LCDPosition.LOWER_STBY_RIGHT };
-            yield return new object[] { "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-06-01-02-03-04", 612345, _zeroes, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-FF-FF-FF-FF-01", 1, ZEROES, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-01-00-00-00-00", 10000, ZEROES, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-01-02-03-04-05", 12345, ZEROES, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-06-01-02-03-04", 612345, ZEROES, PZ69LCDPosition.LOWER_STBY_RIGHT };
         }
 
         [Theory]
@@ -78,24 +76,24 @@ namespace Tests.NonVisuals
 
         public static IEnumerable<object[]> IntegerData()
         {
-            yield return new object[] { "00-FF-FF-FF-FF-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 1, _zeroes, PZ69LCDPosition.UPPER_ACTIVE_LEFT};
-            yield return new object[] { "00-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 10000, _zeroes, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-03-04-05-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 12345, _zeroes, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            
+            yield return new object[] { "00-FF-FF-FF-FF-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 1, ZEROES, PZ69LCDPosition.UPPER_ACTIVE_LEFT};
+            yield return new object[] { "00-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 10000, ZEROES, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-05-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 12345, ZEROES, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+
             //no sign managed?
-            //yield return new object[] { "00-FF-FF-FF-FF-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", -1, _zeroes, PZ69LCDPosition.UPPER_ACTIVE_LEFT  };
-            
+            //yield return new object[] { "00-FF-FF-FF-FF-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", -1, ZEROES, PZ69LCDPosition.UPPER_ACTIVE_LEFT  };
+
             //no sign managed ?
-            //yield return new object[] { "00-06-01-02-03-04-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", -12345, _zeroes, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            
+            //yield return new object[] { "00-06-01-02-03-04-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", -12345, ZEROES, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+
             //Overflow of 1 char to the right (looks like a bug)
-            yield return new object[] { "00-01-02-03-04-05-06-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 123456, _zeroes, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-05-06-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 123456, ZEROES, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
 
             //Overflow of 1 char to the right (not 2) (looks like a bug)
-            yield return new object[] { "00-01-02-03-04-05-06-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 1234567, _zeroes, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-05-06-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 1234567, ZEROES, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
 
             //IndexOutOfRangeException. Overflow of 1 char to the right (looks like a bug)
-            //yield return new object[] { "00-01-02-03-04-05-06-00-00-00-00-00-00-00-00-00-01-02-03-04-05", 123456, _zeroes, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            //yield return new object[] { "00-01-02-03-04-05-06-00-00-00-00-00-00-00-00-00-01-02-03-04-05", 123456, ZEROES, PZ69LCDPosition.LOWER_STBY_RIGHT };
         }
 
         /// <summary>
@@ -112,12 +110,12 @@ namespace Tests.NonVisuals
 
         public static IEnumerable<object[]> CustomData()
         {
-            yield return new object[] { "00-D1-D2-D3-D4-D5-06-07-08-09-01-02-03-04-05-06-07-08-09-01-02", "D1-D2-D3-D4-D5", _values, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-D1-D2-D3-D4-05-06-07-08-09-01-02-03-04-05-06-07-08-09-01-02", "D1-D2-D3-D4", _values, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-D1-D2-D3-D4-D5-06-07-08-09-01-02-03-04-05-06-07-08-09-01-02", "D1-D2-D3-D4-D5-D6", _values, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-03-04-05-D1-D2-D3-D4-D5-02-03-04-05-06-07-08-09-01-02", "D1-D2-D3-D4-D5", _values, PZ69LCDPosition.UPPER_STBY_RIGHT };
-            yield return new object[] { "00-01-02-03-04-05-06-07-08-09-01-D1-D2-D3-D4-D5-07-08-09-01-02", "D1-D2-D3-D4-D5", _values, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-03-04-05-06-07-08-09-01-02-03-04-05-06-D1-D2-D3-D4-D5", "D1-D2-D3-D4-D5", _values, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-D1-D2-D3-D4-D5-06-07-08-09-01-02-03-04-05-06-07-08-09-01-02", "D1-D2-D3-D4-D5", VALUES, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-D1-D2-D3-D4-05-06-07-08-09-01-02-03-04-05-06-07-08-09-01-02", "D1-D2-D3-D4", VALUES, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-D1-D2-D3-D4-D5-06-07-08-09-01-02-03-04-05-06-07-08-09-01-02", "D1-D2-D3-D4-D5-D6", VALUES, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-05-D1-D2-D3-D4-D5-02-03-04-05-06-07-08-09-01-02", "D1-D2-D3-D4-D5", VALUES, PZ69LCDPosition.UPPER_STBY_RIGHT };
+            yield return new object[] { "00-01-02-03-04-05-06-07-08-09-01-D1-D2-D3-D4-D5-07-08-09-01-02", "D1-D2-D3-D4-D5", VALUES, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-05-06-07-08-09-01-02-03-04-05-06-D1-D2-D3-D4-D5", "D1-D2-D3-D4-D5", VALUES, PZ69LCDPosition.LOWER_STBY_RIGHT };
         }
 
         [Theory]
@@ -132,39 +130,39 @@ namespace Tests.NonVisuals
 
         public static IEnumerable<object[]> DefaultStringAsItData()
         {
-            yield return new object[] { "00-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-03-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "123", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12345", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "123456", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-FF-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1 2", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-FF-02-FF-03-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1 2 3", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-FF-01-FF-02-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", " 1 2 3", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-FF-02-FF-03-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1 2 34", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-FF-FF-FF-FF-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "     ", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-FF-FF-FF-FF-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "    1", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-FF-FF-FF-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1   2", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            
-            //IndexOutOfRangeException. Should maybe return D1-FF-FF-FF-FF ?
-            //yield return new object[] { "00-D1-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1.", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            
-            yield return new object[] { "00-D1-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1. ", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-FF-FF-FF-FF-D1-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "    1.", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-00-00-00-00-D1-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "00001.", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-00-00-00-D2-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "0002.1", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-D1-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1.2345", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-03-04-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12345.", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-03-04-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12345.6", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-FF-FF-FF-D0-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "   0.1", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-D1-D2-D3-D4-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1.2.3.4.5.", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-D1-02-03-D4-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1.234.5.", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-D2-D3-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12.3.45", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "123", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12345", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "123456", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-FF-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1 2", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-FF-02-FF-03-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1 2 3", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-01-FF-02-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", " 1 2 3", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-FF-02-FF-03-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1 2 34", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-FF-FF-FF-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "     ", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-FF-FF-FF-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "    1", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-FF-FF-FF-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1   2", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
 
-            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-D8-D8-D8-D8", "1", _deights, PZ69LCDPosition.LOWER_STBY_RIGHT };
-            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-02-D8-D8-D8", "12", _deights, PZ69LCDPosition.LOWER_STBY_RIGHT };
-            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-02-03-D8-D8", "123", _deights, PZ69LCDPosition.LOWER_STBY_RIGHT };
-            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-02-03-04-05", "12345", _deights, PZ69LCDPosition.LOWER_STBY_RIGHT };
-            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-02-03-04-05", "123456", _deights, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            //IndexOutOfRangeException. Should maybe return D1-FF-FF-FF-FF ?
+            //yield return new object[] { "00-D1-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1.", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+
+            yield return new object[] { "00-D1-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1. ", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-FF-FF-FF-D1-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "    1.", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-00-00-00-00-D1-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "00001.", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-00-00-00-D2-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "0002.1", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-D1-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1.2345", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12345.", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12345.6", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-FF-FF-D0-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "   0.1", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-D1-D2-D3-D4-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1.2.3.4.5.", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-D1-02-03-D4-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1.234.5.", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-D2-D3-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12.3.45", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-D8-D8-D8-D8", "1", DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-02-D8-D8-D8", "12", DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-02-03-D8-D8", "123", DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-02-03-04-05", "12345", DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-02-03-04-05", "123456", DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
         }
 
         [Theory]
@@ -186,49 +184,49 @@ namespace Tests.NonVisuals
         [InlineData("1..2345")]
         public void DefaultStringAsIt_InvalidChars_OrCombination_ShouldThrow_FormatException(string inputString)
         {
-            var bytes = StringToBytes(_deights);
+            var bytes = StringToBytes(DEIGHTS);
             Assert.Throws<FormatException>(() => _dp.DefaultStringAsIt(ref bytes, inputString, PZ69LCDPosition.UPPER_ACTIVE_LEFT));            
         }
 
         public static IEnumerable<object[]> BytesStringData()
         {
-            yield return new object[] { "00-FF-FF-FF-FF-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //diff. than DefaultStringAsIt
-            yield return new object[] { "00-FF-FF-FF-01-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //diff. than DefaultStringAsIt
-            yield return new object[] { "00-FF-FF-01-02-03-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "123", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //diff. than DefaultStringAsIt
-            yield return new object[] { "00-01-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12345", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "123456", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-FF-FF-01-FF-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1 2", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //diff. than DefaultStringAsIt
-            yield return new object[] { "00-01-FF-02-FF-03-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1 2 3", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-FF-01-FF-02-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", " 1 2 3", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-FF-02-FF-03-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1 2 34", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-FF-FF-FF-FF-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "     ", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-FF-FF-FF-FF-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "    1", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-FF-FF-FF-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1   2", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-FF-FF-FF-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //diff. than DefaultStringAsIt
+            yield return new object[] { "00-FF-FF-FF-01-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //diff. than DefaultStringAsIt
+            yield return new object[] { "00-FF-FF-01-02-03-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "123", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //diff. than DefaultStringAsIt
+            yield return new object[] { "00-01-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12345", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "123456", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-FF-01-FF-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1 2", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //diff. than DefaultStringAsIt
+            yield return new object[] { "00-01-FF-02-FF-03-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1 2 3", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-01-FF-02-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", " 1 2 3", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-FF-02-FF-03-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1 2 34", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-FF-FF-FF-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "     ", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-FF-FF-FF-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "    1", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-FF-FF-FF-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1   2", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
            
-            yield return new object[] { "00-FF-FF-FF-FF-D1-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1.", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-FF-FF-FF-D1-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1. ", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //diff. than DefaultStringAsIt
-            yield return new object[] { "00-FF-FF-FF-FF-D1-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "    1.", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-00-00-00-00-D1-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "00001.", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-00-00-00-D2-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "0002.1", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-D1-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1.2345", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-03-04-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12345.", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-03-04-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12345.6", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-FF-FF-FF-D0-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "   0.1", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            
-            //IndexOutOfRangeException
-            //yield return new object[] { "00-D1-D2-D3-D4-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1.2.3.4.5.", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            
-            //IndexOutOfRangeException
-            //yield return new object[] { "00-D1-02-03-D4-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1.234.5.", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            
-            //Not what I expect, should return 01-D2-D3-04-05
-            yield return new object[] { "00-01-D2-D3-04-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12.3.45", _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-FF-FF-FF-D1-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1.", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-FF-FF-D1-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1. ", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //diff. than DefaultStringAsIt
+            yield return new object[] { "00-FF-FF-FF-FF-D1-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "    1.", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-00-00-00-00-D1-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "00001.", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-00-00-00-D2-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "0002.1", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-D1-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1.2345", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12345.", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12345.6", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-FF-FF-D0-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "   0.1", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
 
-            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-FF-FF-FF-01", "1", _deights, PZ69LCDPosition.LOWER_STBY_RIGHT };
-            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-FF-FF-01-02", "12", _deights, PZ69LCDPosition.LOWER_STBY_RIGHT };
-            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-FF-01-02-03", "123", _deights, PZ69LCDPosition.LOWER_STBY_RIGHT };
-            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-02-03-04-05", "12345", _deights, PZ69LCDPosition.LOWER_STBY_RIGHT };
-            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-02-03-04-05", "123456", _deights, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            //IndexOutOfRangeException
+            //yield return new object[] { "00-D1-D2-D3-D4-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1.2.3.4.5.", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+
+            //IndexOutOfRangeException
+            //yield return new object[] { "00-D1-02-03-D4-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1.234.5.", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+
+            //Not what I expect, should return 01-D2-D3-04-05
+            yield return new object[] { "00-01-D2-D3-04-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12.3.45", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-FF-FF-FF-01", "1", DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-FF-FF-01-02", "12", DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-FF-01-02-03", "123", DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-02-03-04-05", "12345", DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-02-03-04-05", "123456", DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
         }
 
         [Theory]
@@ -243,55 +241,55 @@ namespace Tests.NonVisuals
 
         public static IEnumerable<object[]> DoubleWithSpecifiedDecimalsPlacesData()
         {
-            yield return new object[] { "00-FF-FF-FF-FF-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"     "*/, 1, 0, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //??
-            yield return new object[] { "00-FF-FF-FF-FF-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"    1"*/, 12, 0, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };//??
-            yield return new object[] { "00-FF-FF-FF-01-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"   12"*/, 123, 0, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };//??
-            yield return new object[] { "00-FF-FF-01-02-03-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"  123"*/, 1234, 0, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };//??
-            yield return new object[] { "00-FF-01-02-03-04-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*" 1234"*/, 12345, 0, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };//??
-            yield return new object[] { "00-01-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12345"*/, 123456, 0, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };//??
-            yield return new object[] { "00-01-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12345"*/, 1234567, 0, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };//??
+            yield return new object[] { "00-FF-FF-FF-FF-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"     "*/, 1, 0, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //??
+            yield return new object[] { "00-FF-FF-FF-FF-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"    1"*/, 12, 0, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };//??
+            yield return new object[] { "00-FF-FF-FF-01-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"   12"*/, 123, 0, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };//??
+            yield return new object[] { "00-FF-FF-01-02-03-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"  123"*/, 1234, 0, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };//??
+            yield return new object[] { "00-FF-01-02-03-04-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*" 1234"*/, 12345, 0, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };//??
+            yield return new object[] { "00-01-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12345"*/, 123456, 0, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };//??
+            yield return new object[] { "00-01-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12345"*/, 1234567, 0, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };//??
 
-            yield return new object[] { "00-FF-FF-FF-D1-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"   1.0"*/, 1, 1, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-FF-FF-01-D2-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"  12.0"*/, 12, 1, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-FF-01-02-D3-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*" 123.0"*/, 123, 1, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-03-D4-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1234.0"*/, 1234, 1, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-03-04-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12345."*/, 12345, 1, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12345"*/, 123456, 1, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-FF-FF-D1-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"   1.0"*/, 1, 1, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-FF-01-D2-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"  12.0"*/, 12, 1, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-01-02-D3-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*" 123.0"*/, 123, 1, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-D4-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1234.0"*/, 1234, 1, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12345."*/, 12345, 1, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12345"*/, 123456, 1, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
 
-            yield return new object[] { "00-FF-FF-FF-FF-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"      "*/, 1.2, 0, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //??
-            yield return new object[] { "00-FF-FF-FF-D1-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"   1.2"*/, 1.2, 1, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-FF-FF-D1-02-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"  1.20"*/, 1.2, 2, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-FF-D1-02-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*" 1.200"*/, 1.2, 3, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-D1-02-00-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2000"*/, 1.2, 4, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-D1-02-00-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2000"*/, 1.2, 5, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-FF-FF-FF-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"      "*/, 1.2, 0, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //??
+            yield return new object[] { "00-FF-FF-FF-D1-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"   1.2"*/, 1.2, 1, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-FF-D1-02-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"  1.20"*/, 1.2, 2, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-D1-02-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*" 1.200"*/, 1.2, 3, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-D1-02-00-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2000"*/, 1.2, 4, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-D1-02-00-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2000"*/, 1.2, 5, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
 
-            yield return new object[] { "00-FF-FF-FF-FF-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"      "*/, 1.23, 0, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //??
-            yield return new object[] { "00-FF-FF-FF-D1-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"   1.2"*/, 1.23, 1, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-FF-FF-D1-02-03-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"  1.23"*/, 1.23, 2, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-FF-D1-02-03-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*" 1.230"*/, 1.23, 3, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; 
-            yield return new object[] { "00-D1-02-03-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2300"*/, 1.23, 4, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; 
-            yield return new object[] { "00-D1-02-03-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2300"*/, 1.23, 5, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //??
+            yield return new object[] { "00-FF-FF-FF-FF-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"      "*/, 1.23, 0, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //??
+            yield return new object[] { "00-FF-FF-FF-D1-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"   1.2"*/, 1.23, 1, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-FF-D1-02-03-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"  1.23"*/, 1.23, 2, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-D1-02-03-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*" 1.230"*/, 1.23, 3, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; 
+            yield return new object[] { "00-D1-02-03-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2300"*/, 1.23, 4, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; 
+            yield return new object[] { "00-D1-02-03-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2300"*/, 1.23, 5, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //??
             
-            yield return new object[] { "00-FF-FF-FF-FF-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"      "*/, 1.01, 0, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //??
-            yield return new object[] { "00-FF-FF-FF-D1-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"   1.2"*/, 1.23456, 1, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; 
-            yield return new object[] { "00-FF-FF-D1-02-03-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"  1.23"*/, 1.23456, 2, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; 
-            yield return new object[] { "00-FF-D1-02-03-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*" 1.235"*/, 1.23456, 3, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //????
-            yield return new object[] { "00-D1-02-03-04-06-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2346"*/, 1.23456, 4, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //????
-            yield return new object[] { "00-D1-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2345"*/, 1.23456, 5, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-D1-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2345"*/, 1.23456, 6, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-FF-FF-FF-FF-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"      "*/, 1.01, 0, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //??
+            yield return new object[] { "00-FF-FF-FF-D1-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"   1.2"*/, 1.23456, 1, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; 
+            yield return new object[] { "00-FF-FF-D1-02-03-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"  1.23"*/, 1.23456, 2, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; 
+            yield return new object[] { "00-FF-D1-02-03-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*" 1.235"*/, 1.23456, 3, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //????
+            yield return new object[] { "00-D1-02-03-04-06-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2346"*/, 1.23456, 4, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //????
+            yield return new object[] { "00-D1-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2345"*/, 1.23456, 5, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-D1-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2345"*/, 1.23456, 6, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
 
             //More or less good frequencies to display with realistic number of digits and decimals
-            yield return new object[] { "00-01-02-D3-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"123.00"*/, 123.00, 2, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; 
-            yield return new object[] { "00-01-02-D3-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"123.00"*/, 123, 2, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; 
-            yield return new object[] { "00-01-D2-00-05-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.050"*/, 12.050, 3, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-D2-00-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.000"*/, 12, 3, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; 
-            yield return new object[] { "00-01-D2-00-00-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.005"*/, 12.005, 3, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-D2-00-05-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.050"*/, 12.05, 3, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-D2-05-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.500"*/, 12.5, 3, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-D3-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"123.45"*/, 123.45, 2, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-D3-04-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"123.40"*/, 123.40, 2, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-D3-04-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"123.40"*/, 123.4, 2, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; 
-            yield return new object[] { "00-01-D2-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.345"*/, 12.345, 3, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-D3-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"123.00"*/, 123.00, 2, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; 
+            yield return new object[] { "00-01-02-D3-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"123.00"*/, 123, 2, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; 
+            yield return new object[] { "00-01-D2-00-05-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.050"*/, 12.050, 3, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-D2-00-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.000"*/, 12, 3, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; 
+            yield return new object[] { "00-01-D2-00-00-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.005"*/, 12.005, 3, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-D2-00-05-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.050"*/, 12.05, 3, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-D2-05-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.500"*/, 12.5, 3, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-D3-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"123.45"*/, 123.45, 2, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-D3-04-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"123.40"*/, 123.40, 2, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-D3-04-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"123.40"*/, 123.4, 2, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; 
+            yield return new object[] { "00-01-D2-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.345"*/, 12.345, 3, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
         }
 
         [Theory]
@@ -305,32 +303,32 @@ namespace Tests.NonVisuals
 
         public static IEnumerable<object[]> DoubleJustifyLeftData()
         {
-            yield return new object[] { "00-D1-00-00-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.0000"*/, 1, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-D2-00-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.000"*/, 12, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-D3-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"123.00"*/, 123, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-03-D4-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1234.0"*/, 1234, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-03-04-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12345."*/, 12345, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-03-04-D6-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12346."*/, 12346, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //??
-            yield return new object[] { "00-01-02-03-04-06-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12346"*/, 123467, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //??
+            yield return new object[] { "00-D1-00-00-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.0000"*/, 1, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-D2-00-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.000"*/, 12, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-D3-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"123.00"*/, 123, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-D4-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1234.0"*/, 1234, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12345."*/, 12345, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-D6-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12346."*/, 12346, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //??
+            yield return new object[] { "00-01-02-03-04-06-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12346"*/, 123467, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //??
 
-            yield return new object[] { "00-D1-02-00-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2000"*/, 1.2, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-D1-02-03-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2300"*/, 1.23, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-D1-02-03-04-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2340"*/, 1.234, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-D1-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2345"*/, 1.2345, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-D1-02-03-04-06-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2346"*/, 1.23456, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //??
-            yield return new object[] { "00-D1-02-03-04-06-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2346"*/, 1.234567, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //??
+            yield return new object[] { "00-D1-02-00-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2000"*/, 1.2, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-D1-02-03-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2300"*/, 1.23, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-D1-02-03-04-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2340"*/, 1.234, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-D1-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2345"*/, 1.2345, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-D1-02-03-04-06-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2346"*/, 1.23456, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //??
+            yield return new object[] { "00-D1-02-03-04-06-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1.2346"*/, 1.234567, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //??
 
-            yield return new object[] { "00-01-D2-03-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.300"*/, 12.3, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-D2-03-04-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.340"*/, 12.34, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-D2-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.345"*/, 12.345, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-D2-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.346"*/, 12.3456, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-D2-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.346"*/, 12.34567, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-D2-03-00-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.300"*/, 12.3, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-D2-03-04-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.340"*/, 12.34, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-D2-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.345"*/, 12.345, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-D2-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.346"*/, 12.3456, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-D2-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12.346"*/, 12.34567, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
 
-            yield return new object[] { "00-01-02-03-D4-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1234.5"*/, 1234.5, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-03-D4-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1234.5"*/, 1234.56, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-03-04-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12345"*/, 12345.6789, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-D3-04-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"123.40"*/, 123.40, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-D3-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"123.45"*/, 123.45, _deights, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-D4-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1234.5"*/, 1234.5, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-D4-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"1234.5"*/, 1234.56, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"12345"*/, 12345.6789, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-D3-04-00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"123.40"*/, 123.40, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-D3-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"123.45"*/, 123.45, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
         }
 
         [Theory]


### PR DESCRIPTION
`SetPZ69DisplayBytesString` had only 5 references. (1 in the Base Identification function and 4 in the Tomcat Rio Link4 radio)

With the test units I found that the `SetPZ69DisplayBytesDefault` function was the closest one to be a candidate for replacement.

I made some new unit tests to ensure that they return the same results with the same inputs.

Unfortunately I could not test the F14 in the game since I don't have the module. My guess is that it should behave 100% like the old one. 

Some things I don't quite understand is why the active frequency is (apparently) padded left with blanks and the standby frequency with 0 ?

Even that the old function is not used anymore, I didn't remove them yet so that you can make test for yourself and change some stuff if necessary.

If all goes well , the remove of the old function and test data will be done in another PR.