### PR TITLE
Feature/fix texbox focus after edit

### DIFF
--- a/Source/DCSFlightpanels/Bills/BillBaseInput.cs
+++ b/Source/DCSFlightpanels/Bills/BillBaseInput.cs
@@ -733,7 +733,10 @@
         private void DeleteBIPLink()
         {
             BipLink?.BIPLights?.Clear();
-            TextBox.Background = Brushes.White;
+            if (!TextBox.IsFocused && TextBox.Background != Brushes.Yellow)
+            {
+                TextBox.Background = Brushes.White;
+            }
             UpdateBIPLinkBindings();
         }
 

--- a/Source/DCSFlightpanels/PanelUserControls/FarmingPanelUserControl.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/FarmingPanelUserControl.xaml.cs
@@ -727,7 +727,7 @@
                     }
                 }
 
-                SetTextBoxBackgroundColors(Brushes.White);
+                SetTextBoxBackgroundColors(Brushes.White); //Maybe we can remove this function and only retain the _textBoxBillsSet = true; ?
                 foreach (var bipLink in _farmingSidePanel.BIPLinkHashSet)
                 {
                     var textBox = (FarmingPanelTextBox)GetTextBox(bipLink.FarmingPanelKey, bipLink.WhenTurnedOn);
@@ -747,7 +747,10 @@
         {
             foreach (var textBox in Common.FindVisualChildren<TextBox>(this))
             {
-                textBox.Background = brush;
+                if (!textBox.IsFocused && textBox.Background != Brushes.Yellow)
+                {
+                    textBox.Background = brush;
+                }
             }
             _textBoxBillsSet = true;
         }

--- a/Source/DCSFlightpanels/PanelUserControls/SwitchPanelPZ55UserControl.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/SwitchPanelPZ55UserControl.xaml.cs
@@ -814,7 +814,7 @@
                     }
                 }
 
-                SetTextBoxBackgroundColors(Brushes.White);
+                SetTextBoxBackgroundColors(Brushes.White); //Maybe we can remove this function and only retain the _textBoxBillsSet = true; ?
                 foreach (var bipLinkPZ55 in _switchPanelPZ55.BIPLinkHashSet)
                 {
                     var textBox = (PZ55TextBox)GetTextBox(bipLinkPZ55.SwitchPanelPZ55Key, bipLinkPZ55.WhenTurnedOn);
@@ -837,7 +837,10 @@
         {
             foreach (var textBox in Common.FindVisualChildren<TextBox>(this))
             {
-                textBox.Background = brush;
+                if (!textBox.IsFocused && textBox.Background != Brushes.Yellow)
+                {
+                    textBox.Background = brush;
+                }
             }
             _textBoxBillsSet = true;
         }

--- a/Source/DCSFlightpanels/Windows/KeySequenceWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/KeySequenceWindow.xaml.cs
@@ -143,6 +143,7 @@
                 ReassignSortedListKeys();
                 DataGridSequences.Items.Refresh();
                 SetIsDirty();
+                SetFormState();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Last fixes of Key sequence edit

This fixes those behavior: 

- When editing a sequence, after OK in key sequence edit, the textbox was assigned brush color white (even if it still had focus)  When re-calling the context menu in the same textbox, it failed the test  `if (!(TextBox.IsFocused && Equals(TextBox.Background, Brushes.Yellow)))`in `BillBaseInput:TextBoxContextMenuOpening` and the context menu was empty. (in PZ55 and FarmPanel)

- When deleting all settings of any textbox, the brush was set to white and failed the same test as above.

- When deleting a sequence action in `KeySequenceWindow`, the button OK was not set to enabled.

NB: I saw that there was intricate links with BIPLink but could not test those changes as I don't own a BIP panel.