### PR TITLE
Feature/remove setpz69displaybytesstring

### DIFF
--- a/Source/ClassLibraryCommon/Common.cs
+++ b/Source/ClassLibraryCommon/Common.cs
@@ -179,10 +179,12 @@
         {
             if (_pz69NumberFormatInfoFullDisplay == null)
             {
-                _pz69NumberFormatInfoFullDisplay = new NumberFormatInfo();
-                _pz69NumberFormatInfoFullDisplay.NumberDecimalSeparator = ".";
-                _pz69NumberFormatInfoFullDisplay.NumberDecimalDigits = 4;
-                _pz69NumberFormatInfoFullDisplay.NumberGroupSeparator = string.Empty;
+                _pz69NumberFormatInfoFullDisplay = new NumberFormatInfo
+                {
+                    NumberDecimalSeparator = ".",
+                    NumberDecimalDigits = 4,
+                    NumberGroupSeparator = string.Empty
+                };
             }
             return _pz69NumberFormatInfoFullDisplay;
         }
@@ -225,9 +227,11 @@
         {
             if (_pz69NumberFormatInfoEmpty == null)
             {
-                _pz69NumberFormatInfoEmpty = new NumberFormatInfo();
-                _pz69NumberFormatInfoEmpty.NumberDecimalSeparator = ".";
-                _pz69NumberFormatInfoEmpty.NumberGroupSeparator = string.Empty;
+                _pz69NumberFormatInfoEmpty = new NumberFormatInfo
+                {
+                    NumberDecimalSeparator = ".",
+                    NumberGroupSeparator = string.Empty
+                };
             }
             return _pz69NumberFormatInfoEmpty;
         }

--- a/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlSRS.xaml.cs
+++ b/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlSRS.xaml.cs
@@ -435,10 +435,12 @@
             {
                 if (UserControlLoaded)
                 {
-                    var numberFormat = new NumberFormatInfo();
-                    numberFormat.NumberDecimalSeparator = ".";
-                    numberFormat.NumberDecimalDigits = 3;
-                    numberFormat.NumberGroupSeparator = string.Empty;
+                    var numberFormat = new NumberFormatInfo
+                    {
+                        NumberDecimalSeparator = ".",
+                        NumberDecimalDigits = 3,
+                        NumberGroupSeparator = string.Empty
+                    };
                     Settings.Default.SRSSmallFreqStepping = double.Parse(ComboBoxSmallFreqStepping.SelectedValue.ToString(), numberFormat);
                     _radioPanelPZ69SRS.SmallFreqStepping = double.Parse(ComboBoxSmallFreqStepping.SelectedValue.ToString(), numberFormat);
                     Settings.Default.Save();

--- a/Source/NonVisuals/Radios/Misc/PZ69DisplayBytes.cs
+++ b/Source/NonVisuals/Radios/Misc/PZ69DisplayBytes.cs
@@ -171,7 +171,7 @@
             // Debug.WriteLine("Array position = " + arrayPosition);
             // Debug.WriteLine("Max array position = " + (maxArrayPosition));
             var i = 0;
-            NumberFormatInfo numberFormatInfoFullDisplay = new NumberFormatInfo()
+            var numberFormatInfoFullDisplay = new NumberFormatInfo()
             {
                 NumberDecimalSeparator = ".",
                 NumberDecimalDigits = 4,

--- a/Source/NonVisuals/Radios/Misc/PZ69DisplayBytes.cs
+++ b/Source/NonVisuals/Radios/Misc/PZ69DisplayBytes.cs
@@ -65,7 +65,7 @@
         }
         
         /// <summary>
-        /// Inject the preformatted 5 bytes at position in the array.
+        /// Inject the pre-formatted 5 bytes at position in the array.
         /// </summary>
         public void Custom5Bytes(ref byte[] bytes, byte[] bytesToBeInjected, PZ69LCDPosition pz69LCDPosition)
         {
@@ -86,7 +86,7 @@
         }
 
         /// <summary>
-        /// Expect a string of 5 chars that are going to be dispaleyd as it.
+        /// Expect a string of 5 chars that are going to be displayed as it.
         /// Can deal with multiple '.' chars.
         /// If size does not match 5, it will NOT replace previous characters in the array (no padding left or right).
         /// </summary>
@@ -124,83 +124,7 @@
             }
             while (i < digits.Length && arrayPosition < maxArrayPosition + 1);
         }
