### PR TITLE
[PZ55] Add user selectable manual gear transition time in seconds

### DIFF
--- a/Source/DCSFlightpanels/PanelUserControls/SwitchPanelPZ55UserControl.xaml
+++ b/Source/DCSFlightpanels/PanelUserControls/SwitchPanelPZ55UserControl.xaml
@@ -6,8 +6,7 @@
              xmlns:dcsFlightpanels="clr-namespace:DCSFlightpanels"
              xmlns:panelUserControls="clr-namespace:DCSFlightpanels.PanelUserControls"
              xmlns:customControl="clr-namespace:DCSFlightpanels.CustomControls"
-             mc:Ignorable="d" 
-             d:DesignHeight="650" d:DesignWidth="1000" Loaded="SwitchPanelPZ55UserControl_OnLoaded">
+             mc:Ignorable="d" Loaded="SwitchPanelPZ55UserControl_OnLoaded" Height="687" Width="975">
     <UserControl.Resources>
         <ContextMenu x:Key="PZ55LEDContextMenu" x:Shared="False">
             <MenuItem Header="Configure" Name="ContextConfigureLandingGearLED" Click="ContextConfigureLandingGearLEDClick"/>
@@ -176,15 +175,17 @@
 
                             <ColumnDefinition Width="32*"/>
                         </Grid.ColumnDefinitions>
-                        <StackPanel Grid.Column="1">
-                            <ComboBox x:Name="ManualLedUpCombo" SelectionChanged="ManualLedUpCombo_SelectionChanged" Width="87"/>
-                            <ComboBox x:Name="ManualLedTransCombo" SelectionChanged="ManualLedTransCombo_SelectionChanged" Width="87"/>
-                            <ComboBox x:Name="ManualLedDownCombo" SelectionChanged="ManualLedDownCombo_SelectionChanged" Width="87"/>
+                        <StackPanel Grid.ColumnSpan="2" Margin="45,0,0,-25">
+                            <ComboBox x:Name="ManualLedUpCombo" SelectionChanged="ManualLedUpCombo_SelectionChanged" Width="87" HorizontalAlignment="Right" />
+                            <ComboBox x:Name="ManualLedTransCombo" SelectionChanged="ManualLedTransCombo_SelectionChanged" Width="87" HorizontalAlignment="Right"/>
+                            <ComboBox x:Name="ManualLedDownCombo" SelectionChanged="ManualLedDownCombo_SelectionChanged" Width="87" HorizontalAlignment="Right"/>
+                            <ComboBox x:Name="ManualLedTransSecondsCombo" SelectionChanged="ManualLedTransSecondsCombo_SelectionChanged" Width="57" HorizontalAlignment="Right"/>
                         </StackPanel>
-                        <StackPanel Grid.ColumnSpan="2" Margin="0,0,89,0">
-                            <Label x:Name="ManualLedUpLabel" Content="Up" Padding="5,3,5,3"/>
-                            <Label x:Name="ManualLedTransLabel" Content="Trans" Padding="5,3,5,3"/>
-                            <Label x:Name="ManualLedDownLabel" Content="Down" Padding="5,3,5,3"/>
+                        <StackPanel Grid.ColumnSpan="2" Margin="0,0,0,-25">
+                            <Label x:Name="ManualLedUpLabel" Content="Up" Padding="5,3,5,3" HorizontalAlignment="Left" Width="52"/>
+                            <Label x:Name="ManualLedTransLabel" Content="Trans." Padding="5,3,5,3" HorizontalAlignment="Left" Width="52"/>
+                            <Label x:Name="ManualLedDownLabel" Content="Down" Padding="5,3,5,3" HorizontalAlignment="Left" Width="52"/>
+                            <Label x:Name="ManualLedTransSecondsLabel" Content="Trans. seconds" Padding="5,3,5,3" HorizontalAlignment="Left" Width="80"/>
                         </StackPanel>
                     </Grid>
                 </StackPanel>

--- a/Source/DCSFlightpanels/PanelUserControls/SwitchPanelPZ55UserControl.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/SwitchPanelPZ55UserControl.xaml.cs
@@ -92,10 +92,15 @@
             ManualLedUpCombo.ItemsSource = Enum.GetValues(typeof(PanelLEDColor));
             ManualLedDownCombo.ItemsSource = Enum.GetValues(typeof(PanelLEDColor));
             ManualLedTransCombo.ItemsSource = Enum.GetValues(typeof(PanelLEDColor));
+            for (int i = 1; i <= 30; i++)
+            {
+                ManualLedTransSecondsCombo.Items.Add(i);
+            }
 
             ManualLedUpCombo.SelectedValue = _switchPanelPZ55.ManualLandingGearLedsColorUp;
             ManualLedDownCombo.SelectedValue = _switchPanelPZ55.ManualLandingGearLedsColorDown;
             ManualLedTransCombo.SelectedValue = _switchPanelPZ55.ManualLandingGearLedsColorTrans;
+            ManualLedTransSecondsCombo.SelectedValue = _switchPanelPZ55.ManualLandingGearTransTimeSeconds;
         }
 
         public void BipPanelRegisterEvent(object sender, BipPanelRegisteredEventArgs e)
@@ -1274,16 +1279,23 @@
             _switchPanelPZ55.ManualLandingGearLedsColorDown = (PanelLEDColor)((ComboBox)sender).SelectedValue;
         }
 
+        private void ManualLedTransSecondsCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            _switchPanelPZ55.ManualLandingGearTransTimeSeconds = (int)((ComboBox)sender).SelectedValue;
+        }
+
         private void SetManualLedColorsSelectionVisibility(bool isVisible)
         {
             var visibility = isVisible ? Visibility.Visible : Visibility.Hidden;
             ManualLedUpCombo.Visibility = visibility;
             ManualLedTransCombo.Visibility = visibility;
             ManualLedDownCombo.Visibility = visibility;
+            ManualLedTransSecondsCombo.Visibility = visibility;
 
             ManualLedUpLabel.Visibility = visibility;
             ManualLedTransLabel.Visibility = visibility;
             ManualLedDownLabel.Visibility = visibility;
+            ManualLedTransSecondsLabel.Visibility = visibility;
         }
     }
 }


### PR DESCRIPTION
Last little update on the Pz55

The user can configure (from 1 to 30 seconds) the transition time of the LEDS when switching gear knob position.
This would visually help the user to know the real time the gears take to deploy or retract.

There is still a fixed random deviation of about 0 to 3 seconds to make things more fun.

All in all, the default value of 5 + 3 seconds should mimic the previous fixed random (1500, 10000)