### PR TITLE
Feature/pz55 manual landing lights colors

### DIFF
--- a/Source/DCSFlightpanels/PanelUserControls/SwitchPanelPZ55UserControl.xaml
+++ b/Source/DCSFlightpanels/PanelUserControls/SwitchPanelPZ55UserControl.xaml
@@ -170,6 +170,23 @@
                     <Label Content="Gear Down (on)" FontSize="10" Height="23"  />
                     <customControl:PZ55TextBox FontSize="10" Height="18"  IsReadOnly="True" x:Name="TextBoxGearDown"  />
                     <CheckBox x:Name="CheckBoxManualLeDs" Content="Manual LEDs (via LG lever)" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0,10,0,0" Click="CheckBoxManualLEDs_OnClick"/>
+                    <Grid Height="61">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="15*"/>
+
+                            <ColumnDefinition Width="32*"/>
+                        </Grid.ColumnDefinitions>
+                        <StackPanel Grid.Column="1">
+                            <ComboBox x:Name="ManualLedUpCombo" SelectionChanged="ManualLedUpCombo_SelectionChanged" Width="87"/>
+                            <ComboBox x:Name="ManualLedTransCombo" SelectionChanged="ManualLedTransCombo_SelectionChanged" Width="87"/>
+                            <ComboBox x:Name="ManualLedDownCombo" SelectionChanged="ManualLedDownCombo_SelectionChanged" Width="87"/>
+                        </StackPanel>
+                        <StackPanel Grid.ColumnSpan="2" Margin="0,0,89,0">
+                            <Label x:Name="ManualLedUpLabel" Content="Up" Padding="5,3,5,3"/>
+                            <Label x:Name="ManualLedTransLabel" Content="Trans" Padding="5,3,5,3"/>
+                            <Label x:Name="ManualLedDownLabel" Content="Down" Padding="5,3,5,3"/>
+                        </StackPanel>
+                    </Grid>
                 </StackPanel>
                 <StackPanel Grid.Column="1" MouseDown="MouseDownFocusLogTextBox">
                     <Label Content="Master Bat. Off" FontSize="10" Height="23"   />

--- a/Source/DCSFlightpanels/PanelUserControls/SwitchPanelPZ55UserControl.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/SwitchPanelPZ55UserControl.xaml.cs
@@ -81,9 +81,21 @@
         private void SwitchPanelPZ55UserControl_OnLoaded(object sender, RoutedEventArgs e)
         {
             SetTextBoxBills();
+            LoadComboBoxesManualLeds();
             SetContextMenuClickHandlers();
             UserControlLoaded = true;
             ShowGraphicConfiguration();
+        }
+
+        private void LoadComboBoxesManualLeds()
+        {
+            ManualLedUpCombo.ItemsSource = Enum.GetValues(typeof(PanelLEDColor));
+            ManualLedDownCombo.ItemsSource = Enum.GetValues(typeof(PanelLEDColor));
+            ManualLedTransCombo.ItemsSource = Enum.GetValues(typeof(PanelLEDColor));
+
+            ManualLedUpCombo.SelectedValue = _switchPanelPZ55.ManualLandingGearLedsColorUp;
+            ManualLedDownCombo.SelectedValue = _switchPanelPZ55.ManualLandingGearLedsColorDown;
+            ManualLedTransCombo.SelectedValue = _switchPanelPZ55.ManualLandingGearLedsColorTrans;
         }
 
         public void BipPanelRegisterEvent(object sender, BipPanelRegisteredEventArgs e)
@@ -825,6 +837,7 @@
                 }
 
                 CheckBoxManualLeDs.IsChecked = _switchPanelPZ55.ManualLandingGearLeds;
+                SetManualLedColorsSelectionVisibility(_switchPanelPZ55.ManualLandingGearLeds);
                 SetConfigExistsImageVisibility();
             }
             catch (Exception ex)
@@ -1244,6 +1257,33 @@
             {
                 Common.ShowErrorMessageBox(ex);
             }
+        }
+
+        private void ManualLedUpCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            _switchPanelPZ55.ManualLandingGearLedsColorUp = (PanelLEDColor)((ComboBox)sender).SelectedValue;
+        }
+
+        private void ManualLedTransCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            _switchPanelPZ55.ManualLandingGearLedsColorTrans = (PanelLEDColor)((ComboBox)sender).SelectedValue;
+        }
+
+        private void ManualLedDownCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            _switchPanelPZ55.ManualLandingGearLedsColorDown = (PanelLEDColor)((ComboBox)sender).SelectedValue;
+        }
+
+        private void SetManualLedColorsSelectionVisibility(bool isVisible)
+        {
+            var visibility = isVisible ? Visibility.Visible : Visibility.Hidden;
+            ManualLedUpCombo.Visibility = visibility;
+            ManualLedTransCombo.Visibility = visibility;
+            ManualLedDownCombo.Visibility = visibility;
+
+            ManualLedUpLabel.Visibility = visibility;
+            ManualLedTransLabel.Visibility = visibility;
+            ManualLedDownLabel.Visibility = visibility;
         }
     }
 }