-
-        /// <summary>
-        /// THIS FUNCTION WILL BE REMOVED
-        /// Expect a string of max 5 chars that are going to be displayed as it.
-        /// If size does not match 5, justify the value right and pad left with blanks.
-        /// </summary>
-        public void BytesStringAsItOrPadLeftBlanks(ref byte[] bytes, string digitString, PZ69LCDPosition pz69LCDPosition)
-        {
-            var arrayPosition = GetArrayPosition(pz69LCDPosition);
-            var maxArrayPosition = GetArrayPosition(pz69LCDPosition) + 4;
-            var i = 0;
-            var digits = string.Empty;
-            if (digitString.Length > 5)
-            {
-                if (digitString.Contains("."))
-                {
-                    digits = digitString.Substring(0, 6);
-                }
-                else
-                {
-                    digits = digitString.Substring(0, 5);
-                }
-            }
-            else if (digitString.Length < 5)
-            {
-                if (digitString.Contains("."))
-                {
-                    digits = digitString.PadLeft(6, ' ');
-                }
-                else
-                {
-                    digits = digitString.PadLeft(5, ' ');
-                }
-            }
-            else if (digitString.Length == 5)
-            {
-                if (digitString.Contains("."))
-                {
-                    digits = digitString.PadLeft(1, ' ');
-                }
-                else
-                {
-                    digits = digitString;
-                }
-            }
-
-            do
-            {
-                if (digits[i] == '.')
-                {
-                    // skip to next position, this has already been dealt with
-                    i++;
-                }
-
-                if (digits[i] == ' ')
-                {
-                    bytes[arrayPosition] = 0xff;
-                }
-                else
-                {
-                    var b = byte.Parse(digits[i].ToString());
-                    bytes[arrayPosition] = b;
-                }
-
-
-                if (digits.Length > i + 1 && digits[i + 1] == '.')
-                {
-                    // Add decimal marker
-                    bytes[arrayPosition] = (byte)(bytes[arrayPosition] + 0xd0);
-                }
-
-                arrayPosition++;
-                i++;
-            }
-            while (i < digits.Length && arrayPosition < maxArrayPosition + 1);
-        }
-
+       
         public void DoubleWithSpecifiedDecimalsPlaces(ref byte[] bytes, double digits, int decimals, PZ69LCDPosition pz69LCDPosition)
         {
             var arrayPosition = GetArrayPosition(pz69LCDPosition);

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
@@ -103,7 +103,7 @@
         }
 
         /// <summary>
-        /// Inject the preformatted 5 bytes at position in the array.
+        /// Inject the pre-formatted 5 bytes at position in the array.
         /// </summary>
         protected void SetPZ69DisplayBytesCustom1(ref byte[] bytes, byte[] bytesToBeInjected, PZ69LCDPosition pz69LCDPosition)
         {
@@ -176,25 +176,7 @@
         }
 
         /// <summary>
-        /// THIS FUNCTION WILL BE REMOVED
-        /// Expect a string of max 5 chars that are going to be displayed as it.
-        /// If size does not match 5, justify the value right and pad left with blanks.
-        /// </summary>        
-        protected void SetPZ69DisplayBytesString(ref byte[] bytes, string digitString, PZ69LCDPosition pz69LCDPosition)
-        {
-            // Todo: 5 references only, maybe change the F14 radio to use DefaultStringAsIt() instead ?
-            try
-            {
-                _pZ69DisplayBytes.BytesStringAsItOrPadLeftBlanks(ref bytes, digitString, pz69LCDPosition);
-            }
-            catch (Exception ex)
-            {
-                logger.Error(ex, "SetPZ69DisplayBytesString()");
-            }
-        }
-
-        /// <summary>
-        /// Expect a string of 5 chars that are going to be dispaleyd as it.
+        /// Expect a string of 5 chars that are going to be displayed as it.
         /// Can deal with multiple '.' chars.
         /// If size does not match 5, it will NOT replace previous characters in the array (no padding left or right).
         /// </summary>

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
@@ -21,7 +21,7 @@
     public abstract class RadioPanelPZ69Base : SaitekPanel
     {
         private byte _ignoreSwitchButtonCounter = 3;
-        private NumberFormatInfo _numberFormatInfoFullDisplay;
+        private readonly NumberFormatInfo _numberFormatInfoFullDisplay;
         private int _frequencyKnobSensitivity;
         private volatile byte _frequencySensitivitySkipper;
         protected readonly object LockLCDUpdateObject = new object();
@@ -44,10 +44,12 @@
                 throw new ArgumentException();
             }
 
