### PR TITLE
[Interface analysis] small clean reorg

### DIFF
--- a/Source/DCSFlightpanels/PanelUserControls/BackLitPanelUserControl.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/BackLitPanelUserControl.xaml.cs
@@ -166,7 +166,7 @@
             {
                 if (e.PanelType == GamingPanelEnum.BackLitPanel && e.HidInstance.Equals(_backlitPanelBIP.HIDInstanceId))
                 {
-                    //Dispatcher?.BeginInvoke((Action)(() => _parentTabItem.Header = _parentTabItemHeader + " (connected)"));
+                    //Dispatcher?.BeginInvoke((Action)(() => _parentTabItem.Header = ParentTabItemHeader + " (connected)"));
                 }
             }
             catch (Exception ex)
@@ -181,7 +181,7 @@
             {
                 if (e.PanelType == GamingPanelEnum.BackLitPanel && e.HidInstance.Equals(_backlitPanelBIP.HIDInstanceId))
                 {
-                    //Dispatcher?.BeginInvoke((Action)(() => _parentTabItem.Header = _parentTabItemHeader + " (disconnected)"));
+                    //Dispatcher?.BeginInvoke((Action)(() => _parentTabItem.Header = ParentTabItemHeader + " (disconnected)"));
                 }
             }
             catch (Exception ex)

--- a/Source/DCSFlightpanels/PanelUserControls/FarmingPanelUserControl.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/FarmingPanelUserControl.xaml.cs
@@ -172,7 +172,7 @@
             {
                 if (e.PanelType == GamingPanelEnum.FarmingPanel && e.HidInstance.Equals(_farmingSidePanel.HIDInstanceId))
                 {
-                    //Dispatcher?.BeginInvoke((Action)(() => _parentTabItem.Header = _parentTabItemHeader + " (connected)"));
+                    //Dispatcher?.BeginInvoke((Action)(() => _parentTabItem.Header = ParentTabItemHeader + " (connected)"));
                 }
             }
             catch (Exception ex)
@@ -187,7 +187,7 @@
             {
                 if (e.PanelType == GamingPanelEnum.FarmingPanel && e.HidInstance.Equals(_farmingSidePanel.HIDInstanceId))
                 {
-                    //Dispatcher?.BeginInvoke((Action)(() => _parentTabItem.Header = _parentTabItemHeader + " (disconnected)"));
+                    //Dispatcher?.BeginInvoke((Action)(() => _parentTabItem.Header = ParentTabItemHeader + " (disconnected)"));
                 }
             }
             catch (Exception ex)

--- a/Source/DCSFlightpanels/PanelUserControls/StreamDeck/UserControlStreamDeckUIBase.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/StreamDeck/UserControlStreamDeckUIBase.cs
@@ -89,7 +89,7 @@
                  */
                 if (newlySelectedImage.Bill.Button != _streamDeckPanel.SelectedButton && EventHandlers.AreThereDirtyListeners(this))
                 {
-                    if (CommonUI.DoDiscardAfterMessage(true, "Discard Changes to " + SelectedButtonName + " ?"))
+                    if (CommonUI.DoDiscardAfterMessage(true, $"Discard Changes to {SelectedButtonName} ?"))
                     {
                         SetFormState();
                     }

--- a/Source/DCSFlightpanels/PanelUserControls/SwitchPanelPZ55UserControl.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/SwitchPanelPZ55UserControl.xaml.cs
@@ -303,7 +303,7 @@
             {
                 if (e.PanelType == GamingPanelEnum.PZ55SwitchPanel && e.HidInstance.Equals(_switchPanelPZ55.HIDInstanceId))
                 {
-                    //Dispatcher?.BeginInvoke((Action)(() => _parentTabItem.Header = _parentTabItemHeader + " (connected)"));
+                    //Dispatcher?.BeginInvoke((Action)(() => _parentTabItem.Header = ParentTabItemHeader + " (connected)"));
                 }
             }
             catch (Exception ex)
@@ -318,7 +318,7 @@
             {
                 if (e.PanelType == GamingPanelEnum.PZ55SwitchPanel && e.HidInstance.Equals(_switchPanelPZ55.HIDInstanceId))
                 {
-                    //Dispatcher?.BeginInvoke((Action)(() => _parentTabItem.Header = _parentTabItemHeader + " (disconnected)"));
+                    //Dispatcher?.BeginInvoke((Action)(() => _parentTabItem.Header = ParentTabItemHeader + " (disconnected)"));
                 }
             }
             catch (Exception ex)

--- a/Source/DCSFlightpanels/PanelUserControls/UserControlBase.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/UserControlBase.cs
@@ -2,22 +2,34 @@
 using System.Windows.Controls;
 using ClassLibraryCommon;
 using NonVisuals;
-using NonVisuals.Interfaces;
+
 
 namespace DCSFlightpanels.PanelUserControls
 {
     public class UserControlBase : UserControl, IDisposable
     {
         private TabItem _parentTabItem;
-        private string _parentTabItemHeader;
-        private bool _userControlLoaded;
-        
+        private bool _disposed;
+
+        public string ParentTabItemHeader { get; set; }  //unused except in 6 commented lines and I think those lines could be deleted, not very clear in my head.
+        public bool UserControlLoaded { get; set; }
+
+        public TabItem ParentTabItem
+        {
+            get => _parentTabItem;
+            set
+            {
+                _parentTabItem = value;
+                if (_parentTabItem != null && _parentTabItem.Header != null)
+                {
+                    ParentTabItemHeader = ParentTabItem.Header.ToString();
+                }
+            }
+        }
 
         public UserControlBase()
         {}
         
-
-        private bool _disposed;
         protected virtual void Dispose(bool disposing)
         {
             if (_disposed)
@@ -52,33 +64,5 @@ namespace DCSFlightpanels.PanelUserControls
         {
             return GamingPanelEnum.Unknown;
         }
-        
-
-        public TabItem ParentTabItem
-        {
-            get => _parentTabItem;
-            set
-            {
-                _parentTabItem = value;
-                if (_parentTabItem != null && _parentTabItem.Header != null)
-                {
-                    ParentTabItemHeader = ParentTabItem.Header.ToString();
-                }
-            }
-        }
-
-        public string ParentTabItemHeader
-        {
-            get => _parentTabItemHeader;
-            set => _parentTabItemHeader = value;
-        }
-
-        public bool UserControlLoaded
-        {
-            get => _userControlLoaded;
-            set => _userControlLoaded = value;
-        }
-
-
     }
 }

--- a/Source/DCSFlightpanels/Shared/CommonUI.cs
+++ b/Source/DCSFlightpanels/Shared/CommonUI.cs
@@ -9,19 +9,14 @@ namespace DCSFlightpanels.Shared
             return DoDiscardAfterMessage(isDirty, "Discard changes?");
         }
 
-        public static bool DoDiscardAfterMessage(bool isDirty, string question, string caption = "Confirm")
+        public static bool DoDiscardAfterMessage(bool isDirty, string question)
         {
-            /*
-             * Defaults to true so only if "is dirty" and "do not discard" will result change
-             */
-            var result = true;
-
+            // Defaults to true so only if "is dirty" and "do not discard" will result change
             if (isDirty)
             {
-                result = MessageBox.Show(question, caption, MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes;
+                return(MessageBox.Show(question, "Confirm", MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes);
             }
-
-            return result;
+            return true;
         }
 
     }

--- a/Source/NonVisuals/GamingPanel.cs
+++ b/Source/NonVisuals/GamingPanel.cs
@@ -17,7 +17,6 @@
     {
         internal static Logger logger = LogManager.GetCurrentClassLogger();
         private readonly DCSBIOSOutput _updateCounterDCSBIOSOutput;
-        private readonly Guid _guid = Guid.NewGuid();
         private static readonly object UpdateCounterLockObject = new object();
         private static readonly object LockObject = new object();
         private readonly object _exceptionLockObject = new object();
@@ -200,9 +199,6 @@
                 }
             }
         }
