### PR TITLE
[Bills-Interface_analysis] Class reorganisation, use of auto properties, ternary

### DIFF
--- a/Source/DCSFlightpanels/Bills/BillBaseInput.cs
+++ b/Source/DCSFlightpanels/Bills/BillBaseInput.cs
@@ -17,7 +17,6 @@
 
     using NonVisuals;
     using NonVisuals.DCSBIOSBindings;
-    using NonVisuals.Interfaces;
     using NonVisuals.Saitek;
     using NonVisuals.Saitek.Panels;
 
@@ -25,51 +24,52 @@
     {
         private readonly SaitekPanel _saitekPanel;
         private KeyPress _keyPress;
-        private OSCommand _operatingSystemCommand;
-        private IPanelUI _panelUI;
-        private TextBox _textBox;
         private ContextMenuPanelTextBox _contextMenu;
 
-
         public abstract bool ContainsDCSBIOS();
-
         public abstract bool ContainsBIPLink();
-
         public abstract bool IsEmpty();
-
         public abstract bool IsEmptyNoCareBipLink();
-
         public abstract void Consume(List<DCSBIOSInput> dcsBiosInputs);
-
         public abstract void ClearAll();
-
         protected abstract void ClearDCSBIOSFromBill();
+        public abstract BIPLink BipLink { get; set; }
+        public abstract List<DCSBIOSInput> DCSBIOSInputs { get; set; }
+        public abstract DCSBIOSActionBindingBase DCSBIOSBinding { get; set; }
 
+        protected TextBox TextBox { get; set; }
+        private OSCommand OSCommand { get; set; }
+        public IPanelUI PanelUIParent { get; set; }
 
+        public OSCommand OSCommandObject
+        {
+            get => OSCommand;
+            set
+            {
+                OSCommand = value;
+                TextBox.Text = OSCommand != null ? OSCommand.Name : string.Empty;
+            }
+        }
+
+        public KeyPress KeyPress
+        {
+            get => _keyPress;
+            set
+            {
+                if (value != null && ContainsDCSBIOS())
+                {
+                    throw new Exception("Cannot insert KeyPress, Bill already contains DCSBIOSInputs");
+                }
+                _keyPress = value;
+                TextBox.Text = _keyPress != null ? _keyPress.GetKeyPressInformation() : string.Empty;
+            }
+        }
 
         protected BillBaseInput(TextBox textBox, IPanelUI panelUI, SaitekPanel saitekPanel)
         {
-            _textBox = textBox;
-            _panelUI = panelUI;
+            TextBox = textBox;
+            PanelUIParent = panelUI;
             _saitekPanel = saitekPanel;
-        }
-
-        public abstract BIPLink BipLink
-        {
-            get;
-            set;
-        }
-
-        public abstract List<DCSBIOSInput> DCSBIOSInputs
-        {
-            get;
-            set;
-        }
-
-        public abstract DCSBIOSActionBindingBase DCSBIOSBinding
-        {
-            get;
-            set;
         }
 
         private void CopySetting(CopyContentType copyContentType)
@@ -141,7 +141,6 @@
                         {
                             AddKeyStroke((KeyPressInfo)copyPackage.Content);
                         }
-
                         break;
                     }
 
@@ -151,7 +150,6 @@
                         {
                             AddKeySequence(copyPackage.Description, (SortedList<int, IKeyPressInfo>)copyPackage.Content);
                         }
-
                         break;
                     }
 
@@ -161,7 +159,6 @@
                         {
                             AddDCSBIOS(copyPackage.Description, (List<DCSBIOSInput>)copyPackage.Content);
                         }
-
                         break;
                     }
 
@@ -180,11 +177,9 @@
                         {
                             AddOSCommand((OSCommand)copyPackage.Content);
                         }
-
                         break;
                     }
             }
-
         }
 
         protected void SetContextMenu()
@@ -289,7 +284,6 @@
                     ContainsDCSBIOS(),
                     ContainsBIPLink(),
                     ContainsOSCommand());
-
             }
             catch (Exception ex)
             {
@@ -394,8 +388,7 @@
                 return;
             }
 
-            var keyPress = new KeyPress(virtualKeyNull, KeyPressLength.ThirtyTwoMilliSec);
-            KeyPress = keyPress;
+            KeyPress = new KeyPress(virtualKeyNull, KeyPressLength.ThirtyTwoMilliSec);
             KeyPress.Description = "VK_NULL";
             TextBox.Text = virtualKeyNull;
             UpdateKeyBindingKeyStroke();
@@ -433,8 +426,7 @@
                 }
                 else
                 {
-                    var keyPress = new KeyPress(keyPressReadingWindow.VirtualKeyCodesAsString, keyPressReadingWindow.LengthOfKeyPress);
-                    KeyPress = keyPress;
+                    KeyPress = new KeyPress(keyPressReadingWindow.VirtualKeyCodesAsString, keyPressReadingWindow.LengthOfKeyPress);
                     KeyPress.Description = string.Empty;
                     TextBox.Text = keyPressReadingWindow.VirtualKeyCodesAsString;
                 }
