### PR TITLE
Replace volatile bool by static int & Interlocked in A-10

### DIFF
--- a/Source/NonVisuals/Radios/RadioPanelPZ69A10C.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69A10C.cs
@@ -234,11 +234,11 @@
             {
                 if (disposing)
                 {
-                    _shutdownUHFThread = true;
-                    _shutdownVHFAMThread = true;
-                    _shutdownILSThread = true;
-                    _shutdownTACANThread = true;
-                    _shutdownVHFFMThread = true;
+                    _shutdownUHFThread = 1;
+                    _shutdownVHFAMThread = 1;
+                    _shutdownILSThread = 1;
+                    _shutdownTACANThread = 1;
+                    _shutdownVHFFMThread = 1;
                 }
 
                 _disposed = true;
@@ -866,14 +866,14 @@
             }
 
             // #1
-            _shutdownVHFAMThread = true;
+            Interlocked.Exchange(ref _shutdownVHFAMThread, 1);
             Thread.Sleep(Constants.ThreadShutDownWaitTime);
-            _shutdownVHFAMThread = false;
+            Interlocked.Exchange(ref _shutdownVHFAMThread, 0);
             _vhfAmSyncThread = new Thread(() => VhfAmSynchThreadMethod(desiredPositionDial1, desiredPositionDial2, desiredPositionDial3, desiredPositionDial4));
             _vhfAmSyncThread.Start();
         }
 
-        private volatile bool _shutdownVHFAMThread;
+        private static int _shutdownVHFAMThread;
         private void VhfAmSynchThreadMethod(int desiredPositionDial1, int desiredPositionDial2, int desiredPositionDial3, int desiredPositionDial4)
         {
             try
@@ -1027,7 +1027,7 @@
 
                         Thread.Sleep(SynchSleepTime); // Should be enough to get an update cycle from DCS-BIOS
                     }
-                    while ((IsTooShort(dial1OkTime) || IsTooShort(dial2OkTime) || IsTooShort(dial3OkTime) || IsTooShort(dial4OkTime)) && !_shutdownVHFAMThread);
+                    while ((IsTooShort(dial1OkTime) || IsTooShort(dial2OkTime) || IsTooShort(dial3OkTime) || IsTooShort(dial4OkTime)) && _shutdownVHFAMThread == 0);
                     SwapCockpitStandbyFrequencyVhfAm();
                     ShowFrequenciesOnPanel();
                 }
@@ -1042,7 +1042,6 @@
             {
                 Interlocked.Exchange(ref _vhfAmThreadNowSynching, 0);
             }
-
             Interlocked.Increment(ref _doUpdatePanelLCD);
         }
 
@@ -1191,14 +1190,14 @@
             // Small dial 0.00-0.95 [step of 0.05]
 
             // #1
-            _shutdownUHFThread = true;
+            Interlocked.Exchange(ref _shutdownUHFThread, 1);
             Thread.Sleep(Constants.ThreadShutDownWaitTime);
-            _shutdownUHFThread = false;
+            Interlocked.Exchange(ref _shutdownUHFThread, 0);
             _uhfSyncThread = new Thread(() => UhfSynchThreadMethod(freqDial1, freqDial2, freqDial3, freqDial4, freqDial5));
             _uhfSyncThread.Start();
         }
 
-        private volatile bool _shutdownUHFThread;
+        private static int _shutdownUHFThread;
         private void UhfSynchThreadMethod(int desiredPosition1, int desiredPosition2, int desiredPosition3, int desiredPosition4, int desiredPosition5)
         {
             try
@@ -1423,7 +1422,7 @@
 
                         Thread.Sleep(SynchSleepTime); // Should be enough to get an update cycle from DCS-BIOS
                     }
-                    while ((IsTooShort(dial1OkTime) || IsTooShort(dial2OkTime) || IsTooShort(dial3OkTime) || IsTooShort(dial4OkTime) || IsTooShort(dial5OkTime)) && !_shutdownUHFThread);
+                    while ((IsTooShort(dial1OkTime) || IsTooShort(dial2OkTime) || IsTooShort(dial3OkTime) || IsTooShort(dial4OkTime) || IsTooShort(dial5OkTime)) && _shutdownUHFThread == 0);
                     SwapCockpitStandbyFrequencyUhf();
                     ShowFrequenciesOnPanel();
                 }
@@ -1519,14 +1518,14 @@
                 desiredPositionDial4 = 0;
             }
 
-            _shutdownVHFFMThread = true;
+            Interlocked.Exchange(ref _shutdownVHFFMThread, 1);
             Thread.Sleep(Constants.ThreadShutDownWaitTime);