-
-        // public string Hash => _hash;
-        public string GuidString => _guid.ToString();
 
         protected void SetLastException(Exception ex)
         {

--- a/Source/NonVisuals/GamingPanel.cs
+++ b/Source/NonVisuals/GamingPanel.cs
@@ -18,7 +18,6 @@
         internal static Logger logger = LogManager.GetCurrentClassLogger();
         private readonly DCSBIOSOutput _updateCounterDCSBIOSOutput;
         private static readonly object UpdateCounterLockObject = new object();
-        private static readonly object LockObject = new object();
         private readonly object _exceptionLockObject = new object();
         public static readonly List<GamingPanel> GamingPanels = new List<GamingPanel>(); // TODO REMOVE PUBLIC
 

--- a/Source/NonVisuals/GamingPanel.cs
+++ b/Source/NonVisuals/GamingPanel.cs
@@ -55,7 +55,7 @@
 
         protected abstract void GamingPanelKnobChanged(bool isFirstReport, IEnumerable<object> hashSet);
 
-        protected abstract void StartListeningForPanelChanges();
+        protected abstract void StartListeningForHidPanelChanges();
 
         private string _randomBindingHash = string.Empty;
 

--- a/Source/NonVisuals/GamingPanel.cs
+++ b/Source/NonVisuals/GamingPanel.cs
@@ -16,46 +16,87 @@
     public abstract class GamingPanel : IProfileHandlerListener, IDcsBiosDataListener, IIsDirty, IDisposable
     {
         internal static Logger logger = LogManager.GetCurrentClassLogger();
+
+        public abstract void Startup();
+        public abstract void Identify();
+        public abstract void ClearSettings(bool setIsDirty = false);
+        public abstract void ImportSettings(GenericPanelBinding genericPanelBinding);
+        public abstract List<string> ExportSettings();
+        public abstract void SavePanelSettings(object sender, ProfileHandlerEventArgs e);
+        public abstract void SavePanelSettingsJSON(object sender, ProfileHandlerEventArgs e);
+        public abstract void DcsBiosDataReceived(object sender, DCSBIOSDataEventArgs e);
+        protected abstract void GamingPanelKnobChanged(bool isFirstReport, IEnumerable<object> hashSet);
+        protected abstract void StartListeningForHidPanelChanges();
+
         private readonly DCSBIOSOutput _updateCounterDCSBIOSOutput;
         private static readonly object UpdateCounterLockObject = new object();
         private readonly object _exceptionLockObject = new object();
+        private Exception _lastException;
+        private string _randomBindingHash = string.Empty;
+        private uint _count;
+        private bool _synchedOnce;
+        protected bool Closed { get; set; }
+        protected bool FirstReportHasBeenRead = false;
+        protected readonly HIDSkeleton HIDSkeletonBase;
+        public bool IsDirty { get; set; }
+        public bool SettingsLoading { get; set; }
+        public GamingPanelEnum TypeOfPanel { get; set; }
+        public bool ForwardPanelEvent { get; set; }
+        public int VendorId { get; set; }
+        public int ProductId { get; set; }
+        public long ReportCounter = 0;
         public static readonly List<GamingPanel> GamingPanels = new List<GamingPanel>(); // TODO REMOVE PUBLIC
 
-        private Exception _lastException;
+        public string HIDInstanceId
+        {
+            get => HIDSkeletonBase.InstanceId;
+            set => HIDSkeletonBase.InstanceId = value;
+        }
 
-        private bool _isDirty;
+        public string BindingHash
+        {
+            get
+            {
+                if (string.IsNullOrWhiteSpace(_randomBindingHash))
+                {
+                    _randomBindingHash = Common.GetRandomMd5Hash();
+                }
 
-        private uint _count;
+                return _randomBindingHash;
+            }
 
-        private bool _synchedOnce;
+            set
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    _randomBindingHash = Common.GetRandomMd5Hash();
+                    SetIsDirty();
+                }
+                else
+                {
+                    _randomBindingHash = value;
+                }
+            }
+        }
 