@@ -444,18 +436,16 @@
 
         private void AddKeyStroke(KeyPressInfo keyStroke)
         {
-            var keyPress = new KeyPress();
-            keyPress.KeyPressSequence.Add(0, keyStroke);
-            keyPress.Description = string.Empty;
-            KeyPress = keyPress;
+            KeyPress = new KeyPress();
+            KeyPress.KeyPressSequence.Add(0, keyStroke);
+            KeyPress.Description = string.Empty;
             TextBox.Text = keyStroke.VirtualKeyCodesAsString;
             UpdateKeyBindingKeyStroke();
         }
 
         private void AddKeySequence(string description, SortedList<int, IKeyPressInfo> keySequence)
         {
-            var keyPress = new KeyPress("Key stroke sequence", keySequence);
-            KeyPress = keyPress;
+            KeyPress = new KeyPress("Key stroke sequence", keySequence);
             KeyPress.Description = description;
             if (!string.IsNullOrEmpty(description))
             {
@@ -491,8 +481,7 @@
                 else if (sequenceList.Count == 1)
                 {
                     // If only one press was created treat it as a simple keypress
-                    var keyPress = new KeyPress(sequenceList[0].VirtualKeyCodesAsString, sequenceList[0].LengthOfKeyPress);
-                    KeyPress = keyPress;
+                    KeyPress = new KeyPress(sequenceList[0].VirtualKeyCodesAsString, sequenceList[0].LengthOfKeyPress);
                     KeyPress.Description = keySequenceWindow.Description;
                     TextBox.Text = sequenceList[0].VirtualKeyCodesAsString;
                     UpdateKeyBindingKeyStroke();
@@ -555,35 +544,30 @@
                         bipLinkWindow = new BIPLinkWindow(bipLink);
                         break;
                     }
-
                 case GamingPanelEnum.PZ55SwitchPanel:
                     {
                         var bipLink = ContainsBIPLink() ? BipLink : new BIPLinkPZ55();
                         bipLinkWindow = new BIPLinkWindow(bipLink);
                         break;
                     }
-
                 case GamingPanelEnum.PZ70MultiPanel:
                     {
                         var bipLink = ContainsBIPLink() ? BipLink : new BIPLinkPZ70();
                         bipLinkWindow = new BIPLinkWindow(bipLink);
                         break;
                     }
-
                 case GamingPanelEnum.PZ69RadioPanel:
                     {
                         var bipLink = ContainsBIPLink() ? BipLink : new BIPLinkPZ69();
                         bipLinkWindow = new BIPLinkWindow(bipLink);
                         break;
                     }
-
                 case GamingPanelEnum.TPM:
                     {
                         var bipLink = ContainsBIPLink() ? BipLink : new BIPLinkTPM();
                         bipLinkWindow = new BIPLinkWindow(bipLink);
                         break;
                     }
-
                 default:
                     {
                         return;
@@ -645,7 +629,7 @@
                     keyPressLength = KeyPress.GetLengthOfKeyPress();
                 }
 
-                _saitekPanel.AddOrUpdateKeyStrokeBinding(_panelUI.GetSwitch(TextBox), TextBox.Text, keyPressLength);
+                _saitekPanel.AddOrUpdateKeyStrokeBinding(PanelUIParent.GetSwitch(TextBox), TextBox.Text, keyPressLength);
             }
             catch (Exception ex)
             {
@@ -659,7 +643,7 @@
             {
                 if (_keyPress != null)
                 {
-                    _saitekPanel.AddOrUpdateSequencedKeyBinding(_panelUI.GetSwitch(TextBox), TextBox.Text, _keyPress.KeyPressSequence);
+                    _saitekPanel.AddOrUpdateSequencedKeyBinding(PanelUIParent.GetSwitch(TextBox), TextBox.Text, _keyPress.KeyPressSequence);
                 }
             }
             catch (Exception ex)
@@ -672,7 +656,7 @@
         {
             try
             {
-                _saitekPanel.AddOrUpdateDCSBIOSBinding(_panelUI.GetSwitch(TextBox), DCSBIOSInputs, TextBox.Text);
+                _saitekPanel.AddOrUpdateDCSBIOSBinding(PanelUIParent.GetSwitch(TextBox), DCSBIOSInputs, TextBox.Text);
             }
             catch (Exception ex)
             {
@@ -686,7 +670,7 @@
             {
                 if (BipLink != null)
                 {
-                    _saitekPanel.AddOrUpdateBIPLinkBinding(_panelUI.GetSwitch(TextBox), BipLink);
+                    _saitekPanel.AddOrUpdateBIPLinkBinding(PanelUIParent.GetSwitch(TextBox), BipLink);
                 }
             }
             catch (Exception ex)
@@ -699,7 +683,7 @@
         {
             try
             {
-                _saitekPanel.AddOrUpdateOSCommandBinding(_panelUI.GetSwitch(TextBox), OSCommandObject);
+                _saitekPanel.AddOrUpdateOSCommandBinding(PanelUIParent.GetSwitch(TextBox), OSCommandObject);
             }
             catch (Exception ex)
             {
@@ -724,7 +708,7 @@
         private void DeleteDCSBIOS()
         {
             TextBox.Text = string.Empty;
-            _saitekPanel.RemoveSwitchFromList(ControlListPZ55.DCSBIOS, _panelUI.GetSwitch(TextBox));
+            _saitekPanel.RemoveSwitchFromList(ControlListPZ55.DCSBIOS, PanelUIParent.GetSwitch(TextBox));
             ClearDCSBIOSFromBill();
         }
 
@@ -741,13 +725,13 @@
         private void DeleteOSCommand()
         {
             TextBox.Text = string.Empty;
-            _saitekPanel.RemoveSwitchFromList(ControlListPZ55.OSCOMMANDS, _panelUI.GetSwitch(_textBox));
+            _saitekPanel.RemoveSwitchFromList(ControlListPZ55.OSCOMMANDS, PanelUIParent.GetSwitch(TextBox));
             OSCommandObject = null;
         }
 
         public bool ContainsOSCommand()
         {
-            return _operatingSystemCommand != null;
+            return OSCommand != null;
         }
 
         public bool ContainsKeyPress()
@@ -765,20 +749,6 @@
             return _keyPress != null && !_keyPress.IsMultiSequenced() && _keyPress.KeyPressSequence.Count > 0;
         }
 
-        public KeyPress KeyPress
-        {
-            get => _keyPress;
-            set
-            {
-                if (value != null && ContainsDCSBIOS())
-                {
-                    throw new Exception("Cannot insert KeyPress, Bill already contains DCSBIOSInputs");
-                }
-                _keyPress = value;
-                _textBox.Text = _keyPress != null ? _keyPress.GetKeyPressInformation() : string.Empty;
-            }
-        }
-
         private IKeyPressInfo GetKeyPress()
         {
             return _keyPress.KeyPressSequence[0];
@@ -793,34 +763,5 @@
         {
             return _keyPress.KeyPressSequence;
         }
-
-        public OSCommand OSCommandObject
-        {
-            get => _operatingSystemCommand;
-            set
-            {
-                _operatingSystemCommand = value;
-                _textBox.Text = _operatingSystemCommand != null ? _operatingSystemCommand.Name : string.Empty;
-            }
-        }
-
-        protected TextBox TextBox
-        {
-            get => _textBox;
-            set => _textBox = value;
-        }
-
-        private OSCommand OSCommand
-        {
-            get => _operatingSystemCommand;
-            set => _operatingSystemCommand = value;
-        }
-        
-        public IPanelUI PanelUIParent
-        {
-            get => _panelUI;
-            set => _panelUI = value;
-        }
     }
-
 }

--- a/Source/DCSFlightpanels/Bills/BillBaseInputStreamDeck.cs
+++ b/Source/DCSFlightpanels/Bills/BillBaseInputStreamDeck.cs
@@ -14,18 +14,37 @@
     {
         private KeyPress _keyPress;
         private OSCommand _operatingSystemCommand;
-        private TextBox _textBox;
 
         public abstract bool ContainsDCSBIOS();
-
         public abstract bool ContainsBIPLink();
-
         public abstract bool IsEmpty();
-
         public abstract void Consume(List<DCSBIOSInput> dcsBiosInputs);
-
         public abstract void Clear();
+        public TextBox TextBox { get; set; }
 
+        public OSCommand OSCommandObject
+        {
+            get => _operatingSystemCommand;
+            set
+            {
+                _operatingSystemCommand = value;
+                TextBox.Text = _operatingSystemCommand != null ? _operatingSystemCommand.Name : string.Empty;
+            }
+        }
+
+        public KeyPress KeyPress
+        {
+            get => _keyPress;
+            set
+            {
+                if (value != null && ContainsDCSBIOS())
+                {
+                    throw new Exception("Cannot insert KeyPress, Bill already contains DCSBIOSInputs");
+                }
+                _keyPress = value;
+                TextBox.Text = _keyPress != null ? _keyPress.GetKeyPressInformation() : string.Empty;
+            }
+        }
 
         public bool ContainsOSCommand()
         {
@@ -47,39 +66,9 @@
             return _keyPress != null && !_keyPress.IsMultiSequenced() && _keyPress.KeyPressSequence.Count > 0;
         }
 
-        public KeyPress KeyPress
-        {
-            get => _keyPress;
-            set
-            {
-                if (value != null && ContainsDCSBIOS())
-                {
-                    throw new Exception("Cannot insert KeyPress, Bill already contains DCSBIOSInputs");
-                }
-                _keyPress = value;
-                _textBox.Text = _keyPress != null ? _keyPress.GetKeyPressInformation() : string.Empty;
-            }
-        }
-
         public SortedList<int, IKeyPressInfo> GetKeySequence()
         {
             return _keyPress.KeyPressSequence;
-        }
-
-        public OSCommand OSCommandObject
-        {
-            get => _operatingSystemCommand;
-            set
-            {
-                _operatingSystemCommand = value;
-                _textBox.Text = _operatingSystemCommand != null ? _operatingSystemCommand.Name : string.Empty;
-            }
-        }
-
-        public TextBox TextBox
-        {
-            get => _textBox;
-            set => _textBox = value;
         }
     }
 }

--- a/Source/DCSFlightpanels/Bills/BillBaseOutput.cs
+++ b/Source/DCSFlightpanels/Bills/BillBaseOutput.cs
@@ -4,18 +4,11 @@ namespace DCSFlightpanels.Bills
 {
     public abstract class BillBaseOutput
     {
-        private TextBox _textBox;
-
         public abstract bool ContainsDCSBIOS();
         public abstract bool ContainsBIPLink();
         public abstract bool IsEmpty();
         public abstract void Clear();
 
-        public TextBox TextBox
-        {
-            get => _textBox;
-            set => _textBox = value;
-        }
+        public TextBox TextBox { get; set; }
     }
-
 }

--- a/Source/DCSFlightpanels/Bills/BillPFarmingPanel.cs
+++ b/Source/DCSFlightpanels/Bills/BillPFarmingPanel.cs
@@ -9,7 +9,6 @@
     using DCSFlightpanels.Interfaces;
     
     using NonVisuals.DCSBIOSBindings;
-    using NonVisuals.Interfaces;
     using NonVisuals.Saitek;
     using NonVisuals.Saitek.Panels;
 
@@ -18,30 +17,13 @@
         private DCSBIOSActionBindingFarmingPanel _dcsbiosBinding;
         private BIPLinkFarmingPanel _bipLink;
 
-        public BillPFarmingPanel(IPanelUI panelUI, SaitekPanel saitekPanel, TextBox textBox) : base(textBox, panelUI, saitekPanel)
-        {
-            SetContextMenu();
-        }
-
-        protected override void ClearDCSBIOSFromBill()
-        {
-            DCSBIOSBinding = null;
-        }
-
         public override BIPLink BipLink
         {
             get => _bipLink;
             set
             {
                 _bipLink = (BIPLinkFarmingPanel)value;
-                if (_bipLink != null)
-                {
-                    TextBox.Background = Brushes.Bisque;
-                }
-                else
-                {
-                    TextBox.Background = Brushes.White;
-                }
+                TextBox.Background = _bipLink != null ? Brushes.Bisque : Brushes.White;
             }
         }
 
@@ -49,12 +31,7 @@
         {
             get
             {
-                if (ContainsDCSBIOS())
-                {
-                    return _dcsbiosBinding.DCSBIOSInputs;
-                }
-
-                return null;
+                return ContainsDCSBIOS() ? _dcsbiosBinding.DCSBIOSInputs : null;
             }
             set
             {
@@ -77,14 +54,7 @@
                 _dcsbiosBinding = (DCSBIOSActionBindingFarmingPanel)value;
                 if (_dcsbiosBinding != null)
                 {
-                    if (string.IsNullOrEmpty(_dcsbiosBinding.Description))
-                    {
-                        TextBox.Text = "DCS-BIOS";
-                    }
-                    else
-                    {
-                        TextBox.Text = _dcsbiosBinding.Description;
-                    }
+                    TextBox.Text = string.IsNullOrEmpty(_dcsbiosBinding.Description) ? "DCS-BIOS" : _dcsbiosBinding.Description;
                 }
                 else
                 {
@@ -93,9 +63,19 @@
             }
         }
 
+        public BillPFarmingPanel(IPanelUI panelUI, SaitekPanel saitekPanel, TextBox textBox) : base(textBox, panelUI, saitekPanel)
+        {
+            SetContextMenu();
+        }
+
+        protected override void ClearDCSBIOSFromBill()
+        {
+            DCSBIOSBinding = null;
+        }
+
         public override bool ContainsDCSBIOS()
         {
-            return _dcsbiosBinding != null;// && _dcsbiosInputs.Count > 0;
+            return _dcsbiosBinding != null;
         }
 
         public override bool ContainsBIPLink()

--- a/Source/DCSFlightpanels/Bills/BillPZ55.cs
+++ b/Source/DCSFlightpanels/Bills/BillPZ55.cs
@@ -8,9 +8,7 @@
     using DCS_BIOS;
     using DCSFlightpanels.Interfaces;
 
-
     using NonVisuals.DCSBIOSBindings;
-    using NonVisuals.Interfaces;
     using NonVisuals.Saitek;
     using NonVisuals.Saitek.Panels;
 
@@ -19,30 +17,13 @@
         private DCSBIOSActionBindingPZ55 _dcsbiosBindingPZ55;
         private BIPLinkPZ55 _bipLinkPZ55;
 
-        public BillPZ55(IPanelUI panelUI, SaitekPanel saitekPanel, TextBox textBox) : base(textBox, panelUI, saitekPanel)
-        {
-            SetContextMenu();
-        }
-
-        protected override void ClearDCSBIOSFromBill()
-        {
-            DCSBIOSBinding = null;
-        }
-
         public override BIPLink BipLink
         {
             get => _bipLinkPZ55;
             set
             {
                 _bipLinkPZ55 = (BIPLinkPZ55)value;
-                if (_bipLinkPZ55 != null)
-                {
-                    TextBox.Background = Brushes.Bisque;
-                }
-                else
-                {
-                    TextBox.Background = Brushes.White;
-                }
+                TextBox.Background = _bipLinkPZ55 != null ? Brushes.Bisque : Brushes.White;
             }
         }
 
@@ -50,12 +31,7 @@
         {
             get
             {
-                if (ContainsDCSBIOS())
-                {
-                    return _dcsbiosBindingPZ55.DCSBIOSInputs;
-                }
-
-                return null;
+                return ContainsDCSBIOS() ? _dcsbiosBindingPZ55.DCSBIOSInputs : null;
             }
             set
             {
@@ -78,14 +54,7 @@
                 _dcsbiosBindingPZ55 = (DCSBIOSActionBindingPZ55)value;
                 if (_dcsbiosBindingPZ55 != null)
                 {
-                    if (string.IsNullOrEmpty(_dcsbiosBindingPZ55.Description))
-                    {
-                        TextBox.Text = "DCS-BIOS";
-                    }
-                    else
-                    {
-                        TextBox.Text = _dcsbiosBindingPZ55.Description;
-                    }
+                    TextBox.Text = string.IsNullOrEmpty(_dcsbiosBindingPZ55.Description) ? "DCS-BIOS" : _dcsbiosBindingPZ55.Description;                   
                 }
                 else
                 {
@@ -94,9 +63,19 @@
             }
         }
 
+        public BillPZ55(IPanelUI panelUI, SaitekPanel saitekPanel, TextBox textBox) : base(textBox, panelUI, saitekPanel)
+        {
+            SetContextMenu();
+        }
+
+        protected override void ClearDCSBIOSFromBill()
+        {
+            DCSBIOSBinding = null;
+        }
+
         public override bool ContainsDCSBIOS()
         {
-            return _dcsbiosBindingPZ55 != null;// && _dcsbiosInputs.Count > 0;
+            return _dcsbiosBindingPZ55 != null;
         }
 
         public override bool ContainsBIPLink()

--- a/Source/DCSFlightpanels/Bills/BillPZ69.cs
+++ b/Source/DCSFlightpanels/Bills/BillPZ69.cs
@@ -8,15 +8,35 @@
     using DCS_BIOS;
     using DCSFlightpanels.Interfaces;
 
-
     using NonVisuals.DCSBIOSBindings;
-    using NonVisuals.Interfaces;
     using NonVisuals.Saitek;
     using NonVisuals.Saitek.Panels;
 
     public class BillPZ69 : BillBaseInput
     {
         private BIPLinkPZ69 _bipLinkPZ69;
+
+        public override BIPLink BipLink
+        {
+            get => _bipLinkPZ69;
+            set
+            {
+                _bipLinkPZ69 = (BIPLinkPZ69)value;
+                TextBox.Background = _bipLinkPZ69 != null ? Brushes.Bisque : Brushes.White;
+            }
+        }
+
+        public override List<DCSBIOSInput> DCSBIOSInputs
+        {
+            get => null;
+            set {}
+        }
+
+        public override DCSBIOSActionBindingBase DCSBIOSBinding
+        {
+            get => null;
+            set {}
+        }
 
         public BillPZ69(IPanelUI panelUI, SaitekPanel saitekPanel, TextBox textBox) : base(textBox, panelUI, saitekPanel)
         {
@@ -25,39 +45,6 @@
 
         protected override void ClearDCSBIOSFromBill()
         {
-        }
-
-        public override BIPLink BipLink
-        {
-            get => _bipLinkPZ69;
-            set
-            {
-                _bipLinkPZ69 = (BIPLinkPZ69)value;
-                if (_bipLinkPZ69 != null)
-                {
-                    TextBox.Background = Brushes.Bisque;
-                }
-                else
-                {
-                    TextBox.Background = Brushes.White;
-                }
-            }
-        }
-
-        public override List<DCSBIOSInput> DCSBIOSInputs
-        {
-            get => null;
-            set
-            {
-            }
-        }
-
-        public override DCSBIOSActionBindingBase DCSBIOSBinding
-        {
-            get => null;
-            set
-            {
-            }
         }
 
         public override bool ContainsDCSBIOS()

--- a/Source/DCSFlightpanels/Bills/BillPZ69Button.cs
+++ b/Source/DCSFlightpanels/Bills/BillPZ69Button.cs
@@ -5,35 +5,28 @@ namespace DCSFlightpanels.Bills
 {
     public class BillPZ69Button
     {
-        private DCSBIOSOutputBindingPZ69 _dcsbiosBindingLCDPZ69;
         private readonly PZ69Button _button;
+
+        public DCSBIOSOutputBindingPZ69 DCSBIOSBindingLCD { get; set; }
 
         public BillPZ69Button(PZ69Button button)
         {
             _button = button;
         }
-
         
         public bool ContainsLCDBinding()
         {
-            return _dcsbiosBindingLCDPZ69 != null && _dcsbiosBindingLCDPZ69.HasBinding;
+            return DCSBIOSBindingLCD != null && DCSBIOSBindingLCD.HasBinding;
         }
-
         
         public bool IsEmpty()
         {
-            return _dcsbiosBindingLCDPZ69.DCSBIOSOutputObject == null;
+            return DCSBIOSBindingLCD.DCSBIOSOutputObject == null;
         }
-        
-        public DCSBIOSOutputBindingPZ69 DCSBIOSBindingLCD
-        {
-            get => _dcsbiosBindingLCDPZ69;
-            set => _dcsbiosBindingLCDPZ69 = value;
-        }
-        
+
         public void ClearAll()
         {
-            _dcsbiosBindingLCDPZ69 = null;
+            DCSBIOSBindingLCD = null;
         }
     }
 }

--- a/Source/DCSFlightpanels/Bills/BillPZ69Full.cs
+++ b/Source/DCSFlightpanels/Bills/BillPZ69Full.cs
@@ -8,9 +8,7 @@
     using DCS_BIOS;
     using DCSFlightpanels.Interfaces;
 
-
     using NonVisuals.DCSBIOSBindings;
-    using NonVisuals.Interfaces;
     using NonVisuals.Saitek;
     using NonVisuals.Saitek.Panels;
 
@@ -19,30 +17,13 @@
         private BIPLinkPZ69 _bipLinkPZ69;
         private DCSBIOSActionBindingPZ69 _dcsbiosBindingPZ69;
 
-        public BillPZ69Full(IPanelUI panelUI, SaitekPanel saitekPanel, TextBox textBox) : base(textBox, panelUI, saitekPanel)
-        {
-            SetContextMenu();
-        }
-
-        protected override void ClearDCSBIOSFromBill()
-        {
-            DCSBIOSBinding = null;
-        }
-
         public override BIPLink BipLink
         {
             get => _bipLinkPZ69;
             set
             {
                 _bipLinkPZ69 = (BIPLinkPZ69)value;
-                if (_bipLinkPZ69 != null)
-                {
-                    TextBox.Background = Brushes.Bisque;
-                }
-                else
-                {
-                    TextBox.Background = Brushes.White;
-                }
+                TextBox.Background = _bipLinkPZ69 != null ? Brushes.Bisque : Brushes.White;
             }
         }
 
@@ -50,12 +31,7 @@
         {
             get
             {
-                if (ContainsDCSBIOS())
-                {
-                    return _dcsbiosBindingPZ69.DCSBIOSInputs;
-                }
-
-                return null;
+                return ContainsDCSBIOS() ? _dcsbiosBindingPZ69.DCSBIOSInputs : null;
             }
             set
             {
@@ -78,14 +54,7 @@
                 _dcsbiosBindingPZ69 = (DCSBIOSActionBindingPZ69)value;
                 if (_dcsbiosBindingPZ69 != null)
                 {
-                    if (string.IsNullOrEmpty(_dcsbiosBindingPZ69.Description))
-                    {
-                        TextBox.Text = "DCS-BIOS";
-                    }
-                    else
-                    {
-                        TextBox.Text = _dcsbiosBindingPZ69.Description;
-                    }
+                    TextBox.Text = string.IsNullOrEmpty(_dcsbiosBindingPZ69.Description) ? "DCS-BIOS" : _dcsbiosBindingPZ69.Description;
                 }
                 else
                 {
@@ -94,9 +63,19 @@
             }
         }
 
+        public BillPZ69Full(IPanelUI panelUI, SaitekPanel saitekPanel, TextBox textBox) : base(textBox, panelUI, saitekPanel)
+        {
+            SetContextMenu();
+        }
+
+        protected override void ClearDCSBIOSFromBill()
+        {
+            DCSBIOSBinding = null;
+        }
+
         public override bool ContainsDCSBIOS()
         {
-            return _dcsbiosBindingPZ69 != null;// && _dcsbiosInputs.Count > 0;
+            return _dcsbiosBindingPZ69 != null;
         }
 
         public override bool ContainsBIPLink()

--- a/Source/DCSFlightpanels/Bills/BillPZ70.cs
+++ b/Source/DCSFlightpanels/Bills/BillPZ70.cs
@@ -8,9 +8,7 @@
     using DCS_BIOS;
     using DCSFlightpanels.Interfaces;
 
-
-    using NonVisuals.DCSBIOSBindings;
-    using NonVisuals.Interfaces;
+    using NonVisuals.DCSBIOSBindings;    
     using NonVisuals.Saitek;
     using NonVisuals.Saitek.Panels;
 
@@ -18,31 +16,13 @@
     {
         private DCSBIOSActionBindingPZ70 _dcsbiosBindingPZ70;
         private BIPLinkPZ70 _bipLinkPZ70;
-
-        public BillPZ70(IPanelUI panelUI, SaitekPanel saitekPanel, TextBox textBox) : base(textBox, panelUI, saitekPanel)
-        {
-            SetContextMenu();
-        }
-
-        protected override void ClearDCSBIOSFromBill()
-        {
-            DCSBIOSBinding = null;
-        }
-
         public override BIPLink BipLink
         {
             get => _bipLinkPZ70;
             set
             {
                 _bipLinkPZ70 = (BIPLinkPZ70)value;
-                if (_bipLinkPZ70 != null)
-                {
-                    TextBox.Background = Brushes.Bisque;
-                }
-                else
-                {
-                    TextBox.Background = Brushes.White;
-                }
+                TextBox.Background = _bipLinkPZ70 != null ? Brushes.Bisque : Brushes.White;
             }
         }
 
@@ -50,12 +30,7 @@
         {
             get
             {
-                if (ContainsDCSBIOS())
-                {
-                    return _dcsbiosBindingPZ70.DCSBIOSInputs;
-                }
-
-                return null;
+                return ContainsDCSBIOS() ? _dcsbiosBindingPZ70.DCSBIOSInputs : null;
             }
             set
             {
@@ -78,14 +53,7 @@
                 _dcsbiosBindingPZ70 = (DCSBIOSActionBindingPZ70)value;
                 if (_dcsbiosBindingPZ70 != null)
                 {
-                    if (string.IsNullOrEmpty(_dcsbiosBindingPZ70.Description))
-                    {
-                        TextBox.Text = "DCS-BIOS";
-                    }
-                    else
-                    {
-                        TextBox.Text = _dcsbiosBindingPZ70.Description;
-                    }
+                    TextBox.Text = string.IsNullOrEmpty(_dcsbiosBindingPZ70.Description) ? "DCS-BIOS" : _dcsbiosBindingPZ70.Description;
                 }
                 else
                 {
@@ -94,9 +62,19 @@
             }
         }
 
+        public BillPZ70(IPanelUI panelUI, SaitekPanel saitekPanel, TextBox textBox) : base(textBox, panelUI, saitekPanel)
+        {
+            SetContextMenu();
+        }
+
+        protected override void ClearDCSBIOSFromBill()
+        {
+            DCSBIOSBinding = null;
+        }
+
         public override bool ContainsDCSBIOS()
         {
-            return _dcsbiosBindingPZ70 != null;// && _dcsbiosInputs.Count > 0;
+            return _dcsbiosBindingPZ70 != null;
         }
 
         public override bool ContainsBIPLink()

--- a/Source/DCSFlightpanels/Bills/BillStreamDeckAction.cs
+++ b/Source/DCSFlightpanels/Bills/BillStreamDeckAction.cs
@@ -12,62 +12,21 @@
 
     public class BillStreamDeckAction : BillBaseInputStreamDeck
     {
-        private StreamDeckButtonOnOff _button;
         private ActionTypeDCSBIOS _dcsbiosBindingStreamDeck;
         private BIPLinkStreamDeck _bipLinkStreamDeck;
-        private ActionTypeLayer _actionTypeLayer;
         private StreamDeckPanel _streamDeckPanel;
 
+        public StreamDeckButtonOnOff Key { get; set; }
+        public ActionTypeLayer StreamDeckLayerTarget { get; set; }
 
-        public override void Clear()
+        public BIPLinkStreamDeck BIPLink
         {
-            KeyPress = null;
-            OSCommandObject = null;
-            _button = null;
-            _dcsbiosBindingStreamDeck = null;
-            _bipLinkStreamDeck = null;
-            TextBox.Background = Brushes.LightSteelBlue;
-            TextBox.Text = string.Empty;
-        }
-
-        public BillStreamDeckAction(TextBox textBox, StreamDeckButtonOnOff button, StreamDeckPanel streamDeckPanel)
-        {
-            TextBox = textBox;
-            _button = button;
-            _streamDeckPanel = streamDeckPanel;
-        }
-
-        public override bool ContainsDCSBIOS()
-        {
-            return _dcsbiosBindingStreamDeck != null;// && _dcsbiosInputs.Count > 0;
-        }
-
-        public bool ContainsStreamDeckLayer()
-        {
-            return _actionTypeLayer != null;
-        }
-
-        public override bool ContainsBIPLink()
-        {
-            return _bipLinkStreamDeck != null && _bipLinkStreamDeck.BIPLights.Count > 0;
-        }
-
-        public override bool IsEmpty()
-        {
-            return (_bipLinkStreamDeck == null || _bipLinkStreamDeck.BIPLights.Count == 0) && 
-                   (_dcsbiosBindingStreamDeck?.DCSBIOSInputs == null || _dcsbiosBindingStreamDeck.DCSBIOSInputs.Count == 0) && 
-                   (KeyPress == null || KeyPress.KeyPressSequence.Count == 0) &&
-                   _actionTypeLayer == null;
-        }
-
-        public override void Consume(List<DCSBIOSInput> dcsBiosInputs)
-        {
-            if (_dcsbiosBindingStreamDeck == null)
+            get => _bipLinkStreamDeck;
+            set
             {
-                _dcsbiosBindingStreamDeck = new ActionTypeDCSBIOS(_streamDeckPanel);
+                _bipLinkStreamDeck = value;
+                TextBox.Background = _bipLinkStreamDeck != null ? Brushes.Bisque : Brushes.White;
             }
-
-            _dcsbiosBindingStreamDeck.DCSBIOSInputs = dcsBiosInputs;
         }
 
         public ActionTypeDCSBIOS DCSBIOSBinding
@@ -82,14 +41,7 @@
                 _dcsbiosBindingStreamDeck = value;
                 if (_dcsbiosBindingStreamDeck != null)
                 {
-                    if (string.IsNullOrEmpty(_dcsbiosBindingStreamDeck.Description))
-                    {
-                        TextBox.Text = "DCS-BIOS";
-                    }
-                    else
-                    {
-                        TextBox.Text = _dcsbiosBindingStreamDeck.Description;
-                    }
+                    TextBox.Text = string.IsNullOrEmpty(_dcsbiosBindingStreamDeck.Description) ? "DCS-BIOS" : _dcsbiosBindingStreamDeck.Description;
                 }
                 else
                 {
@@ -98,33 +50,55 @@
             }
         }
 
-        public BIPLinkStreamDeck BIPLink
+        public BillStreamDeckAction(TextBox textBox, StreamDeckButtonOnOff button, StreamDeckPanel streamDeckPanel)
         {
-            get => _bipLinkStreamDeck;
-            set
-            {
-                _bipLinkStreamDeck = value;
-                if (_bipLinkStreamDeck != null)
-                {
-                    TextBox.Background = Brushes.Bisque;
-                }
-                else
-                {
-                    TextBox.Background = Brushes.LightSteelBlue;
-                }
-            }
-        }
-        
-        public StreamDeckButtonOnOff Key
-        {
-            get => _button;
-            set => _button = value;
+            TextBox = textBox;
+            Key = button;
+            _streamDeckPanel = streamDeckPanel;
         }
 
-        public ActionTypeLayer StreamDeckLayerTarget
+        public override void Clear()
         {
-            get => _actionTypeLayer;
-            set => _actionTypeLayer = value;
+            KeyPress = null;
+            OSCommandObject = null;
+            Key = null;
+            _dcsbiosBindingStreamDeck = null;
+            _bipLinkStreamDeck = null;
+            TextBox.Background = Brushes.LightSteelBlue;
+            TextBox.Text = string.Empty;
+        }
+
+        public override bool ContainsDCSBIOS()
+        {
+            return _dcsbiosBindingStreamDeck != null;
+        }
+
+        public bool ContainsStreamDeckLayer()
+        {
+            return StreamDeckLayerTarget != null;
+        }
+
+        public override bool ContainsBIPLink()
+        {
+            return _bipLinkStreamDeck != null && _bipLinkStreamDeck.BIPLights.Count > 0;
+        }
+
+        public override bool IsEmpty()
+        {
+            return (_bipLinkStreamDeck == null || _bipLinkStreamDeck.BIPLights.Count == 0) && 
+                   (_dcsbiosBindingStreamDeck?.DCSBIOSInputs == null || _dcsbiosBindingStreamDeck.DCSBIOSInputs.Count == 0) && 
+                   (KeyPress == null || KeyPress.KeyPressSequence.Count == 0) &&
+                   StreamDeckLayerTarget == null;
+        }
+
+        public override void Consume(List<DCSBIOSInput> dcsBiosInputs)
+        {
+            if (_dcsbiosBindingStreamDeck == null)
+            {
+                _dcsbiosBindingStreamDeck = new ActionTypeDCSBIOS(_streamDeckPanel);
+            }
+
+            _dcsbiosBindingStreamDeck.DCSBIOSInputs = dcsBiosInputs;
         }
     }
 }

--- a/Source/DCSFlightpanels/Bills/BillStreamDeckFace.cs
+++ b/Source/DCSFlightpanels/Bills/BillStreamDeckFace.cs
@@ -24,82 +24,15 @@
         private Color _backgroundColor = SettingsManager.DefaultBackgroundColor; 
         private DCSBIOSDecoder _dcsbiosDecoder;
         private string _imageFileRelativePath;
-        private StreamDeckPanel _streamDeckPanel;
+        
+        public string BackgroundHex 
+        { 
+            get { return $"#{_backgroundColor.R:X2}{_backgroundColor.G:X2}{_backgroundColor.B:X2}"; } 
+        }
 
         public BitmapImage SelectedImage { get; set; }
-
         public BitmapImage DeselectedImage { get; set; }
-
-        public override void Clear()
-        {
-            _streamDeckTargetLayer = null;
-            _bipLinkStreamDeck = null;
-            Button = null;
-            _textFont = SettingsManager.DefaultFont;
-            _fontColor = SettingsManager.DefaultFontColor;
-            _backgroundColor = SettingsManager.DefaultBackgroundColor;
-            _dcsbiosDecoder = null;
-            _textFont = SettingsManager.DefaultFont;
-
-            if (TextBox != null)
-            {
-                TextBox.Background = Brushes.LightSteelBlue;
-                TextBox.Text = string.Empty;
-            }
-            _imageFileRelativePath = string.Empty;
-        }
-
-        public override bool IsEmpty()
-        {
-            return (_bipLinkStreamDeck == null || _bipLinkStreamDeck.BIPLights.Count == 0) && _streamDeckTargetLayer == null;
-        }
-
-
-        public bool ContainsTextFace()
-        {
-            return _textFont != null && !string.IsNullOrEmpty(TextBox.Text);
-        }
-
-        public bool ContainsImageFace()
-        {
-            return !string.IsNullOrEmpty(ImageFileRelativePath);
-        }
-
-        public override bool ContainsDCSBIOS()
-        {
-            return _dcsbiosDecoder != null;
-        }
-
-        public Font TextFont
-        {
-            get => _textFont;
-            set
-            {
-                _textFont = value;
-                if (_textFont == null)
-                {
-                    return;
-                }
-                TextBox.FontFamily = new System.Windows.Media.FontFamily(_textFont.Name);
-                TextBox.FontWeight = _textFont.Bold ? FontWeights.Bold : FontWeights.Regular;
-                TextBox.FontSize = _textFont.Size * 96.0 / 72.0;
-                TextBox.FontStyle = _textFont.Italic ? FontStyles.Italic : FontStyles.Normal;
-                var textDecorationCollection = new TextDecorationCollection();
-                if (_textFont.Underline) textDecorationCollection.Add(TextDecorations.Underline);
-                if (_textFont.Strikeout) textDecorationCollection.Add(TextDecorations.Strikethrough);
-                TextBox.TextDecorations = textDecorationCollection;
-            }
-        }
-
-        public bool ContainsStreamDeckLayer()
-        {
-            return _streamDeckTargetLayer != null;
-        }
-
-        public override bool ContainsBIPLink()
-        {
-            return _bipLinkStreamDeck != null && _bipLinkStreamDeck.BIPLights.Count > 0;
-        }
+        public StreamDeckPanel StreamDeckPanelInstance { get; set; }
 
         public Color FontColor
         {
@@ -125,21 +58,26 @@
 
         public int OffsetY { get; set; } = SettingsManager.OffsetX;
 
-
-        public int ButtonNumber()
+        public Font TextFont
         {
-            if (StreamDeckButtonName == EnumStreamDeckButtonNames.BUTTON0_NO_BUTTON)
+            get => _textFont;
+            set
             {
-                return 0;
+                _textFont = value;
+                if (_textFont == null)
+                {
+                    return;
+                }
+                TextBox.FontFamily = new System.Windows.Media.FontFamily(_textFont.Name);
+                TextBox.FontWeight = _textFont.Bold ? FontWeights.Bold : FontWeights.Regular;
+                TextBox.FontSize = _textFont.Size * 96.0 / 72.0;
+                TextBox.FontStyle = _textFont.Italic ? FontStyles.Italic : FontStyles.Normal;
+                var textDecorationCollection = new TextDecorationCollection();
+                if (_textFont.Underline) textDecorationCollection.Add(TextDecorations.Underline);
+                if (_textFont.Strikeout) textDecorationCollection.Add(TextDecorations.Strikethrough);
+                TextBox.TextDecorations = textDecorationCollection;
             }
-
-            return int.Parse(StreamDeckButtonName.ToString().Replace("BUTTON", string.Empty));
-
         }
-        
-        public string BackgroundHex => "#" + _backgroundColor.R.ToString("X2") + _backgroundColor.G.ToString("X2") + _backgroundColor.B.ToString("X2");
-
-
 
         public DCSBIOSDecoder DCSBIOSDecoder
         {
@@ -162,7 +100,7 @@
                 }
             }
         }
-        
+
         public string ImageFileRelativePath
         {
             get => _imageFileRelativePath;
@@ -173,11 +111,62 @@
             }
         }
 
-        public StreamDeckPanel StreamDeckPanelInstance
+        public override void Clear()
         {
-            get => _streamDeckPanel;
-            set => _streamDeckPanel = value;
+            _streamDeckTargetLayer = null;
+            _bipLinkStreamDeck = null;
+            Button = null;
+            _textFont = SettingsManager.DefaultFont;
+            _fontColor = SettingsManager.DefaultFontColor;
+            _backgroundColor = SettingsManager.DefaultBackgroundColor;
+            _dcsbiosDecoder = null;
+            _textFont = SettingsManager.DefaultFont;
+
+            if (TextBox != null)
+            {
+                TextBox.Background = Brushes.LightSteelBlue;
+                TextBox.Text = string.Empty;
+            }
+            _imageFileRelativePath = string.Empty;
+        }
+
+        public override bool IsEmpty()
+        {
+            return (_bipLinkStreamDeck == null || _bipLinkStreamDeck.BIPLights.Count == 0) && _streamDeckTargetLayer == null;
+        }
+
+        public bool ContainsTextFace()
+        {
+            return _textFont != null && !string.IsNullOrEmpty(TextBox.Text);
+        }
+
+        public bool ContainsImageFace()
+        {
+            return !string.IsNullOrEmpty(ImageFileRelativePath);
+        }
+
+        public override bool ContainsDCSBIOS()
+        {
+            return _dcsbiosDecoder != null;
+        }
+
+        public bool ContainsStreamDeckLayer()
+        {
+            return _streamDeckTargetLayer != null;
+        }
+
+        public override bool ContainsBIPLink()
+        {
+            return _bipLinkStreamDeck != null && _bipLinkStreamDeck.BIPLights.Count > 0;
+        }
+
+        public int ButtonNumber()
+        {
+            if (StreamDeckButtonName == EnumStreamDeckButtonNames.BUTTON0_NO_BUTTON)
+            {
+                return 0;
+            }
+            return int.Parse(StreamDeckButtonName.ToString().Replace("BUTTON", string.Empty));
         }
     }
-
 }

--- a/Source/DCSFlightpanels/Bills/BillTPM.cs
+++ b/Source/DCSFlightpanels/Bills/BillTPM.cs
@@ -8,9 +8,7 @@
     using DCS_BIOS;
     using DCSFlightpanels.Interfaces;
 
-
     using NonVisuals.DCSBIOSBindings;
-    using NonVisuals.Interfaces;
     using NonVisuals.Saitek;
     using NonVisuals.Saitek.Panels;
 
@@ -18,7 +16,53 @@
     {
         private DCSBIOSActionBindingTPM _dcsbiosBindingTPM;
         private BIPLinkTPM _bipLinkTPM;
-        
+
+        public override BIPLink BipLink
+        {
+            get => _bipLinkTPM;
+            set
+            {
+                _bipLinkTPM = (BIPLinkTPM)value;
+                TextBox.Background = _bipLinkTPM != null ? Brushes.Bisque : Brushes.White;
+            }
+        }
+
+        public override List<DCSBIOSInput> DCSBIOSInputs
+        {
+            get
+            {
+                return ContainsDCSBIOS() ? _dcsbiosBindingTPM.DCSBIOSInputs : null;
+            }
+            set
+            {
+                if (ContainsDCSBIOS())
+                {
+                    _dcsbiosBindingTPM.DCSBIOSInputs = value;
+                }
+            }
+        }
+
+        public override DCSBIOSActionBindingBase DCSBIOSBinding
+        {
+            get => _dcsbiosBindingTPM;
+            set
+            {
+                if (ContainsKeyPress())
+                {
+                    throw new Exception("Cannot insert DCSBIOSInputs, Bill already contains KeyPress");
+                }
+                _dcsbiosBindingTPM = (DCSBIOSActionBindingTPM)value;
+                if (_dcsbiosBindingTPM != null)
+                {
+                    TextBox.Text = string.IsNullOrEmpty(_dcsbiosBindingTPM.Description) ? "DCS-BIOS" : _dcsbiosBindingTPM.Description;
+                }
+                else
+                {
+                    TextBox.Text = string.Empty;
+                }
+            }
+        }
+
         public BillTPM(IPanelUI panelUI, SaitekPanel saitekPanel, TextBox textBox) : base(textBox, panelUI, saitekPanel)
         {
             SetContextMenu();
@@ -26,7 +70,7 @@
 
         public override bool ContainsDCSBIOS()
         {
-            return _dcsbiosBindingTPM != null;// && _dcsbiosInputs.Count > 0;
+            return _dcsbiosBindingTPM != null;
         }
 
         public override bool ContainsBIPLink()
@@ -57,71 +101,6 @@
         protected override void ClearDCSBIOSFromBill()
         {
             DCSBIOSBinding = null;
-        }
-        
-        public override BIPLink BipLink
-        {
-            get => _bipLinkTPM;
-            set
-            {
-                _bipLinkTPM = (BIPLinkTPM)value;
-                if (_bipLinkTPM != null)
-                {
-                    TextBox.Background = Brushes.Bisque;
-                }
-                else
-                {
-                    TextBox.Background = Brushes.White;
-                }
-            }
-        }
-
-        public override List<DCSBIOSInput> DCSBIOSInputs
-        {
-            get
-            {
-                if (ContainsDCSBIOS())
-                {
-                    return _dcsbiosBindingTPM.DCSBIOSInputs;
-                }
-
-                return null;
-            }
-            set
-            {
-                if (ContainsDCSBIOS())
-                {
-                    _dcsbiosBindingTPM.DCSBIOSInputs = value;
-                }
-            }
-        }
-
-        public override DCSBIOSActionBindingBase DCSBIOSBinding
-        {
-            get => _dcsbiosBindingTPM;
-            set
-            {
-                if (ContainsKeyPress())
-                {
-                    throw new Exception("Cannot insert DCSBIOSInputs, Bill already contains KeyPress");
-                }
-                _dcsbiosBindingTPM = (DCSBIOSActionBindingTPM)value;
-                if (_dcsbiosBindingTPM != null)
-                {
-                    if (string.IsNullOrEmpty(_dcsbiosBindingTPM.Description))
-                    {
-                        TextBox.Text = "DCS-BIOS";
-                    }
-                    else
-                    {
-                        TextBox.Text = _dcsbiosBindingTPM.Description;
-                    }
-                }
-                else
-                {
-                    TextBox.Text = string.Empty;
-                }
-            }
         }
 
         public override void ClearAll()


### PR DESCRIPTION
First part of Bills refacto in branch interface_analyzis

* Class reorg / standardization
    * Properties on top
    * Constructor
    * Functions

* Some use of auto properties and ternary operators to reduce code size without degrading understandability.

I don't think we want to change the `Bill` name right now. Maybe later with the refactoring and reorganization of events we will come with a better name.

As the branch don't fully compile right now I could not test it. Those changes are quite safe in my opinion. No new errors/warning were introduced