-            _shutdownVHFFMThread = false;
+            Interlocked.Exchange(ref _shutdownVHFFMThread, 0);
             _vhfFmSyncThread = new Thread(() => VhfFmSynchThreadMethod(desiredPositionDial1, desiredPositionDial2, desiredPositionDial3, desiredPositionDial4));
             _vhfFmSyncThread.Start();
         }
 
-        private volatile bool _shutdownVHFFMThread;
+        private static int _shutdownVHFFMThread;
         private void VhfFmSynchThreadMethod(int desiredPositionDial1, int desiredPositionDial2, int desiredPositionDial3, int frequencyDial4)
         {
             try
@@ -1678,7 +1677,7 @@
                         Thread.Sleep(SynchSleepTime); // Should be enough to get an update cycle from DCS-BIOS
 
                     }
-                    while ((IsTooShort(dial1OkTime) || IsTooShort(dial2OkTime) || IsTooShort(dial3OkTime) || IsTooShort(dial4OkTime)) && !_shutdownVHFFMThread);
+                    while ((IsTooShort(dial1OkTime) || IsTooShort(dial2OkTime) || IsTooShort(dial3OkTime) || IsTooShort(dial4OkTime)) && _shutdownVHFFMThread == 0);
                     SwapCockpitStandbyFrequencyVhfFm();
                     ShowFrequenciesOnPanel();
                 }
@@ -1727,14 +1726,14 @@
             freqDial2 = GetILSDialPosForFrequency(2, int.Parse(frequencyAsString.Substring(4, 2)));
 
             // #1
-            _shutdownILSThread = true;
+            Interlocked.Exchange(ref _shutdownILSThread, 1);
             Thread.Sleep(Constants.ThreadShutDownWaitTime);
-            _shutdownILSThread = false;
+            Interlocked.Exchange(ref _shutdownILSThread, 0);
             _ilsSyncThread = new Thread(() => ILSSynchThreadMethod(freqDial1, freqDial2));
             _ilsSyncThread.Start();
         }
 
-        private volatile bool _shutdownILSThread;
+        private static int _shutdownILSThread;
         private void ILSSynchThreadMethod(int position1, int position2)
         {
             try
@@ -1831,7 +1830,7 @@
 
                         Thread.Sleep(SynchSleepTime); // Should be enough to get an update cycle from DCS-BIOS
                     }
-                    while ((IsTooShort(dial1OkTime) || IsTooShort(dial2OkTime)) && !_shutdownILSThread);
+                    while ((IsTooShort(dial1OkTime) || IsTooShort(dial2OkTime)) && _shutdownILSThread == 0);
                     SwapCockpitStandbyFrequencyIls();
                     ShowFrequenciesOnPanel();
                 }
@@ -1873,14 +1872,14 @@
             // #1 = 12  (position = value)
             // #2 = 0   (position = value)
             // #3 = 1   (position = value)
-            _shutdownTACANThread = true;
+            Interlocked.Exchange(ref _shutdownTACANThread, 1);
             Thread.Sleep(Constants.ThreadShutDownWaitTime);
-            _shutdownTACANThread = false;
+            Interlocked.Exchange(ref _shutdownTACANThread, 0);
             _tacanSyncThread = new Thread(() => TacanSynchThreadMethod(_tacanBigFrequencyStandby, _tacanSmallFrequencyStandby, _tacanXYStandby));
             _tacanSyncThread.Start();
         }
 
-        private volatile bool _shutdownTACANThread;
+        private static int _shutdownTACANThread;
         private void TacanSynchThreadMethod(int desiredPositionDial1, int desiredPositionDial2, int desiredPositionDial3)
         {
             try
@@ -2001,7 +2000,7 @@
 
 
                     }
-                    while ((IsTooShort(dial1OkTime) || IsTooShort(dial2OkTime) || IsTooShort(dial3OkTime)) && !_shutdownTACANThread);
+                    while ((IsTooShort(dial1OkTime) || IsTooShort(dial2OkTime) || IsTooShort(dial3OkTime)) && _shutdownTACANThread == 0);
                     SwapCockpitStandbyFrequencyTacan();
                     ShowFrequenciesOnPanel();
                 }


### PR DESCRIPTION
This is more of an issue & proposition than a "real" PR.

I'm investigating a strange behavior. When loading a profile in no key emulation mode (with DCSBios bindings ?), there is a strange delay on every panel controls 

For example when I switch the gear lever on pz55 , there is like a 0.5 second delay before the graphic on the Xaml form is updated.  If I start DCSFP fresh in key emulation, there is no delay.

I still did not find the cause of the delay but during my searches, I though that it may be more solid to change the volatile bool by a static int & `interlocked.Exchange` for the radio synch treads. In theory the volatile would be enough and work in this case if I understand well but the `interlocked.Exchange` seems more robust and reliable. I'll leave it up to you to decide , you know better than me about all this.

https://stackoverflow.com/questions/154551/volatile-vs-interlocked-vs-lock/154803#154803

