### PR TITLE
[radios] Replace integer by unsignedinteger (merge  remove-setpz69displaybytesstring PR first)

### DIFF
--- a/Source/ClassLibraryCommon/Common.cs
+++ b/Source/ClassLibraryCommon/Common.cs
@@ -179,10 +179,12 @@
         {
             if (_pz69NumberFormatInfoFullDisplay == null)
             {
-                _pz69NumberFormatInfoFullDisplay = new NumberFormatInfo();
-                _pz69NumberFormatInfoFullDisplay.NumberDecimalSeparator = ".";
-                _pz69NumberFormatInfoFullDisplay.NumberDecimalDigits = 4;
-                _pz69NumberFormatInfoFullDisplay.NumberGroupSeparator = string.Empty;
+                _pz69NumberFormatInfoFullDisplay = new NumberFormatInfo
+                {
+                    NumberDecimalSeparator = ".",
+                    NumberDecimalDigits = 4,
+                    NumberGroupSeparator = string.Empty
+                };
             }
             return _pz69NumberFormatInfoFullDisplay;
         }
@@ -225,9 +227,11 @@
         {
             if (_pz69NumberFormatInfoEmpty == null)
             {
-                _pz69NumberFormatInfoEmpty = new NumberFormatInfo();
-                _pz69NumberFormatInfoEmpty.NumberDecimalSeparator = ".";
-                _pz69NumberFormatInfoEmpty.NumberGroupSeparator = string.Empty;
+                _pz69NumberFormatInfoEmpty = new NumberFormatInfo
+                {
+                    NumberDecimalSeparator = ".",
+                    NumberGroupSeparator = string.Empty
+                };
             }
             return _pz69NumberFormatInfoEmpty;
         }

--- a/Source/DCSFlightpanels.local.sln
+++ b/Source/DCSFlightpanels.local.sln
@@ -19,7 +19,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MEF", "MEF\MEF.csproj", "{0
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{6CF35974-7D78-4027-BB40-76E724C4CE14}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "Tests\Tests.csproj", "{D80E361D-35C3-4DBD-855B-B6E5F93FC9A5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tests", "Tests\Tests.csproj", "{D80E361D-35C3-4DBD-855B-B6E5F93FC9A5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlSRS.xaml.cs
+++ b/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlSRS.xaml.cs
@@ -435,10 +435,12 @@
             {
                 if (UserControlLoaded)
                 {
-                    var numberFormat = new NumberFormatInfo();
-                    numberFormat.NumberDecimalSeparator = ".";
-                    numberFormat.NumberDecimalDigits = 3;
-                    numberFormat.NumberGroupSeparator = string.Empty;
+                    var numberFormat = new NumberFormatInfo
+                    {
+                        NumberDecimalSeparator = ".",
+                        NumberDecimalDigits = 3,
+                        NumberGroupSeparator = string.Empty
+                    };
                     Settings.Default.SRSSmallFreqStepping = double.Parse(ComboBoxSmallFreqStepping.SelectedValue.ToString(), numberFormat);
                     _radioPanelPZ69SRS.SmallFreqStepping = double.Parse(ComboBoxSmallFreqStepping.SelectedValue.ToString(), numberFormat);
                     Settings.Default.Save();

--- a/Source/NonVisuals/Radios/Misc/PZ69DisplayBytes.cs
+++ b/Source/NonVisuals/Radios/Misc/PZ69DisplayBytes.cs
@@ -171,7 +171,7 @@
             // Debug.WriteLine("Array position = " + arrayPosition);
             // Debug.WriteLine("Max array position = " + (maxArrayPosition));
             var i = 0;
-            NumberFormatInfo numberFormatInfoFullDisplay = new NumberFormatInfo()
+            var numberFormatInfoFullDisplay = new NumberFormatInfo()
             {
                 NumberDecimalSeparator = ".",
                 NumberDecimalDigits = 4,

--- a/Source/NonVisuals/Radios/Misc/PZ69DisplayBytes.cs
+++ b/Source/NonVisuals/Radios/Misc/PZ69DisplayBytes.cs
@@ -35,9 +35,10 @@
             }
             while (i < digitsAsString.Length && arrayPosition < maxArrayPosition + 1);
         }
-        
+
         /// <summary>
         /// Right justify, pad left with blanks.
+        /// This function will be removed later
         /// </summary>
         public void Integer(ref byte[] bytes, int digits, PZ69LCDPosition pz69LCDPosition)
         {

--- a/Source/NonVisuals/Radios/Misc/PZ69DisplayBytes.cs
+++ b/Source/NonVisuals/Radios/Misc/PZ69DisplayBytes.cs
@@ -65,7 +65,7 @@
         }
         
         /// <summary>
-        /// Inject the preformatted 5 bytes at position in the array.
+        /// Inject the pre-formatted 5 bytes at position in the array.
         /// </summary>
         public void Custom5Bytes(ref byte[] bytes, byte[] bytesToBeInjected, PZ69LCDPosition pz69LCDPosition)
         {
@@ -86,7 +86,7 @@
         }
 
         /// <summary>
-        /// Expect a string of 5 chars that are going to be dispaleyd as it.
+        /// Expect a string of 5 chars that are going to be displayed as it.
         /// Can deal with multiple '.' chars.
         /// If size does not match 5, it will NOT replace previous characters in the array (no padding left or right).
         /// </summary>
@@ -124,83 +124,7 @@
             }
             while (i < digits.Length && arrayPosition < maxArrayPosition + 1);
         }
