### PR TITLE
[Radio] Replace the SetPZ69DisplayBytesCustom1 function

### DIFF
--- a/Source/NonVisuals/Radios/Misc/PZ69DisplayBytes.cs
+++ b/Source/NonVisuals/Radios/Misc/PZ69DisplayBytes.cs
@@ -37,27 +37,6 @@
         }
 
         /// <summary>
-        /// Inject the pre-formatted 5 bytes at position in the array.
-        /// </summary>
-        public void Custom5Bytes(ref byte[] bytes, byte[] bytesToBeInjected, PZ69LCDPosition pz69LCDPosition)
-        {
-            var arrayPosition = GetArrayPosition(pz69LCDPosition);
-            var i = 0;
-            do
-            {
-                // 5 digits can be displayed
-                // 12345 -> 12345
-                // 116   -> DD116 
-                // 1     -> DDDD1
-                bytes[arrayPosition] = bytesToBeInjected[i];
-
-                arrayPosition++;
-                i++;
-            }
-            while (i < bytesToBeInjected.Length && i < 5);
-        }
-
-        /// <summary>
         /// Expect a string of 5 chars that are going to be displayed as it.
         /// Can deal with multiple '.' chars.
         /// If size does not match 5, it will NOT replace previous characters in the array (no padding left or right).

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
@@ -96,15 +96,6 @@
             _pZ69DisplayBytes.DoubleWithSpecifiedDecimalsPlaces(ref bytes, digits, decimals, pz69LCDPosition);
         }
 