-        public abstract void Startup();
+        private bool _disposed;
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+            {
+                return;
+            }
 
-        public abstract void Identify();
+            if (disposing)
+            {
+                Closed = true; // Don't know if this is necessary atm. (2021)
+                AppEventHandler.DetachForwardPanelEventListener(this);
+                AppEventHandler.DetachSettingsConsumerListener(this);
+                BIOSEventHandler.DetachDataListener(this);
+            }
 
-        public abstract void ClearSettings(bool setIsDirty = false);
-
-        public abstract void ImportSettings(GenericPanelBinding genericPanelBinding);
-
-        public abstract List<string> ExportSettings();
-
-        public abstract void SavePanelSettings(object sender, ProfileHandlerEventArgs e);
-
-        public abstract void SavePanelSettingsJSON(object sender, ProfileHandlerEventArgs e);
-
-        public abstract void DcsBiosDataReceived(object sender, DCSBIOSDataEventArgs e);
-
-        protected readonly HIDSkeleton HIDSkeletonBase;
-
-        public long ReportCounter = 0;
-
-        protected bool FirstReportHasBeenRead = false;
-
-        protected abstract void GamingPanelKnobChanged(bool isFirstReport, IEnumerable<object> hashSet);
-
-        protected abstract void StartListeningForHidPanelChanges();
-
-        private string _randomBindingHash = string.Empty;
+            _disposed = true;
+        }
 
         protected GamingPanel(GamingPanelEnum typeOfGamingPanel, HIDSkeleton hidSkeleton)
         {
@@ -83,25 +124,6 @@
             AppEventHandler.AttachForwardPanelEventListener(this);
             AppEventHandler.AttachSettingsConsumerListener(this);
             BIOSEventHandler.AttachDataListener(this);
-        }
-
-        private bool _disposed;
-        protected virtual void Dispose(bool disposing)
-        {
-            if (_disposed)
-            {
-                return;
-            }
-
-            if (disposing)
-            {
-                Closed = true; // Don't know if this is necessary atm. (2021)
-                AppEventHandler.DetachForwardPanelEventListener(this);
-                AppEventHandler.DetachSettingsConsumerListener(this);
-                BIOSEventHandler.DetachDataListener(this);
-            }
-
-            _disposed = true;
         }
 
         public void Dispose()
@@ -150,6 +172,11 @@
             }
         }
 
+        public void SetIsDirty()
+        {
+            AppEventHandler.SettingsChanged(this, HIDInstanceId, TypeOfPanel);
+            IsDirty = true;
+        }
 
         public virtual void ProfileSelected(object sender, AirframeEventArgs e)
         {
@@ -159,44 +186,6 @@
         public void SetForwardPanelEvent(object sender, ForwardPanelEventArgs e)
         {
             ForwardPanelEvent = e.Forward;
-        }
-
-        public bool ForwardPanelEvent { get; set; }
-
-        public int VendorId { get; set; }
-
-        public int ProductId { get; set; }
-
-        public string HIDInstanceId
-        {
-            get => HIDSkeletonBase.InstanceId;
-            set => HIDSkeletonBase.InstanceId = value;
-        }
-
-        public string BindingHash
-        {
-            get
-            {
-                if (string.IsNullOrWhiteSpace(_randomBindingHash))
-                {
-                    _randomBindingHash = Common.GetRandomMd5Hash();
-                }
-
-                return _randomBindingHash;
-            }
-
-            set
-            {
-                if (string.IsNullOrWhiteSpace(value))
-                {
-                    _randomBindingHash = Common.GetRandomMd5Hash();
-                    SetIsDirty();
-                }
-                else
-                {
-                    _randomBindingHash = value;
-                }
-            }
         }
 
         protected void SetLastException(Exception ex)
@@ -235,46 +224,10 @@
             return result;
         }
 
-
-        public void SetIsDirty()
-        {
-            IsDirty = true;
-        }
-
-        public bool IsDirty
-        {
-            get => _isDirty;
-            set
-            {
-                _isDirty = value;
-                if (_isDirty)
-                {
-                    AppEventHandler.SettingsChanged(this, HIDInstanceId, TypeOfPanel);
-                }
-            }
-        }
-
         public void StateSaved()
         {
-            _isDirty = false;
+            IsDirty = false;
         }