-
-        /// <summary>
-        /// THIS FUNCTION WILL BE REMOVED
-        /// Expect a string of max 5 chars that are going to be displayed as it.
-        /// If size does not match 5, justify the value right and pad left with blanks.
-        /// </summary>
-        public void BytesStringAsItOrPadLeftBlanks(ref byte[] bytes, string digitString, PZ69LCDPosition pz69LCDPosition)
-        {
-            var arrayPosition = GetArrayPosition(pz69LCDPosition);
-            var maxArrayPosition = GetArrayPosition(pz69LCDPosition) + 4;
-            var i = 0;
-            var digits = string.Empty;
-            if (digitString.Length > 5)
-            {
-                if (digitString.Contains("."))
-                {
-                    digits = digitString.Substring(0, 6);
-                }
-                else
-                {
-                    digits = digitString.Substring(0, 5);
-                }
-            }
-            else if (digitString.Length < 5)
-            {
-                if (digitString.Contains("."))
-                {
-                    digits = digitString.PadLeft(6, ' ');
-                }
-                else
-                {
-                    digits = digitString.PadLeft(5, ' ');
-                }
-            }
-            else if (digitString.Length == 5)
-            {
-                if (digitString.Contains("."))
-                {
-                    digits = digitString.PadLeft(1, ' ');
-                }
-                else
-                {
-                    digits = digitString;
-                }
-            }
-
-            do
-            {
-                if (digits[i] == '.')
-                {
-                    // skip to next position, this has already been dealt with
-                    i++;
-                }
-
-                if (digits[i] == ' ')
-                {
-                    bytes[arrayPosition] = 0xff;
-                }
-                else
-                {
-                    var b = byte.Parse(digits[i].ToString());
-                    bytes[arrayPosition] = b;
-                }
-
-
-                if (digits.Length > i + 1 && digits[i + 1] == '.')
-                {
-                    // Add decimal marker
-                    bytes[arrayPosition] = (byte)(bytes[arrayPosition] + 0xd0);
-                }
-
-                arrayPosition++;
-                i++;
-            }
-            while (i < digits.Length && arrayPosition < maxArrayPosition + 1);
-        }
-
+       
         public void DoubleWithSpecifiedDecimalsPlaces(ref byte[] bytes, double digits, int decimals, PZ69LCDPosition pz69LCDPosition)
         {
             var arrayPosition = GetArrayPosition(pz69LCDPosition);

--- a/Source/NonVisuals/Radios/Misc/PZ69DisplayBytes.cs
+++ b/Source/NonVisuals/Radios/Misc/PZ69DisplayBytes.cs
@@ -37,35 +37,6 @@
         }
 
         /// <summary>
-        /// Right justify, pad left with blanks.
-        /// This function will be removed later
-        /// </summary>
-        public void Integer(ref byte[] bytes, int digits, PZ69LCDPosition pz69LCDPosition)
-        {
-            var arrayPosition = GetArrayPosition(pz69LCDPosition);
-            var maxArrayPosition = GetArrayPosition(pz69LCDPosition) + 5;
-            var i = 0;
-            var digitsAsString = digits.ToString().PadLeft(5);
-
-            // D = DARK
-            // 116 should become DD116!
-            do
-            {
-                // 5 digits can be displayed
-                // 12345 -> 12345
-                // 116   -> DD116 
-                // 1     -> DDDD1
-                byte b;
-                b = digitsAsString[i].ToString().Equals(" ") ? (byte)0xFF : byte.Parse(digitsAsString[i].ToString());
-                bytes[arrayPosition] = b;
-
-                arrayPosition++;
-                i++;
-            }
-            while (i < digitsAsString.Length && arrayPosition < maxArrayPosition + 1);
-        }
-        
-        /// <summary>
         /// Inject the pre-formatted 5 bytes at position in the array.
         /// </summary>
         public void Custom5Bytes(ref byte[] bytes, byte[] bytesToBeInjected, PZ69LCDPosition pz69LCDPosition)

--- a/Source/NonVisuals/Radios/RadioPanelPZ69A10C.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69A10C.cs
@@ -2036,12 +2036,12 @@
                         {
                             if (_upperButtonPressed)
                             {
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_vhfAmCockpitMode, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_vhfAmCockpitFreqMode, PZ69LCDPosition.UPPER_STBY_RIGHT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _vhfAmCockpitMode, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _vhfAmCockpitFreqMode, PZ69LCDPosition.UPPER_STBY_RIGHT);
                             }
                             else if (_vhfAmCockpitMode != 0 && VhfAmPresetSelected())
                             {
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_vhfAmCockpitPresetChannel, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _vhfAmCockpitPresetChannel, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
                                 SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.UPPER_STBY_RIGHT);
                             }
                             else
@@ -2065,12 +2065,12 @@
                         {
                             if (_upperButtonPressed)
                             {
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_uhfCockpitMode, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_uhfCockpitFreqMode, PZ69LCDPosition.UPPER_STBY_RIGHT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _uhfCockpitMode, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _uhfCockpitFreqMode, PZ69LCDPosition.UPPER_STBY_RIGHT);
                             }
                             else if (_uhfCockpitMode != 0 && UhfPresetSelected())
                             {
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_uhfCockpitPresetChannel, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _uhfCockpitPresetChannel, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
                                 SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.UPPER_STBY_RIGHT);
                             }
                             else
@@ -2094,12 +2094,12 @@
                         {
                             if (_upperButtonPressed)
                             {
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_vhfFmCockpitMode, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_vhfFmCockpitFreqMode, PZ69LCDPosition.UPPER_STBY_RIGHT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _vhfFmCockpitMode, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _vhfFmCockpitFreqMode, PZ69LCDPosition.UPPER_STBY_RIGHT);
                             }
                             else if (_vhfFmCockpitMode != 0 && VhfFmPresetSelected())
                             {
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_vhfFmCockpitPresetChannel, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _vhfFmCockpitPresetChannel, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
                                 SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.UPPER_STBY_RIGHT);
                             }
                             else
@@ -2214,12 +2214,12 @@
                         {
                             if (_lowerButtonPressed)
                             {
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_vhfAmCockpitMode, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_vhfAmCockpitFreqMode, PZ69LCDPosition.LOWER_STBY_RIGHT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _vhfAmCockpitMode, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _vhfAmCockpitFreqMode, PZ69LCDPosition.LOWER_STBY_RIGHT);
                             }
                             else if (_vhfAmCockpitMode != 0 && VhfAmPresetSelected())
                             {
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_vhfAmCockpitPresetChannel, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _vhfAmCockpitPresetChannel, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
                                 SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.LOWER_STBY_RIGHT);
                             }
                             else
