### PR TITLE
[Key Sequence Window]  Fix some casts to-and-from IKeyPressInfo

### DIFF
--- a/Source/DCSFlightpanels/Windows/KeySequenceWindow.xaml
+++ b/Source/DCSFlightpanels/Windows/KeySequenceWindow.xaml
@@ -32,7 +32,8 @@
             SelectionChanged="DataGridSequencesSelectionChanged" 
             CanUserReorderColumns="False" 
             CanUserResizeRows="False" 
-            CanUserSortColumns="False" 
+            CanUserSortColumns="False"
+            SelectionMode="Single"
             MouseDoubleClick="DataGridSequences_OnMouseDoubleClick"
             MouseUp="DataGridSequences_OnMouseUp">
 

--- a/Source/DCSFlightpanels/Windows/KeySequenceWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/KeySequenceWindow.xaml.cs
@@ -140,12 +140,26 @@
             {
                 var value = (KeyValuePair<int, IKeyPressInfo>)DataGridSequences.SelectedItem;
                 _sortedList.Remove(value.Key);
+                ReassignSortedListKeys();
                 DataGridSequences.Items.Refresh();
                 SetIsDirty();
             }
             catch (Exception ex)
             {
                 Common.ShowErrorMessageBox( ex);
+            }
+        }
+
+        private void ReassignSortedListKeys()
+        {
+            int newkey = 0;
+            for (int i = 0; i< _sortedList.Count; i++)
+            {
+                var kvp = _sortedList.ElementAt(i);
+                int oldKey = kvp.Key;
+                var val = kvp.Value;
+                _sortedList.Remove(oldKey);
+                _sortedList.Add(newkey++, val);
             }
         }
 

--- a/Source/DCSFlightpanels/Windows/KeySequenceWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/KeySequenceWindow.xaml.cs
@@ -138,7 +138,7 @@
         {
             try
             {
-                var value = (KeyValuePair<int, KeyPressInfo>)DataGridSequences.SelectedItem;
+                var value = (KeyValuePair<int, IKeyPressInfo>)DataGridSequences.SelectedItem;
                 _sortedList.Remove(value.Key);
                 DataGridSequences.Items.Refresh();
                 SetIsDirty();
@@ -163,8 +163,8 @@
 
         private void EditKeyPress()
         {
-            var keyValuePair = (KeyValuePair<int, KeyPressInfo>)DataGridSequences.SelectedItem;
-            var keyPressWindow = new KeyPressWindow(keyValuePair.Value);
+            var keyValuePair = (KeyValuePair<int, IKeyPressInfo>)DataGridSequences.SelectedItem;
+            var keyPressWindow = new KeyPressWindow((KeyPressInfo)keyValuePair.Value);
             keyPressWindow.ShowDialog();
             if (keyPressWindow.DialogResult.HasValue && keyPressWindow.DialogResult.Value)
             {
@@ -189,7 +189,7 @@
         {
             try
             {
-                var value = (KeyValuePair<int, KeyPressInfo>)DataGridSequences.SelectedItem;
+                var value = (KeyValuePair<int, IKeyPressInfo>)DataGridSequences.SelectedItem;
                 MoveItemUp(value.Key);
             }
             catch (Exception ex)
@@ -202,7 +202,7 @@
         {
             try
             {
-                var value = (KeyValuePair<int, KeyPressInfo>)DataGridSequences.SelectedItem;
+                var value = (KeyValuePair<int, IKeyPressInfo>)DataGridSequences.SelectedItem;
                 MoveItemDown(value.Key);
             }
             catch (Exception ex)


### PR DESCRIPTION
Just 2 quick fixes in Key Sequence Window

- Fix some casting to-and-from `IKeyPressInfo`
- When deleting in the middle of a sequence, the [key-1] or [key+1] with `move up` and `move down` didn't work every time. Made a quick reassigning of the keys in the sorted list after a deletion to fix that.
- Made grid selection to single row.