-
-        public bool SettingsLoading { get; set; }
-
-        public GamingPanelEnum TypeOfPanel { get; set; }
-
-        // TODO fixa att man kan koppla in/ur panelerna?
-        /*
-         * 
-        
-        public bool IsAttached
-        {
-            get { return _isAttached; }
-            set { _isAttached = value; }
-        }
-        */
-        protected bool Closed { get; set; }
-
 
         public void PanelBindingReadFromFile(object sender, PanelBindingReadFromFileEventArgs e)
         {

--- a/Source/NonVisuals/Radios/Misc/RadioPanelPZ69DisplayValue.cs
+++ b/Source/NonVisuals/Radios/Misc/RadioPanelPZ69DisplayValue.cs
@@ -10,28 +10,9 @@
 
     public class RadioPanelPZ69DisplayValue
     {
-        private RadioPanelPZ69Display _radioPanelPZ69Display;
-        private RadioPanelPZ69KnobsEmulator _radioPanelPZ69Knob;
-        private string _value;
-        
-
-        public RadioPanelPZ69Display RadioPanelDisplay
-        {
-            get => _radioPanelPZ69Display;
-            set => _radioPanelPZ69Display = value;
-        }
-
-        public string Value
-        {
-            get => _value;
-            set => _value = value;
-        }
-
-        public RadioPanelPZ69KnobsEmulator RadioPanelPZ69Knob
-        {
-            get => _radioPanelPZ69Knob;
-            set => _radioPanelPZ69Knob = value;
-        }
+        public RadioPanelPZ69Display RadioPanelDisplay { get; set; }
+        public string Value { get; set; }
+        public RadioPanelPZ69KnobsEmulator RadioPanelPZ69Knob { get; set; }
 
         public void ImportSettings(string settings)
         {
@@ -48,9 +29,9 @@
             var array = tmp.Split('|');
             try
             {
-                _value = array[2];
-                _radioPanelPZ69Display = (RadioPanelPZ69Display)Enum.Parse(typeof(RadioPanelPZ69Display), array[1]);
-                _radioPanelPZ69Knob = (RadioPanelPZ69KnobsEmulator)Enum.Parse(typeof(RadioPanelPZ69KnobsEmulator), array[0]);
+                Value = array[2];
+                RadioPanelDisplay = (RadioPanelPZ69Display)Enum.Parse(typeof(RadioPanelPZ69Display), array[1]);
+                RadioPanelPZ69Knob = (RadioPanelPZ69KnobsEmulator)Enum.Parse(typeof(RadioPanelPZ69KnobsEmulator), array[0]);
             }
             catch (Exception ex)
             {
@@ -60,9 +41,9 @@
 
         public string ExportSettings()
         {
-            if (!string.IsNullOrEmpty(_value) && double.Parse(_value, Common.GetPZ69FullDisplayNumberFormat()) >= 0)
+            if (!string.IsNullOrEmpty(Value) && double.Parse(Value, Common.GetPZ69FullDisplayNumberFormat()) >= 0)
             {
-                return "PZ69DisplayValue{" + Enum.GetName(typeof(RadioPanelPZ69KnobsEmulator), _radioPanelPZ69Knob) + "|" + Enum.GetName(typeof(RadioPanelPZ69Display), _radioPanelPZ69Display) + "|" + _value + "}";
+                return "PZ69DisplayValue{" + Enum.GetName(typeof(RadioPanelPZ69KnobsEmulator), RadioPanelPZ69Knob) + "|" + Enum.GetName(typeof(RadioPanelPZ69Display), RadioPanelDisplay) + "|" + Value + "}";
             }
 
             return null;

--- a/Source/NonVisuals/Radios/RadioPanelPZ69A10C.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69A10C.cs
@@ -4013,8 +4013,6 @@
         {
             try
             {
-                StartupBase("A-10C");
-
                 // VHF AM
                 _vhfAmDcsbiosOutputFreqDial1 = DCSBIOSControlLocator.GetDCSBIOSOutput("VHFAM_FREQ1");
 

--- a/Source/NonVisuals/Radios/RadioPanelPZ69A10C.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69A10C.cs
@@ -4067,7 +4067,7 @@
                 _tacanDcsbiosOutputFreqChannel = DCSBIOSControlLocator.GetDCSBIOSOutput("TACAN_CHANNEL");
                 DCSBIOSStringManager.AddListener(_tacanDcsbiosOutputFreqChannel, this); // _tacanDcsbiosOutputFreqChannel.MaxLength does not work. Bad JSON format.
 
-                StartListeningForPanelChanges();
+                StartListeningForHidPanelChanges();
 
                 // IsAttached = true;
             }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69AJS37.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69AJS37.cs
@@ -891,7 +891,6 @@
         {
             try
             {
-                StartupBase("AJS-37");
 
                 // COM1
 

--- a/Source/NonVisuals/Radios/RadioPanelPZ69AJS37.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69AJS37.cs
@@ -907,7 +907,7 @@
                 // ADF
 
                 // XPDR
-                StartListeningForPanelChanges();
+                StartListeningForHidPanelChanges();
 
                 // IsAttached = true;
             }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69AV8BNA.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69AV8BNA.cs
@@ -716,7 +716,7 @@
                 _comm2DcsbiosOutputFreq = DCSBIOSControlLocator.GetDCSBIOSOutput("COMM2_STRING_FREQ");
                 DCSBIOSStringManager.AddListener(_comm2DcsbiosOutputFreq, this);
 
-                StartListeningForPanelChanges();
+                StartListeningForHidPanelChanges();
 
                 // IsAttached = true;
             }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69AV8BNA.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69AV8BNA.cs
@@ -706,8 +706,6 @@
         {
             try
             {
-                StartupBase("AV-8B NA");
-
                 // V/UHF COMM1
                 _comm1DcsbiosOutputFreq = DCSBIOSControlLocator.GetDCSBIOSOutput("COMM1_STRING_FREQ");
                 DCSBIOSStringManager.AddListener(_comm1DcsbiosOutputFreq, this);

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
@@ -269,17 +269,6 @@
 
             return false;
         }
-
-        protected void StartupBase(string id)
-        {
-            try
-            {
-            }
-            catch (Exception ex)
-            {
-                SetLastException(ex);
-            }
-        }
         
         public override void SavePanelSettings(object sender, ProfileHandlerEventArgs e)
         {

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Bf109.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Bf109.cs
@@ -892,7 +892,7 @@
                 // NAV1
                 _homingDcsbiosOutputPresetDial = DCSBIOSControlLocator.GetDCSBIOSOutput("FT_ZF_SWITCH");
 
-                StartListeningForPanelChanges();
+                StartListeningForHidPanelChanges();
 
                 // IsAttached = true;
             }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Bf109.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Bf109.cs
@@ -880,8 +880,6 @@
         {
             try
             {
-                StartupBase("Bf 109");
-
                 // COM1
                 _fug16ZyPresetDcsbiosOutputPresetDial = DCSBIOSControlLocator.GetDCSBIOSOutput("RADIO_MODE");
                 _fug16ZyFineTuneDcsbiosOutputDial = DCSBIOSControlLocator.GetDCSBIOSOutput("FUG16_TUNING");

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Emulator.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Emulator.cs
@@ -64,7 +64,7 @@ namespace NonVisuals.Radios
         {
             try
             {
-                StartListeningForPanelChanges();
+                StartListeningForHidPanelChanges();
             }
             catch (Exception ex)
             {

--- a/Source/NonVisuals/Radios/RadioPanelPZ69F14B.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69F14B.cs
@@ -3237,8 +3237,6 @@
         {
             try
             {
-                StartupBase("F-14B");
-
                 // UHF
                 _uhfDcsbiosOutputChannelFreqMode = DCSBIOSControlLocator.GetDCSBIOSOutput("PLT_UHF1_FREQ_MODE");
                 _uhfDcsbiosOutputBigFrequencyNumber = DCSBIOSControlLocator.GetDCSBIOSOutput("PLT_UHF_HIGH_FREQ");

--- a/Source/NonVisuals/Radios/RadioPanelPZ69F14B.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69F14B.cs
@@ -3275,7 +3275,7 @@
                 _rioLink4DcsbiosOutputOnesDial = DCSBIOSControlLocator.GetDCSBIOSOutput("RIO_DATALINK_FREQ_100");
                 _rioLink4DcsbiosOutputPowerSwitch = DCSBIOSControlLocator.GetDCSBIOSOutput("RIO_DATALINK_PW");
 
-                StartListeningForPanelChanges();
+                StartListeningForHidPanelChanges();
 
                 // IsAttached = true;
             }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69F5E.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69F5E.cs
@@ -1935,8 +1935,6 @@
         {
             try
             {
-                StartupBase("F-5E");
-
                 // UHF
                 _uhfDcsbiosOutputFreqDial1 = DCSBIOSControlLocator.GetDCSBIOSOutput("UHF_100MHZ_SEL");
                 _uhfDcsbiosOutputFreqDial2 = DCSBIOSControlLocator.GetDCSBIOSOutput("UHF_10MHZ_SEL");

--- a/Source/NonVisuals/Radios/RadioPanelPZ69F5E.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69F5E.cs
@@ -1951,7 +1951,7 @@
                 _tacanDcsbiosOutputFreqChannel = DCSBIOSControlLocator.GetDCSBIOSOutput("TACAN_CHANNEL");
                 DCSBIOSStringManager.AddListener(_tacanDcsbiosOutputFreqChannel, this); // _tacanDcsbiosOutputFreqChannel.MaxLength does not work. Bad JSON format.
 
-                StartListeningForPanelChanges();
+                StartListeningForHidPanelChanges();
 
                 // IsAttached = true;
             }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69F86F.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69F86F.cs
@@ -1232,7 +1232,7 @@
                 // ADF
                 _apx6ModeDcsbiosOutputCockpit = DCSBIOSControlLocator.GetDCSBIOSOutput("APX6_MASTER");
 
-                StartListeningForPanelChanges();
+                StartListeningForHidPanelChanges();
 
                 // IsAttached = true;
             }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69F86F.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69F86F.cs
@@ -1214,8 +1214,6 @@
         {
             try
             {
-                StartupBase("F-86F");
-
                 // COM1
                 _arc27PresetDcsbiosOutputPresetDial = DCSBIOSControlLocator.GetDCSBIOSOutput("ARC27_CHAN_SEL");
                 _arc27ModeDcsbiosOutputDial = DCSBIOSControlLocator.GetDCSBIOSOutput("ARC27_PWR_SEL");

--- a/Source/NonVisuals/Radios/RadioPanelPZ69FA18C.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69FA18C.cs
@@ -1326,8 +1326,6 @@ namespace NonVisuals.Radios
         {
             try
             {
-                StartupBase("FA-18C_hornet");
-
                 // COMM 1
                 _comm1DcsbiosOutputFreq = DCSBIOSControlLocator.GetDCSBIOSOutput("COMM1_FREQ");
                 _comm1DcsbiosOutputChannel = DCSBIOSControlLocator.GetDCSBIOSOutput("COMM1_CHANNEL_NUMERIC");

--- a/Source/NonVisuals/Radios/RadioPanelPZ69FA18C.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69FA18C.cs
@@ -1348,7 +1348,7 @@ namespace NonVisuals.Radios
                 _ilsDcsbiosOutputChannel = DCSBIOSControlLocator.GetDCSBIOSOutput("COM_ILS_CHANNEL_SW");
 
                 // TACAN
-                StartListeningForPanelChanges();
+                StartListeningForHidPanelChanges();
 
                 // IsAttached = true;
             }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Fw190.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Fw190.cs
@@ -858,7 +858,7 @@
                 // NAV1
                 _homingDcsbiosOutputPresetDial = DCSBIOSControlLocator.GetDCSBIOSOutput("FT_ZF_SWITCH");
 
-                StartListeningForPanelChanges();
+                StartListeningForHidPanelChanges();
 
                 // IsAttached = true;
             }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Fw190.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Fw190.cs
@@ -846,8 +846,6 @@
         {
             try
             {
-                StartupBase("Fw 190");
-
                 // COM1
                 _fug16ZyPresetDcsbiosOutputPresetDial = DCSBIOSControlLocator.GetDCSBIOSOutput("RADIO_MODE");
                 _fug16ZyFineTuneDcsbiosOutputDial = DCSBIOSControlLocator.GetDCSBIOSOutput("FUG16_TUNING");

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Generic.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Generic.cs
@@ -78,7 +78,7 @@ namespace NonVisuals.Radios
         {
             try
             {
-                StartListeningForPanelChanges();
+                StartListeningForHidPanelChanges();
             }
             catch (Exception ex)
             {

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Ka50.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Ka50.cs
@@ -2045,8 +2045,6 @@
         {
             try
             {
-                StartupBase("Ka-50");
-
                 // VHF1
                 _vhf1DcsbiosOutputPresetDial = DCSBIOSControlLocator.GetDCSBIOSOutput("R828_CHANNEL");
 

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Ka50.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Ka50.cs
@@ -2065,7 +2065,7 @@
                 _datalinkSelfIdDcsbiosOutput = DCSBIOSControlLocator.GetDCSBIOSOutput("DLNK_SELF_ID");
                 _datalinkPowerOnOffDcsbiosOutput = DCSBIOSControlLocator.GetDCSBIOSOutput("PVI_POWER");
 
-                StartListeningForPanelChanges();
+                StartListeningForHidPanelChanges();
 
                 // IsAttached = true;
             }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69M2000C.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69M2000C.cs
@@ -1214,8 +1214,6 @@
         {
             try
             {
-                StartupBase("M2000C");
-
                 // COM1
                 _vhfDcsbiosOutputPresetFreqString = DCSBIOSControlLocator.GetDCSBIOSOutput("VHF_FREQUENCY");
                 DCSBIOSStringManager.AddListener(_vhfDcsbiosOutputPresetFreqString, this);

--- a/Source/NonVisuals/Radios/RadioPanelPZ69M2000C.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69M2000C.cs
@@ -1238,7 +1238,7 @@
                 _vorDcsbiosOutputDialPower = DCSBIOSControlLocator.GetDCSBIOSOutput("VORILS_PWR_DIAL");
                 _vorDcsbiosOutputDialTest = DCSBIOSControlLocator.GetDCSBIOSOutput("VORILS_TEST_DIAL");
 
-                StartListeningForPanelChanges();
+                StartListeningForHidPanelChanges();
 
                 // IsAttached = true;
             }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Mi24P.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Mi24P.cs
@@ -1857,7 +1857,7 @@
                 _spu8DcsbiosOutputPresetDial = DCSBIOSControlLocator.GetDCSBIOSOutput("PLT_SPU8_MODE");
                 _spu8ICSSwitchDcsbiosOutput = DCSBIOSControlLocator.GetDCSBIOSOutput("PLT_SPU8_ICS");
 
-                StartListeningForPanelChanges();
+                StartListeningForHidPanelChanges();
             }
             catch (Exception ex)
             {

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Mi24P.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Mi24P.cs
@@ -1828,8 +1828,6 @@
         {
             try
             {
-                StartupBase("Mi-24P");
-
                 //COM1
 
                 //COM2

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Mi8.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Mi8.cs
@@ -2932,7 +2932,7 @@
                 _spu7DcsbiosOutputPresetDial = DCSBIOSControlLocator.GetDCSBIOSOutput("RADIO_SEL_L");
                 _spu7ICSSwitchDcsbiosOutput = DCSBIOSControlLocator.GetDCSBIOSOutput("SPU7_L_ICS");
 
-                StartListeningForPanelChanges();
+                StartListeningForHidPanelChanges();
 
                 // IsAttached = true;
             }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Mi8.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Mi8.cs
@@ -2899,8 +2899,6 @@
         {
             try
             {
-                StartupBase("Mi-8");
-
                 // COM1
                 _r863ManualDcsbiosOutputCockpitFrequency = DCSBIOSControlLocator.GetDCSBIOSOutput("R863_FREQ");
                 DCSBIOSStringManager.AddListener(_r863ManualDcsbiosOutputCockpitFrequency, this);

--- a/Source/NonVisuals/Radios/RadioPanelPZ69MiG21Bis.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69MiG21Bis.cs
@@ -791,7 +791,7 @@
                 _arcSectorCockpitOutput = DCSBIOSControlLocator.GetDCSBIOSOutput("ARC_ZONE");
                 _arcPresetChannelCockpitOutput = DCSBIOSControlLocator.GetDCSBIOSOutput("ARC_CHAN");
 
-                StartListeningForPanelChanges();
+                StartListeningForHidPanelChanges();
 
                 // IsAttached = true;
             }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69MiG21Bis.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69MiG21Bis.cs
@@ -778,8 +778,6 @@
         {
             try
             {
-                StartupBase("MiG21-Bis");
-
                 // Radio
                 _radioDcsbiosOutputFreqSelectorPosition = DCSBIOSControlLocator.GetDCSBIOSOutput("RAD_CHAN");
 

--- a/Source/NonVisuals/Radios/RadioPanelPZ69P51D.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69P51D.cs
@@ -632,8 +632,6 @@
         {
             try
             {
-                StartupBase("P-51D");
-
                 // VHF
                 _vhf1DcsbiosOutputPresetButton0 = DCSBIOSControlLocator.GetDCSBIOSOutput("VHF_RADIO_ON_OFF");
                 _vhf1DcsbiosOutputPresetButton1 = DCSBIOSControlLocator.GetDCSBIOSOutput("VHF_RADIO_CHAN_A");

--- a/Source/NonVisuals/Radios/RadioPanelPZ69P51D.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69P51D.cs
@@ -641,7 +641,7 @@
                 _vhf1DcsbiosOutputPresetButton3 = DCSBIOSControlLocator.GetDCSBIOSOutput("VHF_RADIO_CHAN_C");
                 _vhf1DcsbiosOutputPresetButton4 = DCSBIOSControlLocator.GetDCSBIOSOutput("VHF_RADIO_CHAN_D");
 
-                StartListeningForPanelChanges();
+                StartListeningForHidPanelChanges();
 
                 // IsAttached = true;
             }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69SA342.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69SA342.cs
@@ -1875,8 +1875,6 @@
         {
             try
             {
-                StartupBase("A-10C");
-
                 // VHF AM
                 _vhfAmDcsbiosOutputReading10S = DCSBIOSControlLocator.GetDCSBIOSOutput("AM_RADIO_FREQ_10s");
                 _vhfAmDcsbiosOutputReading1S = DCSBIOSControlLocator.GetDCSBIOSOutput("AM_RADIO_FREQ_1s");

--- a/Source/NonVisuals/Radios/RadioPanelPZ69SA342.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69SA342.cs
@@ -1893,7 +1893,7 @@
                 _nadirModeDcsbiosOutput = DCSBIOSControlLocator.GetDCSBIOSOutput("NADIR_PARAMETER");
                 _nadirDopplerModeDcsbiosOutput = DCSBIOSControlLocator.GetDCSBIOSOutput("NADIR_DOPPLER_MODE");
 
-                StartListeningForPanelChanges();
+                StartListeningForHidPanelChanges();
 
                 // IsAttached = true;
             }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69SRS.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69SRS.cs
@@ -93,7 +93,6 @@
         {
             try
             {
-                StartupBase("SRS");
                 StartListeningForHidPanelChanges();
             }
             catch (Exception ex)

--- a/Source/NonVisuals/Radios/RadioPanelPZ69SRS.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69SRS.cs
@@ -94,7 +94,7 @@
             try
             {
                 StartupBase("SRS");
-                StartListeningForPanelChanges();
+                StartListeningForHidPanelChanges();
             }
             catch (Exception ex)
             {

--- a/Source/NonVisuals/Radios/RadioPanelPZ69UH1H.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69UH1H.cs
@@ -3139,7 +3139,7 @@ namespace NonVisuals.Radios
                 _adfDcsbiosOutputCockpitFrequency = DCSBIOSControlLocator.GetDCSBIOSOutput("ADF_FREQ");
                 _adfDcsbiosOutputSignalStrength = DCSBIOSControlLocator.GetDCSBIOSOutput("ADF_SIGNAL");
 
-                StartListeningForPanelChanges();
+                StartListeningForHidPanelChanges();
             }
             catch (Exception ex)
             {

--- a/Source/NonVisuals/Radios/RadioPanelPZ69UH1H.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69UH1H.cs
@@ -3110,8 +3110,6 @@ namespace NonVisuals.Radios
         {
             try
             {
-                StartupBase("UH-1H");
-
                 // VHF COMM
                 _vhfCommDcsbiosOutputCockpitFrequency = DCSBIOSControlLocator.GetDCSBIOSOutput("VHFCOMM_FREQ");
                 DCSBIOSStringManager.AddListener(_vhfCommDcsbiosOutputCockpitFrequency, this);

--- a/Source/NonVisuals/Radios/RadiopanelPZ69P47D.cs
+++ b/Source/NonVisuals/Radios/RadiopanelPZ69P47D.cs
@@ -842,7 +842,7 @@
                 // COM2
                 // _iffBiffDcsbiosOutputDial = DCSBIOSControlLocator.GetDCSBIOSOutput("IFF_B");
                 // _iffDiffDcsbiosOutputDial = DCSBIOSControlLocator.GetDCSBIOSOutput("IFF_D");
-                StartListeningForPanelChanges();
+                StartListeningForHidPanelChanges();
                 // IsAttached = true;
             }
             catch (Exception ex)

--- a/Source/NonVisuals/Radios/RadiopanelPZ69P47D.cs
+++ b/Source/NonVisuals/Radios/RadiopanelPZ69P47D.cs
@@ -830,8 +830,6 @@
         {
             try
             {
-                StartupBase("P-47D");
-
                 // COM1
                 _hfRadioOffDcsbiosOutput = DCSBIOSControlLocator.GetDCSBIOSOutput("RCTRL_OFF");
                 _hfRadioChannelAPresetDcsbiosOutput = DCSBIOSControlLocator.GetDCSBIOSOutput("RCTRL_A");

--- a/Source/NonVisuals/Radios/RadiopanelSpitfireLFMkIX.cs
+++ b/Source/NonVisuals/Radios/RadiopanelSpitfireLFMkIX.cs
@@ -883,7 +883,7 @@
                 _iffBiffDcsbiosOutputDial = DCSBIOSControlLocator.GetDCSBIOSOutput("IFF_B");
                 _iffDiffDcsbiosOutputDial = DCSBIOSControlLocator.GetDCSBIOSOutput("IFF_D");
 
-                StartListeningForPanelChanges();
+                StartListeningForHidPanelChanges();
                 // IsAttached = true;
             }
             catch (Exception ex)

--- a/Source/NonVisuals/Radios/RadiopanelSpitfireLFMkIX.cs
+++ b/Source/NonVisuals/Radios/RadiopanelSpitfireLFMkIX.cs
@@ -870,8 +870,6 @@
         {
             try
             {
-                StartupBase("Spitfire LF Mk. IX");
-
                 // COM1
                 _hfRadioOffDcsbiosOutput = DCSBIOSControlLocator.GetDCSBIOSOutput("RCTRL_OFF");
                 _hfRadioChannelAPresetDcsbiosOutput = DCSBIOSControlLocator.GetDCSBIOSOutput("RCTRL_A");

--- a/Source/NonVisuals/Saitek/Panels/FarmingSidePanel.cs
+++ b/Source/NonVisuals/Saitek/Panels/FarmingSidePanel.cs
@@ -59,7 +59,7 @@
         {
             try
             {
-                StartListeningForPanelChanges();
+                StartListeningForHidPanelChanges();
             }
             catch (Exception ex)
             {

--- a/Source/NonVisuals/Saitek/Panels/MultiPanelPZ70.cs
+++ b/Source/NonVisuals/Saitek/Panels/MultiPanelPZ70.cs
@@ -1361,7 +1361,7 @@
         {
             try
             {
-                // Common.DebugP("HIDWriteDevice writing feature data " + TypeOfSaitekPanel + " " + GuidString);
+                // Common.DebugP("HIDWriteDevice writing feature data " + TypeOfSaitekPanel);
                 HIDSkeletonBase.HIDWriteDevice?.WriteFeatureData(array);
             }
             catch (Exception ex)

--- a/Source/NonVisuals/Saitek/Panels/MultiPanelPZ70.cs
+++ b/Source/NonVisuals/Saitek/Panels/MultiPanelPZ70.cs
@@ -87,7 +87,7 @@
         {
             try
             {
-                StartListeningForPanelChanges();
+                StartListeningForHidPanelChanges();
             }
             catch (Exception ex)
             {

--- a/Source/NonVisuals/Saitek/Panels/SaitekPanel.cs
+++ b/Source/NonVisuals/Saitek/Panels/SaitekPanel.cs
@@ -73,7 +73,7 @@
             {
                 if (HIDSkeletonBase.HIDReadDevice != null && !Closed)
                 {
-                    // Debug.Write("Adding callback " + HIDSkeletonBase.PanelInfo.GamingPanelType + " " + GuidString + "\n");
+                    // Debug.Write("Adding callback " + HIDSkeletonBase.PanelInfo.GamingPanelType\n");
                     HIDSkeletonBase.HIDReadDevice.ReadReport(OnReport);
                 }
             }

--- a/Source/NonVisuals/Saitek/Panels/SaitekPanel.cs
+++ b/Source/NonVisuals/Saitek/Panels/SaitekPanel.cs
@@ -67,7 +67,7 @@
             base.Dispose(disposing);
         }
 
-        protected override void StartListeningForPanelChanges()
+        protected override void StartListeningForHidPanelChanges()
         {
             try
             {
@@ -125,7 +125,7 @@
                 FirstReportHasBeenRead = true;
             }
 
-            StartListeningForPanelChanges();
+            StartListeningForHidPanelChanges();
         }
 
         private HashSet<object> GetHashSetOfChangedKnobs(byte[] oldValue, byte[] newValue)

--- a/Source/NonVisuals/Saitek/Panels/SwitchPanelPZ55.cs
+++ b/Source/NonVisuals/Saitek/Panels/SwitchPanelPZ55.cs
@@ -84,7 +84,7 @@
         {
             try
             {
-                StartListeningForPanelChanges();
+                StartListeningForHidPanelChanges();
             }
             catch (Exception ex)
             {

--- a/Source/NonVisuals/Saitek/Panels/SwitchPanelPZ55.cs
+++ b/Source/NonVisuals/Saitek/Panels/SwitchPanelPZ55.cs
@@ -943,7 +943,7 @@
                 {
                     var array = new[] { (byte)0x0, (byte)switchPanelPZ55LEDs };
 
-                    // Common.DebugP("HIDWriteDevice writing feature data " + TypeOfSaitekPanel + " " + GuidString);
+                    // Common.DebugP("HIDWriteDevice writing feature data " + TypeOfSaitekPanel);
                     HIDSkeletonBase.HIDWriteDevice.WriteFeatureData(new byte[] { 0, 0 });
                     HIDSkeletonBase.HIDWriteDevice.WriteFeatureData(array);
                 }

--- a/Source/NonVisuals/Saitek/Panels/TPMPanel.cs
+++ b/Source/NonVisuals/Saitek/Panels/TPMPanel.cs
@@ -60,7 +60,7 @@
         {
             try
             {
-                StartListeningForPanelChanges();
+                StartListeningForHidPanelChanges();
             }
             catch (Exception ex)
             {

--- a/Source/NonVisuals/StreamDeck/StreamDeckPanel.cs
+++ b/Source/NonVisuals/StreamDeck/StreamDeckPanel.cs
@@ -185,7 +185,7 @@
         {
             try
             {
-                StartListeningForPanelChanges();
+                StartListeningForHidPanelChanges();
             }
             catch (Exception ex)
             {
@@ -237,7 +237,7 @@
             }
         }
 
-        protected override void StartListeningForPanelChanges()
+        protected override void StartListeningForHidPanelChanges()
         { }
 
         public override void DcsBiosDataReceived(object sender, DCSBIOSDataEventArgs e)


### PR DESCRIPTION
Some light cleaning / reorganization of classes

A lot of changes but should not disturb current working , mainly rename / reorg of properties, use of autoproperties.

This reduce code base and allow a better understanding (at least for me) of low level classes like GamingPanel.cs

Feel free to don't merge it if you don't like it, I can undo some stuff if you want.

I separated each change it it's own commit.