--- a/Source/NonVisuals/Saitek/Panels/SwitchPanelPZ55.cs
+++ b/Source/NonVisuals/Saitek/Panels/SwitchPanelPZ55.cs
@@ -41,6 +41,13 @@
         private PanelLEDColor _manualLandingGearLedsColorTrans = PanelLEDColor.RED;
         private Thread _manualLandingGearThread;
 
+        private enum ManualGearsStatus
+        {
+            Down,
+            Up,
+            Trans
+        }
+
         public SwitchPanelPZ55(HIDSkeleton hidSkeleton) : base(GamingPanelEnum.PZ55SwitchPanel, hidSkeleton)
         {
             if (hidSkeleton.PanelInfo.GamingPanelType != GamingPanelEnum.PZ55SwitchPanel)
@@ -281,6 +288,21 @@
             set => _operatingSystemCommandBindings = value;
         }
 
+        private PanelLEDColor GetManualGearsColorForStatus(ManualGearsStatus status)
+        {
+            switch (status)
+            {
+                case ManualGearsStatus.Down:
+                    return _manualLandingGearLedsColorDown;
+                case ManualGearsStatus.Up:
+                    return _manualLandingGearLedsColorUp;
+                case ManualGearsStatus.Trans:
+                    return _manualLandingGearLedsColorTrans;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(status));
+            }
+        }
+
         private void SetLandingGearLedsManually(PanelLEDColor panelLEDColor)
         {
             try
@@ -298,9 +320,9 @@
                 // Now when the gear knob selection is changed, just like a real aircraft
                 // the lights go to their 'Transit' state showing RED.
                 // Then afterwards they change to their final colour (GREEN = DOWN, DARK = UP)
-                SetLandingGearLED(SwitchPanelPZ55LEDPosition.UP, PanelLEDColor.RED);
-                SetLandingGearLED(SwitchPanelPZ55LEDPosition.RIGHT, PanelLEDColor.RED);
-                SetLandingGearLED(SwitchPanelPZ55LEDPosition.LEFT, PanelLEDColor.RED);
+                SetLandingGearLED(SwitchPanelPZ55LEDPosition.UP, GetManualGearsColorForStatus(ManualGearsStatus.Trans));
+                SetLandingGearLED(SwitchPanelPZ55LEDPosition.RIGHT, GetManualGearsColorForStatus(ManualGearsStatus.Trans));
+                SetLandingGearLED(SwitchPanelPZ55LEDPosition.LEFT, GetManualGearsColorForStatus(ManualGearsStatus.Trans));
 
                 while (true)
                 {
@@ -365,13 +387,13 @@
                         _manualLandingGearThread?.Abort();
 
                         // Changed Lights to go DARK when gear level is selected to UP, instead of RED.
-                        _manualLandingGearThread = new Thread(() => SetLandingGearLedsManually(PanelLEDColor.DARK));
+                        _manualLandingGearThread = new Thread(() => SetLandingGearLedsManually(GetManualGearsColorForStatus(ManualGearsStatus.Up)));
                         _manualLandingGearThread.Start();
                     }
                     else if (switchPanelKey.SwitchPanelPZ55Key == SwitchPanelPZ55Keys.LEVER_GEAR_DOWN && switchPanelKey.IsOn)
                     {
                         _manualLandingGearThread?.Abort();
-                        _manualLandingGearThread = new Thread(() => SetLandingGearLedsManually(PanelLEDColor.GREEN));
+                        _manualLandingGearThread = new Thread(() => SetLandingGearLedsManually(GetManualGearsColorForStatus(ManualGearsStatus.Down)));
                         _manualLandingGearThread.Start();
                     }
                 }

--- a/Source/NonVisuals/Saitek/Panels/SwitchPanelPZ55.cs
+++ b/Source/NonVisuals/Saitek/Panels/SwitchPanelPZ55.cs
@@ -133,12 +133,30 @@
                     {
                         _manualLandingGearLeds = setting.Contains("True");
                     }