@@ -2243,12 +2243,12 @@
                         {
                             if (_lowerButtonPressed)
                             {
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_uhfCockpitMode, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_uhfCockpitFreqMode, PZ69LCDPosition.LOWER_STBY_RIGHT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _uhfCockpitMode, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _uhfCockpitFreqMode, PZ69LCDPosition.LOWER_STBY_RIGHT);
                             }
                             else if (_uhfCockpitMode != 0 && UhfPresetSelected())
                             {
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_uhfCockpitPresetChannel, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _uhfCockpitPresetChannel, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
                                 SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.LOWER_STBY_RIGHT);
                             }
                             else
@@ -2272,13 +2272,13 @@
                         {
                             if (_lowerButtonPressed)
                             {
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_vhfFmCockpitMode, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_vhfFmCockpitFreqMode, PZ69LCDPosition.LOWER_STBY_RIGHT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _vhfFmCockpitMode, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _vhfFmCockpitFreqMode, PZ69LCDPosition.LOWER_STBY_RIGHT);
                             }
                             else
                             if (_vhfFmCockpitMode != 0 && VhfFmPresetSelected())
                             {
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_vhfFmCockpitPresetChannel, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _vhfFmCockpitPresetChannel, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
                                 SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.LOWER_STBY_RIGHT);
                             }
                             else

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
@@ -72,15 +72,6 @@
         */
 
         /// <summary>
-        /// Right justify, pad left with blanks.
-        /// This function will be removed later
-        /// </summary>
-        protected void SetPZ69DisplayBytesInteger(ref byte[] bytes, int digits, PZ69LCDPosition pz69LCDPosition)
-        {
-            _pZ69DisplayBytes.Integer(ref bytes, digits, pz69LCDPosition);
-        }
-
-        /// <summary>
         /// Sets the given position to blank without modifying the other positions in the array
         /// </summary>
         protected void SetPZ69DisplayBlank(ref byte[] bytes, PZ69LCDPosition pz69LCDPosition)

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
@@ -103,7 +103,7 @@
         }
 
         /// <summary>
-        /// Inject the preformatted 5 bytes at position in the array.
+        /// Inject the pre-formatted 5 bytes at position in the array.
         /// </summary>
         protected void SetPZ69DisplayBytesCustom1(ref byte[] bytes, byte[] bytesToBeInjected, PZ69LCDPosition pz69LCDPosition)
         {
@@ -176,25 +176,7 @@
         }
 
         /// <summary>
-        /// THIS FUNCTION WILL BE REMOVED
-        /// Expect a string of max 5 chars that are going to be displayed as it.
-        /// If size does not match 5, justify the value right and pad left with blanks.
-        /// </summary>        
-        protected void SetPZ69DisplayBytesString(ref byte[] bytes, string digitString, PZ69LCDPosition pz69LCDPosition)
-        {
-            // Todo: 5 references only, maybe change the F14 radio to use DefaultStringAsIt() instead ?
-            try
-            {
-                _pZ69DisplayBytes.BytesStringAsItOrPadLeftBlanks(ref bytes, digitString, pz69LCDPosition);
-            }
-            catch (Exception ex)
-            {
-                logger.Error(ex, "SetPZ69DisplayBytesString()");
-            }
-        }
-
-        /// <summary>
-        /// Expect a string of 5 chars that are going to be dispaleyd as it.
+        /// Expect a string of 5 chars that are going to be displayed as it.
         /// Can deal with multiple '.' chars.
         /// If size does not match 5, it will NOT replace previous characters in the array (no padding left or right).
         /// </summary>

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
@@ -73,6 +73,7 @@
 
         /// <summary>
         /// Right justify, pad left with blanks.