-        /// <summary>
-        /// Inject the pre-formatted 5 bytes at position in the array.
-        /// </summary>
-        protected void SetPZ69DisplayBytesCustom1(ref byte[] bytes, byte[] bytesToBeInjected, PZ69LCDPosition pz69LCDPosition)
-        {
-            // Todo: 2 references only, maybe change the Mig21 radio to use another function instead like DefaultStringAsIt ?
-            _pZ69DisplayBytes.Custom5Bytes(ref bytes, bytesToBeInjected, pz69LCDPosition);
-        }
-
         public override void Identify()
         {
             try

--- a/Source/NonVisuals/Radios/RadioPanelPZ69MiG21Bis.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69MiG21Bis.cs
@@ -294,7 +294,7 @@
                         {
                             lock (_lockARCSectorObject)
                             {
-                                SetPZ69DisplayBytesCustom1(ref bytes, GetARCSectorBytesForDisplay(), PZ69LCDPosition.UPPER_ACTIVE_LEFT);
+                                SetPZ69DisplayBytesDefault(ref bytes, GetARCSectorStringForDisplay(), PZ69LCDPosition.UPPER_ACTIVE_LEFT);
                             }
 
                             lock (_lockARCPresetChannelObject)
@@ -337,7 +337,7 @@
                         {
                             lock (_lockARCSectorObject)
                             {
-                                SetPZ69DisplayBytesCustom1(ref bytes, GetARCSectorBytesForDisplay(), PZ69LCDPosition.LOWER_ACTIVE_LEFT);
+                                SetPZ69DisplayBytesDefault(ref bytes, GetARCSectorStringForDisplay(), PZ69LCDPosition.LOWER_ACTIVE_LEFT);
                             }
 
                             lock (_lockARCPresetChannelObject)
@@ -817,85 +817,41 @@
             SaitekPanelKnobs = RadioPanelKnobMiG21Bis.GetRadioPanelKnobs();
         }
 
-        private byte[] GetARCSectorBytesForDisplay()
+        /// <summary>
+        /// Returns a string of length 5 formatted as this:
+        /// First pos: Blank
+        /// Second pos: Integer [1-4]
+        /// Third pos: Blank
+        /// Fourth pos: Blank
+        /// Fifth pos: Integer [1-2]
+        /// </summary>
+        private string GetARCSectorStringForDisplay()
         {
-            var result = new byte[5];
-            for (var i = 0; i < result.Length; i++)
-            {
-                result[i] = 0xff;
-            }
-
             lock (_lockARCSectorObject)
             {
                 switch (_arcSectorCockpit)
                 {
                     case 0:
-                        {
-                            // 1  1 
-                            result[0] = 1;
-                            result[4] = 1;
-                            break;
-                        }
-
+                        return " 1  1";
                     case 1:
-                        {
-                            // 1  2
-                            result[0] = 1;
-                            result[4] = 2;
-                            break;
-                        }
-
+                        return " 1  2";
                     case 2:
-                        {
-                            // 2  1
-                            result[0] = 2;
-                            result[4] = 1;
-                            break;
-                        }
-
+                        return " 2  1";
                     case 3:
-                        {
-                            // 2  2
-                            result[0] = 2;
-                            result[4] = 2;
-                            break;
-                        }
-
+                        return " 2  2";
                     case 4:
-                        {
-                            // 3  1
-                            result[0] = 3;
-                            result[4] = 1;
-                            break;
-                        }
-
+                        return " 3  1";
                     case 5:
-                        {
-                            // 3  2
-                            result[0] = 3;
-                            result[4] = 2;
-                            break;
-                        }
-
+                        return " 3  2";
                     case 6:
-                        {
-                            // 4  1
-                            result[0] = 4;
-                            result[4] = 1;
-                            break;
-                        }
-
+                        return " 4  1";
                     case 7:
-                        {
-                            // 4  2
-                            result[0] = 4;
-                            result[4] = 2;
-                            break;
-                        }
+                        return " 4  2";
+                    default:
+                        logger.Error("Unexpected value for _arcSectorCockpit");
+                        return " 0  0";
                 }
             }
-
-            return result;
         }
 
         public override void RemoveSwitchFromList(object controlList, PanelSwitchOnOff panelSwitchOnOff)

--- a/Source/Tests/NonVisuals/RadiosPZ69DisplayBytesTests.cs
+++ b/Source/Tests/NonVisuals/RadiosPZ69DisplayBytesTests.cs
@@ -93,26 +93,6 @@ namespace Tests.NonVisuals
             Assert.Equal(expected, BitConverter.ToString(bytes));
         }
 
-        public static IEnumerable<object[]> CustomData()
-        {
-            yield return new object[] { "00-D1-D2-D3-D4-D5-06-07-08-09-01-02-03-04-05-06-07-08-09-01-02", "D1-D2-D3-D4-D5", VALUES, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-D1-D2-D3-D4-05-06-07-08-09-01-02-03-04-05-06-07-08-09-01-02", "D1-D2-D3-D4", VALUES, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-D1-D2-D3-D4-D5-06-07-08-09-01-02-03-04-05-06-07-08-09-01-02", "D1-D2-D3-D4-D5-D6", VALUES, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-03-04-05-D1-D2-D3-D4-D5-02-03-04-05-06-07-08-09-01-02", "D1-D2-D3-D4-D5", VALUES, PZ69LCDPosition.UPPER_STBY_RIGHT };
-            yield return new object[] { "00-01-02-03-04-05-06-07-08-09-01-D1-D2-D3-D4-D5-07-08-09-01-02", "D1-D2-D3-D4-D5", VALUES, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
-            yield return new object[] { "00-01-02-03-04-05-06-07-08-09-01-02-03-04-05-06-D1-D2-D3-D4-D5", "D1-D2-D3-D4-D5", VALUES, PZ69LCDPosition.LOWER_STBY_RIGHT };
-        }
-
-        [Theory]
-        [MemberData(nameof(CustomData))]
-        public void Custom5Bytes_ShouldInject_TheGiven5BytesMax_AtPosition(string expected, string inputBytes, string inputArray, PZ69LCDPosition lcdPosition)
-        {
-            var bytes = StringToBytes(inputArray);
-            var bytesToInject = StringToBytes(inputBytes);
-            _dp.Custom5Bytes(ref bytes, bytesToInject, lcdPosition);
-            Assert.Equal(expected, BitConverter.ToString(bytes));
-        }
-
         public static IEnumerable<object[]> DefaultStringAsItData()
         {
             yield return new object[] { "00-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", "1", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };

--- a/Source/Tests/NonVisuals/RadiosPZ69DisplayBytesTests.cs
+++ b/Source/Tests/NonVisuals/RadiosPZ69DisplayBytesTests.cs
@@ -148,6 +148,16 @@ namespace Tests.NonVisuals
             yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-02-03-D8-D8", "123", DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
             yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-02-03-04-05", "12345", DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
             yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-01-02-03-04-05", "123456", DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
+
+            //Mig 21bis special Tests
+            yield return new object[] { "00-FF-01-FF-FF-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", " 1  1", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-FF-01-FF-FF-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", " 1  2", DEIGHTS, PZ69LCDPosition.UPPER_STBY_RIGHT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-02-FF-FF-01-D8-D8-D8-D8-D8", " 2  1", DEIGHTS, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-02-FF-FF-02", " 2  2", DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
+            yield return new object[] { "00-FF-03-FF-FF-01-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", " 3  1", DEIGHTS, PZ69LCDPosition.UPPER_ACTIVE_LEFT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-FF-03-FF-FF-02-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8", " 3  2", DEIGHTS, PZ69LCDPosition.UPPER_STBY_RIGHT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-04-FF-FF-01-D8-D8-D8-D8-D8", " 4  1", DEIGHTS, PZ69LCDPosition.LOWER_ACTIVE_LEFT };
+            yield return new object[] { "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-FF-04-FF-FF-02", " 4  2", DEIGHTS, PZ69LCDPosition.LOWER_STBY_RIGHT };
         }
 
         [Theory]


### PR DESCRIPTION
This replace the `SetPZ69DisplayBytesCustom1` function with `SetPZ69DisplayBytesDefault`
* The `SetPZ69DisplayBytesCustom1` was only used in the Mig21bis and was expecting a custom byte array.
* We can replace with a more clearer formatted string of length 5 given to `SetPZ69DisplayBytesDefault`
* Added 8 Test units for `SetPZ69DisplayBytesDefault`
* `SetPZ69DisplayBytesCustom1` & related functions & tests are removed.

Note : I could not test the Mig 21 module, should work but a "real" quick test is always better to see if it react as expected.