-            _numberFormatInfoFullDisplay = new NumberFormatInfo();
-            _numberFormatInfoFullDisplay.NumberDecimalSeparator = ".";
-            _numberFormatInfoFullDisplay.NumberDecimalDigits = 4;
-            _numberFormatInfoFullDisplay.NumberGroupSeparator = string.Empty;
+            _numberFormatInfoFullDisplay = new NumberFormatInfo
+            {
+                NumberDecimalSeparator = ".",
+                NumberDecimalDigits = 4,
+                NumberGroupSeparator = string.Empty
+            };
         }
 
         /*         

--- a/Source/Tests/NonVisuals/RadiosPZ69DisplayBytesTests.cs
+++ b/Source/Tests/NonVisuals/RadiosPZ69DisplayBytesTests.cs
@@ -188,63 +188,6 @@ namespace Tests.NonVisuals
             Assert.Throws<FormatException>(() => _dp.DefaultStringAsIt(ref bytes, inputString, PZ69LCDPosition.UPPER_ACTIVE_LEFT));            
         }
 
-        /// <summary>
-        /// THIS FUNCTION WILL BE REMOVED
-        /// </summary>
-        public static IEnumerable<object[]> BytesStringData()
-        {
-            yield return new object[] { "00-FF-FF-FF-FF-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //diff. than DefaultStringAsIt
-            yield return new object[] { "00-FF-FF-FF-01-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //diff. than DefaultStringAsIt
-            yield return new object[] { "00-FF-FF-01-02-03-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "123", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //diff. than DefaultStringAsIt
-            yield return new object[] { "00-01-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12345", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "123456", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-FF-FF-01-FF-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1 2", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //diff. than DefaultStringAsIt
-            yield return new object[] { "00-01-FF-02-FF-03-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1 2 3", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-FF-01-FF-02-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", " 1 2 3", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-FF-02-FF-03-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1 2 34", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-FF-FF-FF-FF-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "     ", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-FF-FF-FF-FF-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "    1", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-FF-FF-FF-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1   2", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-           
-            yield return new object[] { "00-FF-FF-FF-FF-D1-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1.", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-FF-FF-FF-D1-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1. ", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //diff. than DefaultStringAsIt
-            yield return new object[] { "00-FF-FF-FF-FF-D1-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "    1.", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-00-00-00-00-D1-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "00001.", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-00-00-00-D2-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "0002.1", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-D1-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1.2345", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-03-04-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12345.", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-03-04-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12345.6", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-FF-FF-FF-D0-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "   0.1", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-
-            //IndexOutOfRangeException
-            //yield return new object[] { "00-D1-D2-D3-D4-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1.2.3.4.5.", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-
-            //IndexOutOfRangeException
-            //yield return new object[] { "00-D1-02-03-D4-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1.234.5.", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-
-            //Not what I expect, should return 01-D2-D3-04-05
-            yield return new object[] { "00-01-D2-D3-04-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12.3.45", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-
-            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-FF-FF-FF-01", "1", DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
-            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-FF-FF-01-02", "12", DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
-            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-FF-01-02-03", "123", DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
-            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-02-03-04-05", "12345", DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
-            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-02-03-04-05", "123456", DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
-        }
-
-        /// <summary>
-        /// THIS FUNCTION WILL BE REMOVED
-        /// </summary>
-        [Theory]
-        [MemberData(nameof(BytesStringData))]
-        public void BytesStringAsItOrPadLeftBlanks_ShouldReturn_ExpectedValue(string expected, string inputString, string inputArray, PZ69LCDPosition lcdPosition)
-        {
-            var bytes = StringToBytes(inputArray);
-            _dp.BytesStringAsItOrPadLeftBlanks(ref bytes, inputString, lcdPosition);
-            Assert.Equal(expected, BitConverter.ToString(bytes));
-        }
-
-
         public static IEnumerable<object[]> DoubleWithSpecifiedDecimalsPlacesData()
         {
             yield return new object[] { "00-FF-FF-FF-FF-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"     "*/, 1, 0, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //??
@@ -344,34 +287,6 @@ namespace Tests.NonVisuals
             var bytes = StringToBytes(inputArray);
             _dp.DoubleJustifyLeft(ref bytes, digits, lcdPosition);
             Assert.Equal(expected, BitConverter.ToString(bytes));
-        }
-
-        public static IEnumerable<object[]> ReplaceTestData()
-        {
-            yield return new object[] { "1", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "12", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "123", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00000", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00001", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "10001", DEIGHTS, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
-            yield return new object[] { "12345", DEIGHTS, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
-            yield return new object[] { "123.45", DEIGHTS, PZ69LCDPosition.UPPER_STBY_RIGHT };
-            yield return new object[] { "0123.4", DEIGHTS, PZ69LCDPosition.UPPER_STBY_RIGHT };
-            yield return new object[] { "00123", DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
-            yield return new object[] { "00123", DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
-            yield return new object[] { " 0123", DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
-        }
-
-        [Theory]
-        [MemberData(nameof(ReplaceTestData))]
-        public void ReplaceTest_NewFunctionShouldBehaveLikeOld(string value, string inputArray, PZ69LCDPosition lcdPosition)
-        {
-            var oldBytes = StringToBytes(inputArray);
-            var newBytes = StringToBytes(inputArray);
-            _dp.BytesStringAsItOrPadLeftBlanks(ref oldBytes, value, lcdPosition); //this function will be removed
-            _dp.DefaultStringAsIt(ref newBytes, value.PadLeft(5, ' '), lcdPosition);
-          
-            Assert.Equal(oldBytes, newBytes);
         }
     }
 }


### PR DESCRIPTION
Small PR to:
* Remove the now unused functions & test units of `setpz69displaybytesstring`
* Fixed some typos 
* Used object initializer on all the `new NumberFormatInfo`

Less code, less potential bugs, easier to maintain :-)

Tested on the A10 and works perfectly.