+        /// This function will be removed later
         /// </summary>
         protected void SetPZ69DisplayBytesInteger(ref byte[] bytes, int digits, PZ69LCDPosition pz69LCDPosition)
         {

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
@@ -21,7 +21,7 @@
     public abstract class RadioPanelPZ69Base : SaitekPanel
     {
         private byte _ignoreSwitchButtonCounter = 3;
-        private NumberFormatInfo _numberFormatInfoFullDisplay;
+        private readonly NumberFormatInfo _numberFormatInfoFullDisplay;
         private int _frequencyKnobSensitivity;
         private volatile byte _frequencySensitivitySkipper;
         protected readonly object LockLCDUpdateObject = new object();
@@ -44,10 +44,12 @@
                 throw new ArgumentException();
             }
 
-            _numberFormatInfoFullDisplay = new NumberFormatInfo();
-            _numberFormatInfoFullDisplay.NumberDecimalSeparator = ".";
-            _numberFormatInfoFullDisplay.NumberDecimalDigits = 4;
-            _numberFormatInfoFullDisplay.NumberGroupSeparator = string.Empty;
+            _numberFormatInfoFullDisplay = new NumberFormatInfo
+            {
+                NumberDecimalSeparator = ".",
+                NumberDecimalDigits = 4,
+                NumberGroupSeparator = string.Empty
+            };
         }
 
         /*         

--- a/Source/NonVisuals/Radios/RadioPanelPZ69F14B.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69F14B.cs
@@ -1641,12 +1641,12 @@
                         {
                             if (_upperButtonPressed)
                             {
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_uhfCockpitMode, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_uhfCockpitFreqMode, PZ69LCDPosition.UPPER_STBY_RIGHT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _uhfCockpitMode, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _uhfCockpitFreqMode, PZ69LCDPosition.UPPER_STBY_RIGHT);
                             }
                             else if (_uhfCockpitMode != 0 && UhfPresetSelected())
                             {
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_uhfCockpitPresetChannel, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _uhfCockpitPresetChannel, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
                                 SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.UPPER_STBY_RIGHT);
                             }
                             else
@@ -1671,12 +1671,12 @@
                         {
                             if (_upperButtonPressed)
                             {
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_vuhfCockpitMode, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_vuhfCockpitFreqMode, PZ69LCDPosition.UPPER_STBY_RIGHT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _vuhfCockpitMode, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _vuhfCockpitFreqMode, PZ69LCDPosition.UPPER_STBY_RIGHT);
                             }
                             else if (_vuhfCockpitMode != 0 && VuhfPresetSelected())
                             {
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_vuhfCockpitPresetChannel, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _vuhfCockpitPresetChannel, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
                                 SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.UPPER_STBY_RIGHT);
                             }
                             else
@@ -1760,7 +1760,7 @@
                             }
                             else if (_upperButtonPressed)
                             {
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_rioLink4CockpitPowerSwitch, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _rioLink4CockpitPowerSwitch, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
                                 SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.UPPER_STBY_RIGHT);
                             }
                             else
@@ -1800,12 +1800,12 @@
                         {
                             if (_lowerButtonPressed)
                             {
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_uhfCockpitMode, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_uhfCockpitFreqMode, PZ69LCDPosition.LOWER_STBY_RIGHT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _uhfCockpitMode, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _uhfCockpitFreqMode, PZ69LCDPosition.LOWER_STBY_RIGHT);
                             }
                             else if (_uhfCockpitMode != 0 && UhfPresetSelected())
                             {
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_uhfCockpitPresetChannel, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _uhfCockpitPresetChannel, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
                                 SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.LOWER_STBY_RIGHT);
                             }
                             else
@@ -1830,12 +1830,12 @@
                         {
                             if (_lowerButtonPressed)
                             {
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_vuhfCockpitMode, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_vuhfCockpitFreqMode, PZ69LCDPosition.LOWER_STBY_RIGHT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _vuhfCockpitMode, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _vuhfCockpitFreqMode, PZ69LCDPosition.LOWER_STBY_RIGHT);
                             }
                             else if (_vuhfCockpitMode != 0 && VuhfPresetSelected())
                             {
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_vuhfCockpitPresetChannel, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _vuhfCockpitPresetChannel, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
                                 SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.LOWER_STBY_RIGHT);
                             }
                             else
@@ -1910,7 +1910,7 @@
                             }
                             else if (_lowerButtonPressed)
                             {
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_rioLink4CockpitPowerSwitch, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _rioLink4CockpitPowerSwitch, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
                                 SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.LOWER_STBY_RIGHT);
                             }
                             else

--- a/Source/NonVisuals/Radios/RadioPanelPZ69F5E.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69F5E.cs
@@ -932,12 +932,12 @@
                         {
                             if (_upperButtonPressed)
                             {
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_uhfCockpitFunction, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_uhfCockpitFreqMode, PZ69LCDPosition.UPPER_STBY_RIGHT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _uhfCockpitFunction, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _uhfCockpitFreqMode, PZ69LCDPosition.UPPER_STBY_RIGHT);
                             }
                             else if (_uhfCockpitFunction != 0 && UhfPresetSelected())
                             {
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_uhfCockpitPresetChannel, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _uhfCockpitPresetChannel, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
                                 SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.UPPER_STBY_RIGHT);
                             }
                             else
@@ -1051,12 +1051,12 @@
                         {
                             if (_lowerButtonPressed)
                             {
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_uhfCockpitFunction, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_uhfCockpitFreqMode, PZ69LCDPosition.LOWER_STBY_RIGHT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _uhfCockpitFunction, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _uhfCockpitFreqMode, PZ69LCDPosition.LOWER_STBY_RIGHT);
                             }
                             else if (_uhfCockpitFunction != 0 && UhfPresetSelected())
                             {
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_uhfCockpitPresetChannel, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _uhfCockpitPresetChannel, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
                                 SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.LOWER_STBY_RIGHT);
                             }
                             else

--- a/Source/NonVisuals/Radios/RadioPanelPZ69FA18C.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69FA18C.cs
@@ -505,7 +505,7 @@ namespace NonVisuals.Radios
 
                                 // SetPZ69DisplayBytesDefault(ref bytes, _COMM1BigFrequencyStandby + _COMM1SmallFrequencyStandby, PZ69LCDPosition.UPPER_STBY_RIGHT);
                                 // SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.UPPER_STBY_RIGHT);
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_comm1CockpitChannel, PZ69LCDPosition.UPPER_STBY_RIGHT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _comm1CockpitChannel, PZ69LCDPosition.UPPER_STBY_RIGHT);
                             }
 
                             break;
@@ -532,7 +532,7 @@ namespace NonVisuals.Radios
 
                                 // SetPZ69DisplayBytesDefault(ref bytes, _COMM1BigFrequencyStandby + _COMM1SmallFrequencyStandby, PZ69LCDPosition.UPPER_STBY_RIGHT);
                                 // SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.UPPER_STBY_RIGHT);
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_comm2CockpitChannel, PZ69LCDPosition.UPPER_STBY_RIGHT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _comm2CockpitChannel, PZ69LCDPosition.UPPER_STBY_RIGHT);
                             }
 
                             break;
@@ -563,8 +563,8 @@ namespace NonVisuals.Radios
                                 ilsChannel = _ilsCockpitChannel;
                             }
 
-                            SetPZ69DisplayBytesInteger(ref bytes, (int)ilsChannel, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
-                            SetPZ69DisplayBytesInteger(ref bytes, (int)_ilsChannelStandby, PZ69LCDPosition.UPPER_STBY_RIGHT);
+                            SetPZ69DisplayBytesUnsignedInteger(ref bytes, ilsChannel, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
+                            SetPZ69DisplayBytesUnsignedInteger(ref bytes, _ilsChannelStandby, PZ69LCDPosition.UPPER_STBY_RIGHT);
                             break;
                         }
 
@@ -613,7 +613,7 @@ namespace NonVisuals.Radios
 
                                 // SetPZ69DisplayBytesDefault(ref bytes, _COMM1BigFrequencyStandby + _COMM1SmallFrequencyStandby, PZ69LCDPosition.LOWER_STBY_RIGHT);
                                 // SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.LOWER_STBY_RIGHT);
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_comm1CockpitChannel, PZ69LCDPosition.LOWER_STBY_RIGHT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _comm1CockpitChannel, PZ69LCDPosition.LOWER_STBY_RIGHT);
                             }
 
                             break;
@@ -640,7 +640,7 @@ namespace NonVisuals.Radios
 
                                 // SetPZ69DisplayBytesDefault(ref bytes, _COMM1BigFrequencyStandby + _COMM1SmallFrequencyStandby, PZ69LCDPosition.LOWER_STBY_RIGHT);
                                 // SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.LOWER_STBY_RIGHT);
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)_comm2CockpitChannel, PZ69LCDPosition.LOWER_STBY_RIGHT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, _comm2CockpitChannel, PZ69LCDPosition.LOWER_STBY_RIGHT);
                             }
 
                             break;
@@ -663,8 +663,8 @@ namespace NonVisuals.Radios
                                 ilsChannel = _ilsCockpitChannel;
                             }
 
-                            SetPZ69DisplayBytesInteger(ref bytes, (int)ilsChannel, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
-                            SetPZ69DisplayBytesInteger(ref bytes, (int)_ilsChannelStandby, PZ69LCDPosition.LOWER_STBY_RIGHT);
+                            SetPZ69DisplayBytesUnsignedInteger(ref bytes, ilsChannel, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
+                            SetPZ69DisplayBytesUnsignedInteger(ref bytes, _ilsChannelStandby, PZ69LCDPosition.LOWER_STBY_RIGHT);
                             break;
                         }
 

--- a/Source/NonVisuals/Radios/RadioPanelPZ69SA342.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69SA342.cs
@@ -849,7 +849,7 @@
                                 preset = _fmRadioPresetCockpitDialPos + 1;
                             }
 
-                            SetPZ69DisplayBytesInteger(ref bytes, (int)preset, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
+                            SetPZ69DisplayBytesUnsignedInteger(ref bytes, preset, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
                             SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.UPPER_STBY_RIGHT);
                             break;
                         }
@@ -874,7 +874,7 @@
                             }
 
                             SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
-                            SetPZ69DisplayBytesInteger(ref bytes, (int)tmpValue, PZ69LCDPosition.UPPER_STBY_RIGHT);
+                            SetPZ69DisplayBytesUnsignedInteger(ref bytes, tmpValue, PZ69LCDPosition.UPPER_STBY_RIGHT);
                             break;
                         }
 
@@ -888,8 +888,8 @@
                                 tmpValueDopper = _nadirDopplerModeCockpitValue + 1;
                             }
 
-                            SetPZ69DisplayBytesInteger(ref bytes, (int)tmpValueMode, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
-                            SetPZ69DisplayBytesInteger(ref bytes, (int)tmpValueDopper, PZ69LCDPosition.UPPER_STBY_RIGHT);
+                            SetPZ69DisplayBytesUnsignedInteger(ref bytes, tmpValueMode, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
+                            SetPZ69DisplayBytesUnsignedInteger(ref bytes, tmpValueDopper, PZ69LCDPosition.UPPER_STBY_RIGHT);
                             break;
                         }
 
@@ -959,7 +959,7 @@
                                 preset = _fmRadioPresetCockpitDialPos + 1;
                             }
 
-                            SetPZ69DisplayBytesInteger(ref bytes, (int)preset, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
+                            SetPZ69DisplayBytesUnsignedInteger(ref bytes, preset, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
                             SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.LOWER_STBY_RIGHT);
                             break;
                         }
@@ -984,7 +984,7 @@
                             }
 
                             SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
-                            SetPZ69DisplayBytesInteger(ref bytes, (int)tmpValue, PZ69LCDPosition.LOWER_STBY_RIGHT);
+                            SetPZ69DisplayBytesUnsignedInteger(ref bytes, tmpValue, PZ69LCDPosition.LOWER_STBY_RIGHT);
                             break;
                         }
 
@@ -998,8 +998,8 @@
                                 tmpValueDopper = _nadirDopplerModeCockpitValue + 1;
                             }
 
-                            SetPZ69DisplayBytesInteger(ref bytes, (int)tmpValueMode, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
-                            SetPZ69DisplayBytesInteger(ref bytes, (int)tmpValueDopper, PZ69LCDPosition.LOWER_STBY_RIGHT);
+                            SetPZ69DisplayBytesUnsignedInteger(ref bytes, tmpValueMode, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
+                            SetPZ69DisplayBytesUnsignedInteger(ref bytes, tmpValueDopper, PZ69LCDPosition.LOWER_STBY_RIGHT);
                             break;
                         }
 

--- a/Source/NonVisuals/Radios/RadioPanelPZ69SRS.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69SRS.cs
@@ -601,7 +601,7 @@
                         {
                             if (SRSListenerFactory.GetSRSListener().GetRadioMode(_currentUpperRadioMode) == SRSRadioMode.Channel)
                             {
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)Math.Floor(_upperMainFreq), PZ69LCDPosition.UPPER_STBY_RIGHT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, (uint)Math.Floor(_upperMainFreq), PZ69LCDPosition.UPPER_STBY_RIGHT);
                             }
                             else
                             {
@@ -626,7 +626,7 @@
                         {
                             if (SRSListenerFactory.GetSRSListener().GetRadioMode(_currentLowerRadioMode) == SRSRadioMode.Channel)
                             {
-                                SetPZ69DisplayBytesInteger(ref bytes, (int)Math.Floor(_lowerMainFreq), PZ69LCDPosition.LOWER_STBY_RIGHT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, (uint)Math.Floor(_lowerMainFreq), PZ69LCDPosition.LOWER_STBY_RIGHT);
                             }
                             else
                             {

--- a/Source/NonVisuals/Radios/RadioPanelPZ69UH1H.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69UH1H.cs
@@ -1915,7 +1915,7 @@ namespace NonVisuals.Radios
 
                             lock (_lockAdfSignalStrengthObject)
                             {
-                                SetPZ69DisplayBytesInteger(ref bytes, Convert.ToInt32(Math.Truncate(_adfSignalStrength)), PZ69LCDPosition.UPPER_STBY_RIGHT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, Convert.ToUInt32(Math.Truncate(_adfSignalStrength)), PZ69LCDPosition.UPPER_STBY_RIGHT);
                             }
 
                             break;
@@ -2058,7 +2058,7 @@ namespace NonVisuals.Radios
 
                             lock (_lockAdfSignalStrengthObject)
                             {
-                                SetPZ69DisplayBytesInteger(ref bytes, Convert.ToInt32(Math.Truncate(_adfSignalStrength)), PZ69LCDPosition.LOWER_STBY_RIGHT);
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, Convert.ToUInt32(Math.Truncate(_adfSignalStrength)), PZ69LCDPosition.LOWER_STBY_RIGHT);
                             }
 
                             break;

--- a/Source/Tests/NonVisuals/RadiosPZ69DisplayBytesTests.cs
+++ b/Source/Tests/NonVisuals/RadiosPZ69DisplayBytesTests.cs
@@ -188,63 +188,6 @@ namespace Tests.NonVisuals
             Assert.Throws<FormatException>(() => _dp.DefaultStringAsIt(ref bytes, inputString, PZ69LCDPosition.UPPER_ACTIVE_LEFT));            
         }
 
-        /// <summary>
-        /// THIS FUNCTION WILL BE REMOVED
-        /// </summary>
-        public static IEnumerable<object[]> BytesStringData()
-        {
-            yield return new object[] { "00-FF-FF-FF-FF-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //diff. than DefaultStringAsIt
-            yield return new object[] { "00-FF-FF-FF-01-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //diff. than DefaultStringAsIt
-            yield return new object[] { "00-FF-FF-01-02-03-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "123", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //diff. than DefaultStringAsIt
-            yield return new object[] { "00-01-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12345", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "123456", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-FF-FF-01-FF-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1 2", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //diff. than DefaultStringAsIt
-            yield return new object[] { "00-01-FF-02-FF-03-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1 2 3", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-FF-01-FF-02-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", " 1 2 3", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-FF-02-FF-03-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1 2 34", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-FF-FF-FF-FF-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "     ", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-FF-FF-FF-FF-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "    1", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-FF-FF-FF-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1   2", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-           
-            yield return new object[] { "00-FF-FF-FF-FF-D1-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1.", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-FF-FF-FF-D1-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1. ", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //diff. than DefaultStringAsIt
-            yield return new object[] { "00-FF-FF-FF-FF-D1-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "    1.", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-00-00-00-00-D1-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "00001.", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-00-00-00-D2-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "0002.1", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-D1-02-03-04-05-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1.2345", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-03-04-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12345.", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-03-04-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12345.6", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-FF-FF-FF-D0-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "   0.1", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-
-            //IndexOutOfRangeException
-            //yield return new object[] { "00-D1-D2-D3-D4-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1.2.3.4.5.", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-
-            //IndexOutOfRangeException
-            //yield return new object[] { "00-D1-02-03-D4-D5-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1.234.5.", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-
-            //Not what I expect, should return 01-D2-D3-04-05
-            yield return new object[] { "00-01-D2-D3-04-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "12.3.45", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-
-            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-FF-FF-FF-01", "1", DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
-            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-FF-FF-01-02", "12", DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
-            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-FF-01-02-03", "123", DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
-            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-02-03-04-05", "12345", DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
-            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-02-03-04-05", "123456", DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
-        }
-
-        /// <summary>
-        /// THIS FUNCTION WILL BE REMOVED
-        /// </summary>
-        [Theory]
-        [MemberData(nameof(BytesStringData))]
-        public void BytesStringAsItOrPadLeftBlanks_ShouldReturn_ExpectedValue(string expected, string inputString, string inputArray, PZ69LCDPosition lcdPosition)
-        {
-            var bytes = StringToBytes(inputArray);
-            _dp.BytesStringAsItOrPadLeftBlanks(ref bytes, inputString, lcdPosition);
-            Assert.Equal(expected, BitConverter.ToString(bytes));
-        }
-
-
         public static IEnumerable<object[]> DoubleWithSpecifiedDecimalsPlacesData()
         {
             yield return new object[] { "00-FF-FF-FF-FF-FF-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8"/*"     "*/, 1, 0, DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT }; //??