+                    else if (setting.StartsWith("ManualLandingGearLedsColorDown{"))
+                    {
+                        _manualLandingGearLedsColorDown = GetSettingPanelLEDColor(setting);
+                    }
+                    else if (setting.StartsWith("ManualLandingGearLedsColorUp{"))
+                    {
+                        _manualLandingGearLedsColorUp = GetSettingPanelLEDColor(setting);
+                    }
+                    else if (setting.StartsWith("ManualLandingGearLedsColorTrans{"))
+                    {
+                        _manualLandingGearLedsColorTrans = GetSettingPanelLEDColor(setting);
+                    }
                 }
             }
 
             SettingsApplied();
             _keyBindings = KeyBindingPZ55.SetNegators(_keyBindings);
 
+        }
+        private PanelLEDColor GetSettingPanelLEDColor(string setting)
+        {
+            int pos = setting.IndexOf('{');
+            string settingValue = setting.Substring(pos+1, setting.LastIndexOf('}') - pos - 1);
+            return (PanelLEDColor)Enum.Parse(typeof(PanelLEDColor), settingValue);
         }
 
         public override List<string> ExportSettings()

--- a/Source/NonVisuals/Saitek/Panels/SwitchPanelPZ55.cs
+++ b/Source/NonVisuals/Saitek/Panels/SwitchPanelPZ55.cs
@@ -36,6 +36,9 @@
         private SwitchPanelPZ55LEDs _ledLeftColor = SwitchPanelPZ55LEDs.ALL_DARK;
         private SwitchPanelPZ55LEDs _ledRightColor = SwitchPanelPZ55LEDs.ALL_DARK;
         private bool _manualLandingGearLeds;
+        private PanelLEDColor _manualLandingGearLedsColorDown = PanelLEDColor.GREEN;
+        private PanelLEDColor _manualLandingGearLedsColorUp = PanelLEDColor.DARK;
+        private PanelLEDColor _manualLandingGearLedsColorTrans = PanelLEDColor.RED;
         private Thread _manualLandingGearThread;
 
         public SwitchPanelPZ55(HIDSkeleton hidSkeleton) : base(GamingPanelEnum.PZ55SwitchPanel, hidSkeleton)
@@ -178,6 +181,9 @@
             }
 
             result.Add("ManualLandingGearLEDs{" + _manualLandingGearLeds + "}");
+            result.Add("ManualLandingGearLedsColorUp{" + _manualLandingGearLedsColorUp + "}");
+            result.Add("ManualLandingGearLedsColorDown{" + _manualLandingGearLedsColorDown + "}");
+            result.Add("ManualLandingGearLedsColorTrans{" + _manualLandingGearLedsColorTrans + "}");
             return result;
         }
 
@@ -1015,6 +1021,36 @@
             set
             {
                 _manualLandingGearLeds = value;
+                SetIsDirty();
+            }
+        }
+
+        public PanelLEDColor ManualLandingGearLedsColorDown
+        {
+            get => _manualLandingGearLedsColorDown;
+            set
+            {
+                _manualLandingGearLedsColorDown = value;
+                SetIsDirty();
+            }
+        }
+
+        public PanelLEDColor ManualLandingGearLedsColorUp
+        {
+            get => _manualLandingGearLedsColorUp;
+            set
+            {
+                _manualLandingGearLedsColorUp = value;
+                SetIsDirty();
+            }
+        }
+
+        public PanelLEDColor ManualLandingGearLedsColorTrans
+        {
+            get => _manualLandingGearLedsColorTrans;
+            set
+            {
+                _manualLandingGearLedsColorTrans = value;
                 SetIsDirty();
             }
         }


### PR DESCRIPTION
Let the user select the colors status of the landing lights LEDS when manual mode is enabled.
Use can select the color displayed for the 3 phases:

- Up
- Transition
- Down

<img width="246" alt="image" src="https://user-images.githubusercontent.com/67550369/143122184-aa718e1f-bba1-4543-9b40-ec376ec713e4.png">

- This change was suggested by a friend to mimic the "real" lights status in one of the plane in IL2
- The default values for a new profile are the same as before : Up= dark, Down = green, Trans = red
- Should not disturb old profiles
- I wanted to do better with the interface (use one container to directly hide all the controls, better spacing...)  but I was nearly driven nuts by the xaml and the way all controls resize when changing windows size (strange anchors, overlapping controls..). So I made the minimal changes that is usable and do the job without breaking anything. I definitely need to read or watch a tutorial on how to manage resize of controls in Wpf 🔩 , it's a strange world.