@@ -344,34 +287,6 @@ namespace Tests.NonVisuals
             var bytes = StringToBytes(inputArray);
             _dp.DoubleJustifyLeft(ref bytes, digits, lcdPosition);
             Assert.Equal(expected, BitConverter.ToString(bytes));
-        }
-
-        public static IEnumerable<object[]> ReplaceTestData()
-        {
-            yield return new object[] { "1", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "12", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "123", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00000", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00001", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "10001", DEIGHTS, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
-            yield return new object[] { "12345", DEIGHTS, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
-            yield return new object[] { "123.45", DEIGHTS, PZ69LCDPosition.UPPER_STBY_RIGHT };
-            yield return new object[] { "0123.4", DEIGHTS, PZ69LCDPosition.UPPER_STBY_RIGHT };
-            yield return new object[] { "00123", DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
-            yield return new object[] { "00123", DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
-            yield return new object[] { " 0123", DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
-        }
-
-        [Theory]
-        [MemberData(nameof(ReplaceTestData))]
-        public void ReplaceTest_NewFunctionShouldBehaveLikeOld(string value, string inputArray, PZ69LCDPosition lcdPosition)
-        {
-            var oldBytes = StringToBytes(inputArray);
-            var newBytes = StringToBytes(inputArray);
-            _dp.BytesStringAsItOrPadLeftBlanks(ref oldBytes, value, lcdPosition); //this function will be removed
-            _dp.DefaultStringAsIt(ref newBytes, value.PadLeft(5, ' '), lcdPosition);
-          
-            Assert.Equal(oldBytes, newBytes);
         }
     }
 }

--- a/Source/Tests/NonVisuals/RadiosPZ69DisplayBytesTests.cs
+++ b/Source/Tests/NonVisuals/RadiosPZ69DisplayBytesTests.cs
@@ -63,6 +63,25 @@ namespace Tests.NonVisuals
             yield return new object[] { "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-01-00-00-00-00", 10000, ZEROES, PZ69LCDPosition.LOWER_STBY_RIGHT };
             yield return new object[] { "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-01-02-03-04-05", 12345, ZEROES, PZ69LCDPosition.LOWER_STBY_RIGHT };
             yield return new object[] { "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-06-01-02-03-04", 612345, ZEROES, PZ69LCDPosition.LOWER_STBY_RIGHT };
+
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-FF-FF-FF-01", 1, DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-FF-FF-01-02", 12, DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-FF-01-02-03", 123, DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-01-02-03-04", 1234, DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-02-03-04-05", 12345, DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-00-00-00-00", 10000, DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-00-00-00-05", 10005, DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-00-00-00-05", 100056, DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
+
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-FF-FF-FF-01-D8-D8-D8-D8-D8", 1, DEIGHTS, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-FF-FF-01-02-D8-D8-D8-D8-D8", 12, DEIGHTS, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-FF-01-02-03-D8-D8-D8-D8-D8", 123, DEIGHTS, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-01-02-03-04-D8-D8-D8-D8-D8", 1234, DEIGHTS, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-02-03-04-05-D8-D8-D8-D8-D8", 12345, DEIGHTS, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-00-00-00-00-D8-D8-D8-D8-D8", 10000, DEIGHTS, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-00-00-00-05-D8-D8-D8-D8-D8", 10005, DEIGHTS, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-00-00-00-05-D8-D8-D8-D8-D8", 100056, DEIGHTS, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-09-09-09-09-09-D8-D8-D8-D8-D8", 99999, DEIGHTS, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
         }
 
         [Theory]
@@ -79,7 +98,7 @@ namespace Tests.NonVisuals
             yield return new object[] { "00-FF-FF-FF-FF-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 1, ZEROES, PZ69LCDPosition.UPPER_ACTIVE_LEFT};
             yield return new object[] { "00-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 10000, ZEROES, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
             yield return new object[] { "00-01-02-03-04-05-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 12345, ZEROES, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-
+            
             //no sign managed?
             //yield return new object[] { "00-FF-FF-FF-FF-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", -1, ZEROES, PZ69LCDPosition.UPPER_ACTIVE_LEFT  };
 
@@ -287,6 +306,55 @@ namespace Tests.NonVisuals
             var bytes = StringToBytes(inputArray);
             _dp.DoubleJustifyLeft(ref bytes, digits, lcdPosition);
             Assert.Equal(expected, BitConverter.ToString(bytes));
+        }
+
+        /// <summary>
+        /// This function will be removed later
+        /// </summary>
+        public static IEnumerable<object[]> ReplaceTestData()
+        {
+            yield return new object[] { "00-FF-FF-FF-FF-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 1, ZEROES, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 10000, ZEROES, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-01-02-03-04-05-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 12345, ZEROES, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            // Bug Overflow on integer, no problem on UnsignedInteger
+            //yield return new object[] { "00-06-01-02-03-04-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 612345, ZEROES, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            //yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-00-00-00-05-D8-D8-D8-D8-D8", 100056, DEIGHTS, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
+
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-FF-FF-FF-01", 1, DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-FF-FF-01-02", 12, DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-FF-01-02-03", 123, DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-01-02-03-04", 1234, DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-02-03-04-05", 12345, DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-00-00-00-00", 10000, DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-00-00-00-05", 10005, DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
+
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-FF-FF-FF-01-D8-D8-D8-D8-D8", 1, DEIGHTS, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-FF-FF-01-02-D8-D8-D8-D8-D8", 12, DEIGHTS, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-FF-01-02-03-D8-D8-D8-D8-D8", 123, DEIGHTS, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-01-02-03-04-D8-D8-D8-D8-D8", 1234, DEIGHTS, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-02-03-04-05-D8-D8-D8-D8-D8", 12345, DEIGHTS, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-00-00-00-00-D8-D8-D8-D8-D8", 10000, DEIGHTS, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-00-00-00-05-D8-D8-D8-D8-D8", 10005, DEIGHTS, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-09-09-09-09-09-D8-D8-D8-D8-D8", 99999, DEIGHTS, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
+            // Bug Index out of bound on integer, no problem on UnsignedInteger
+            // yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-00-00-00-05", 100056, DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
+        }
+
+        /// <summary>
+        /// This function will be removed later
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(ReplaceTestData))]
+        public void ReplaceTest_Integer_Should_Behave_Like_UnsignedInteger(string expected, int digits, string inputArray, PZ69LCDPosition lcdPosition)
+        {
+            var bytesInteger = StringToBytes(inputArray);
+            var bytesUnsignedInteger = StringToBytes(inputArray);
+
+            _dp.Integer(ref bytesInteger, digits, lcdPosition);
+            _dp.UnsignedInteger(ref bytesUnsignedInteger, (uint)digits, lcdPosition);
+
+            Assert.Equal(expected, BitConverter.ToString(bytesInteger));
+            Assert.Equal(expected, BitConverter.ToString(bytesUnsignedInteger));
         }
     }
 }

--- a/Source/Tests/NonVisuals/RadiosPZ69DisplayBytesTests.cs
+++ b/Source/Tests/NonVisuals/RadiosPZ69DisplayBytesTests.cs
@@ -93,40 +93,6 @@ namespace Tests.NonVisuals
             Assert.Equal(expected, BitConverter.ToString(bytes));
         }
 
-        public static IEnumerable<object[]> IntegerData()
-        {
-            yield return new object[] { "00-FF-FF-FF-FF-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 1, ZEROES, PZ69LCDPosition.UPPER_ACTIVE_LEFT};
-            yield return new object[] { "00-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 10000, ZEROES, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-03-04-05-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 12345, ZEROES, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            
-            //no sign managed?
-            //yield return new object[] { "00-FF-FF-FF-FF-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", -1, ZEROES, PZ69LCDPosition.UPPER_ACTIVE_LEFT  };
-
-            //no sign managed ?
-            //yield return new object[] { "00-06-01-02-03-04-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", -12345, ZEROES, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-
-            //Overflow of 1 char to the right (looks like a bug)
-            yield return new object[] { "00-01-02-03-04-05-06-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 123456, ZEROES, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-
-            //Overflow of 1 char to the right (not 2) (looks like a bug)
-            yield return new object[] { "00-01-02-03-04-05-06-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 1234567, ZEROES, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-
-            //IndexOutOfRangeException. Overflow of 1 char to the right (looks like a bug)
-            //yield return new object[] { "00-01-02-03-04-05-06-00-00-00-00-00-00-00-00-00-01-02-03-04-05", 123456, ZEROES, PZ69LCDPosition.LOWER_STBY_RIGHT };
-        }
-
-        /// <summary>
-        /// Todo: Replace Integer by UnsignedInteger since they seems to react the same way. Is there a use for sign ?
-        /// </summary>
-        [Theory]
-        [MemberData(nameof(IntegerData))]
-        public void Integer_ShouldReturn_ExpectedValue(string expected, int inputInt, string inputArray, PZ69LCDPosition lcdPosition)
-        {
-            var bytes = StringToBytes(inputArray);
-            _dp.Integer(ref bytes, inputInt, lcdPosition);
-            Assert.Equal(expected, BitConverter.ToString(bytes));
-        }
-
         public static IEnumerable<object[]> CustomData()
         {
             yield return new object[] { "00-D1-D2-D3-D4-D5-06-07-08-09-01-02-03-04-05-06-07-08-09-01-02", "D1-D2-D3-D4-D5", VALUES, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
@@ -306,55 +272,6 @@ namespace Tests.NonVisuals
             var bytes = StringToBytes(inputArray);
             _dp.DoubleJustifyLeft(ref bytes, digits, lcdPosition);
             Assert.Equal(expected, BitConverter.ToString(bytes));
-        }
-
-        /// <summary>
-        /// This function will be removed later
-        /// </summary>
-        public static IEnumerable<object[]> ReplaceTestData()
-        {
-            yield return new object[] { "00-FF-FF-FF-FF-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 1, ZEROES, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 10000, ZEROES, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-03-04-05-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 12345, ZEROES, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            // Bug Overflow on integer, no problem on UnsignedInteger
-            //yield return new object[] { "00-06-01-02-03-04-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00", 612345, ZEROES, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            //yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-00-00-00-05-D8-D8-D8-D8-D8", 100056, DEIGHTS, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
-
-            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-FF-FF-FF-01", 1, DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
-            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-FF-FF-01-02", 12, DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
-            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-FF-01-02-03", 123, DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
-            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-01-02-03-04", 1234, DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
-            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-02-03-04-05", 12345, DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
-            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-00-00-00-00", 10000, DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
-            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-00-00-00-05", 10005, DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
-
-            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-FF-FF-FF-01-D8-D8-D8-D8-D8", 1, DEIGHTS, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
-            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-FF-FF-01-02-D8-D8-D8-D8-D8", 12, DEIGHTS, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
-            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-FF-01-02-03-D8-D8-D8-D8-D8", 123, DEIGHTS, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
-            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-01-02-03-04-D8-D8-D8-D8-D8", 1234, DEIGHTS, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
-            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-02-03-04-05-D8-D8-D8-D8-D8", 12345, DEIGHTS, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
-            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-00-00-00-00-D8-D8-D8-D8-D8", 10000, DEIGHTS, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
-            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-00-00-00-05-D8-D8-D8-D8-D8", 10005, DEIGHTS, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
-            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-09-09-09-09-09-D8-D8-D8-D8-D8", 99999, DEIGHTS, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
-            // Bug Index out of bound on integer, no problem on UnsignedInteger
-            // yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-00-00-00-05", 100056, DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
-        }
-
-        /// <summary>
-        /// This function will be removed later
-        /// </summary>
-        [Theory]
-        [MemberData(nameof(ReplaceTestData))]
-        public void ReplaceTest_Integer_Should_Behave_Like_UnsignedInteger(string expected, int digits, string inputArray, PZ69LCDPosition lcdPosition)
-        {
-            var bytesInteger = StringToBytes(inputArray);
-            var bytesUnsignedInteger = StringToBytes(inputArray);
-
-            _dp.Integer(ref bytesInteger, digits, lcdPosition);
-            _dp.UnsignedInteger(ref bytesUnsignedInteger, (uint)digits, lcdPosition);
-
-            Assert.Equal(expected, BitConverter.ToString(bytesInteger));
-            Assert.Equal(expected, BitConverter.ToString(bytesUnsignedInteger));
         }
     }
 }


### PR DESCRIPTION
**Since this PR is branched from `Feature/remove-setpz69displaybytesstring` I think it's better to merge the `Feature/remove setpz69displaybytesstring` PR first.**

This PR:
* Removes the SetPZ69DisplayBytesInteger function and all related functions.
* Make the code in the radio cleaner since there is no more casting of `uint` to `int` 
* By removing the `Integer` function we'll remove the overflow bug that was present in it. The `UnsignedInteger` function is more robust.

I made intermediary test units to be sure that the `Integer` and `UnsignedInteger` behave the same way.

I tested the radios of the A10, F18, and Huey with the new calls and they work exactly like with the old one. Could not test the other module but there is no reason that it should not work.


