### PR TITLE
Various Tweaks and fixes

### DIFF
--- a/Source/DCS-BIOS/DCSBIOS.cs
+++ b/Source/DCS-BIOS/DCSBIOS.cs
@@ -144,10 +144,13 @@ namespace DCS_BIOS
                 {
                     try
                     {
-                        var byteData = _udpReceiveClient.Receive(ref _ipEndPointReceiverUdp);
-                        if ((_dcsBiosNotificationMode & DcsBiosNotificationMode.AddressValue) == DcsBiosNotificationMode.AddressValue)
+                        if (_udpReceiveClient.Available > 0)
                         {
-                            _dcsProtocolParser.AddArray(byteData);
+                            var byteData = _udpReceiveClient.Receive(ref _ipEndPointReceiverUdp);
+                            if ((_dcsBiosNotificationMode & DcsBiosNotificationMode.AddressValue) == DcsBiosNotificationMode.AddressValue)
+                            {
+                                _dcsProtocolParser.AddArray(byteData);
+                            }
                         }
                     }
                     catch (SocketException)

--- a/Source/DCSFlightpanels/DCSFlightpanels.csproj
+++ b/Source/DCSFlightpanels/DCSFlightpanels.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <LangVersion>8.0</LangVersion>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{6459906E-71BE-4987-B128-B793B50EAD10}</ProjectGuid>

--- a/Source/DCSFlightpanels/PanelUserControls/MultiPanelUserControl.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/MultiPanelUserControl.xaml.cs
@@ -829,110 +829,34 @@
         
         public PanelSwitchOnOff GetSwitch(TextBox textBox)
         {
-            try
+            return textBox switch
             {
-                if (textBox.Equals(TextBoxLcdKnobDecrease))
-                {
-                    return new PZ70SwitchOnOff(MultiPanelPZ70Knobs.LCD_WHEEL_DEC, true);
-                }
-                if (textBox.Equals(TextBoxLcdKnobIncrease))
-                {
-                    return new PZ70SwitchOnOff(MultiPanelPZ70Knobs.LCD_WHEEL_INC, true);
-                }
-                if (textBox.Equals(TextBoxAutoThrottleOff))
-                {
-                    return new PZ70SwitchOnOff(MultiPanelPZ70Knobs.AUTO_THROTTLE, false);
-                }
-                if (textBox.Equals(TextBoxAutoThrottleOn))
-                {
-                    return new PZ70SwitchOnOff(MultiPanelPZ70Knobs.AUTO_THROTTLE, true);
-                }
-                if (textBox.Equals(TextBoxFlapsUp))
-                {
-                    return new PZ70SwitchOnOff(MultiPanelPZ70Knobs.FLAPS_LEVER_UP, true);
-                }
-                if (textBox.Equals(TextBoxFlapsDown))
-                {
-                    return new PZ70SwitchOnOff(MultiPanelPZ70Knobs.FLAPS_LEVER_DOWN, true);
-                }
-                if (textBox.Equals(TextBoxPitchTrimUp))
-                {
-                    return new PZ70SwitchOnOff(MultiPanelPZ70Knobs.PITCH_TRIM_WHEEL_UP, true);
-                }
-                if (textBox.Equals(TextBoxPitchTrimDown))
-                {
-                    return new PZ70SwitchOnOff(MultiPanelPZ70Knobs.PITCH_TRIM_WHEEL_DOWN, true);
-                }
-                if (textBox.Equals(TextBoxApButtonOn))
-                {
-                    return new PZ70SwitchOnOff(MultiPanelPZ70Knobs.AP_BUTTON, true);
-                }
-                if (textBox.Equals(TextBoxApButtonOff))
-                {
-                    return new PZ70SwitchOnOff(MultiPanelPZ70Knobs.AP_BUTTON, false);
-                }
-                if (textBox.Equals(TextBoxHdgButtonOn))
-                {
-                    return new PZ70SwitchOnOff(MultiPanelPZ70Knobs.HDG_BUTTON, true);
-                }
-                if (textBox.Equals(TextBoxHdgButtonOff))
-                {
-                    return new PZ70SwitchOnOff(MultiPanelPZ70Knobs.HDG_BUTTON, false);
-                }
-                if (textBox.Equals(TextBoxNavButtonOn))
-                {
-                    return new PZ70SwitchOnOff(MultiPanelPZ70Knobs.NAV_BUTTON, true);
-                }
-                if (textBox.Equals(TextBoxNavButtonOff))
-                {
-                    return new PZ70SwitchOnOff(MultiPanelPZ70Knobs.NAV_BUTTON, false);
-                }
-                if (textBox.Equals(TextBoxIasButtonOn))
-                {
-                    return new PZ70SwitchOnOff(MultiPanelPZ70Knobs.IAS_BUTTON, true);
-                }
-                if (textBox.Equals(TextBoxIasButtonOff))
-                {
-                    return new PZ70SwitchOnOff(MultiPanelPZ70Knobs.IAS_BUTTON, false);
-                }
-                if (textBox.Equals(TextBoxAltButtonOn))
-                {
-                    return new PZ70SwitchOnOff(MultiPanelPZ70Knobs.ALT_BUTTON, true);
-                }
-                if (textBox.Equals(TextBoxAltButtonOff))
-                {
-                    return new PZ70SwitchOnOff(MultiPanelPZ70Knobs.ALT_BUTTON, false);
-                }
-                if (textBox.Equals(TextBoxVsButtonOn))
-                {
-                    return new PZ70SwitchOnOff(MultiPanelPZ70Knobs.VS_BUTTON, true);
-                }
-                if (textBox.Equals(TextBoxVsButtonOff))
-                {
-                    return new PZ70SwitchOnOff(MultiPanelPZ70Knobs.VS_BUTTON, false);
-                }
-                if (textBox.Equals(TextBoxAprButtonOn))
-                {
-                    return new PZ70SwitchOnOff(MultiPanelPZ70Knobs.APR_BUTTON, true);
-                }
-                if (textBox.Equals(TextBoxAprButtonOff))
-                {
-                    return new PZ70SwitchOnOff(MultiPanelPZ70Knobs.APR_BUTTON, false);
-                }
-                if (textBox.Equals(TextBoxRevButtonOn))
-                {
-                    return new PZ70SwitchOnOff(MultiPanelPZ70Knobs.REV_BUTTON, true);
-                }
-                if (textBox.Equals(TextBoxRevButtonOff))
-                {
-                    return new PZ70SwitchOnOff(MultiPanelPZ70Knobs.REV_BUTTON, false);
-                }
-            }
-            catch (Exception ex)
-            {
-                Common.ShowErrorMessageBox(ex);
-            }
-            throw new Exception("Failed to find MultiPanel knob for TextBox " + textBox.Name);
+                TextBox t when t.Equals(TextBoxLcdKnobDecrease) => new PZ70SwitchOnOff(MultiPanelPZ70Knobs.LCD_WHEEL_DEC, true),
+                TextBox t when t.Equals(TextBoxLcdKnobIncrease) => new PZ70SwitchOnOff(MultiPanelPZ70Knobs.LCD_WHEEL_INC, true),
+                TextBox t when t.Equals(TextBoxAutoThrottleOn) => new PZ70SwitchOnOff(MultiPanelPZ70Knobs.AUTO_THROTTLE, true),
+                TextBox t when t.Equals(TextBoxAutoThrottleOff) => new PZ70SwitchOnOff(MultiPanelPZ70Knobs.AUTO_THROTTLE, false),
+                TextBox t when t.Equals(TextBoxFlapsUp) => new PZ70SwitchOnOff(MultiPanelPZ70Knobs.FLAPS_LEVER_UP, true),
+                TextBox t when t.Equals(TextBoxFlapsDown) => new PZ70SwitchOnOff(MultiPanelPZ70Knobs.FLAPS_LEVER_DOWN, true),
+                TextBox t when t.Equals(TextBoxPitchTrimUp) => new PZ70SwitchOnOff(MultiPanelPZ70Knobs.PITCH_TRIM_WHEEL_UP, true),
+                TextBox t when t.Equals(TextBoxPitchTrimDown) => new PZ70SwitchOnOff(MultiPanelPZ70Knobs.PITCH_TRIM_WHEEL_DOWN, true),
+                TextBox t when t.Equals(TextBoxApButtonOn) => new PZ70SwitchOnOff(MultiPanelPZ70Knobs.AP_BUTTON, true),
+                TextBox t when t.Equals(TextBoxApButtonOff) => new PZ70SwitchOnOff(MultiPanelPZ70Knobs.AP_BUTTON, false),
+                TextBox t when t.Equals(TextBoxHdgButtonOn) => new PZ70SwitchOnOff(MultiPanelPZ70Knobs.HDG_BUTTON, true),
+                TextBox t when t.Equals(TextBoxHdgButtonOff) => new PZ70SwitchOnOff(MultiPanelPZ70Knobs.HDG_BUTTON, false),
+                TextBox t when t.Equals(TextBoxNavButtonOn) => new PZ70SwitchOnOff(MultiPanelPZ70Knobs.NAV_BUTTON, true),
+                TextBox t when t.Equals(TextBoxNavButtonOff) => new PZ70SwitchOnOff(MultiPanelPZ70Knobs.NAV_BUTTON, false),
+                TextBox t when t.Equals(TextBoxIasButtonOn) => new PZ70SwitchOnOff(MultiPanelPZ70Knobs.IAS_BUTTON, true),
+                TextBox t when t.Equals(TextBoxIasButtonOff) => new PZ70SwitchOnOff(MultiPanelPZ70Knobs.IAS_BUTTON, false),
+                TextBox t when t.Equals(TextBoxAltButtonOn) => new PZ70SwitchOnOff(MultiPanelPZ70Knobs.ALT_BUTTON, true),
+                TextBox t when t.Equals(TextBoxAltButtonOff) => new PZ70SwitchOnOff(MultiPanelPZ70Knobs.ALT_BUTTON, false),
+                TextBox t when t.Equals(TextBoxVsButtonOn) => new PZ70SwitchOnOff(MultiPanelPZ70Knobs.VS_BUTTON, true),
+                TextBox t when t.Equals(TextBoxVsButtonOff) => new PZ70SwitchOnOff(MultiPanelPZ70Knobs.VS_BUTTON, false),
+                TextBox t when t.Equals(TextBoxAprButtonOn) => new PZ70SwitchOnOff(MultiPanelPZ70Knobs.APR_BUTTON, true),
+                TextBox t when t.Equals(TextBoxAprButtonOff) => new PZ70SwitchOnOff(MultiPanelPZ70Knobs.APR_BUTTON, false),
+                TextBox t when t.Equals(TextBoxRevButtonOn) => new PZ70SwitchOnOff(MultiPanelPZ70Knobs.REV_BUTTON, true),
+                TextBox t when t.Equals(TextBoxRevButtonOff) => new PZ70SwitchOnOff(MultiPanelPZ70Knobs.REV_BUTTON, false),
+                _ => throw new Exception($"Failed to find MultiPanel knob for TextBox {textBox.Name}")
+            };
         }
 
 

--- a/Source/DCSFlightpanels/PanelUserControls/MultiPanelUserControl.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/MultiPanelUserControl.xaml.cs
@@ -617,10 +617,6 @@
                         {
                             textBox.Bill.KeyPress = keyBinding.OSKeyPress;
                         }
-                        else
-                        {
-                            textBox.Bill.KeyPress = null;
-                        }
                     }
                 }
 
@@ -632,10 +628,6 @@
                         {
                             textBox.Bill.OSCommandObject = operatingSystemCommand.OSCommandObject;
                         }
-                        else
-                        {
-                            textBox.Bill.OSCommandObject = null;
-                        }
                 }
 
                 foreach (var dcsBiosBinding in _multiPanelPZ70.DCSBiosBindings)
@@ -644,10 +636,6 @@
                     if (dcsBiosBinding.DialPosition == _multiPanelPZ70.PZ70DialPosition && dcsBiosBinding.DCSBIOSInputs.Count > 0)
                     {
                         textBox.Bill.DCSBIOSBinding = dcsBiosBinding;
-                    }
-                    else
-                    {
-                        textBox.Bill.DCSBIOSBinding = null;
                     }
                 }
 
@@ -658,10 +646,6 @@
                     if (bipLink.DialPosition == _multiPanelPZ70.PZ70DialPosition && bipLink.BIPLights.Count > 0)
                     {
                         textBox.Bill.BipLink = bipLink;
-                    }
-                    else
-                    {
-                        textBox.Bill.BipLink = null;
                     }
                 }
 

--- a/Source/DCSFlightpanels/PanelUserControls/MultiPanelUserControl.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/MultiPanelUserControl.xaml.cs
@@ -936,113 +936,36 @@
         }
 
 
-        public TextBox GetTextBox(object panelSwitch, bool whenTurnedOn)
+        public TextBox GetTextBox(object panelSwitch, bool isTurnedOn)
         {
             var knob = (MultiPanelPZ70Knobs)panelSwitch;
-            try
-            {
-                if (knob == MultiPanelPZ70Knobs.LCD_WHEEL_DEC && whenTurnedOn)
-                {
-                    return TextBoxLcdKnobDecrease;
-                }
-                if (knob == MultiPanelPZ70Knobs.LCD_WHEEL_INC && whenTurnedOn)
-                {
-                    return TextBoxLcdKnobIncrease;
-                }
-                if (knob == MultiPanelPZ70Knobs.AUTO_THROTTLE && !whenTurnedOn)
-                {
-                    return TextBoxAutoThrottleOff;
-                }
-                if (knob == MultiPanelPZ70Knobs.AUTO_THROTTLE && whenTurnedOn)
-                {
-                    return TextBoxAutoThrottleOn;
-                }
-                if (knob == MultiPanelPZ70Knobs.FLAPS_LEVER_UP && whenTurnedOn)
-                {
-                    return TextBoxFlapsUp;
-                }
-                if (knob == MultiPanelPZ70Knobs.FLAPS_LEVER_DOWN && whenTurnedOn)
-                {
-                    return TextBoxFlapsDown;
-                }
-                if (knob == MultiPanelPZ70Knobs.PITCH_TRIM_WHEEL_UP && whenTurnedOn)
-                {
-                    return TextBoxPitchTrimUp;
-                }
-                if (knob == MultiPanelPZ70Knobs.PITCH_TRIM_WHEEL_DOWN && whenTurnedOn)
-                {
-                    return TextBoxPitchTrimDown;
-                }
-                if (knob == MultiPanelPZ70Knobs.AP_BUTTON && whenTurnedOn)
-                {
-                    return TextBoxApButtonOn;
-                }
-                if (knob == MultiPanelPZ70Knobs.AP_BUTTON && !whenTurnedOn)
-                {
-                    return TextBoxApButtonOff;
-                }
-                if (knob == MultiPanelPZ70Knobs.HDG_BUTTON && whenTurnedOn)
-                {
-                    return TextBoxHdgButtonOn;
-                }
-                if (knob == MultiPanelPZ70Knobs.HDG_BUTTON && !whenTurnedOn)
-                {
-                    return TextBoxHdgButtonOff;
-                }
-                if (knob == MultiPanelPZ70Knobs.NAV_BUTTON && whenTurnedOn)
-                {
-                    return TextBoxNavButtonOn;
-                }
-                if (knob == MultiPanelPZ70Knobs.NAV_BUTTON && !whenTurnedOn)
-                {
-                    return TextBoxNavButtonOff;
-                }
-                if (knob == MultiPanelPZ70Knobs.IAS_BUTTON && whenTurnedOn)
-                {
-                    return TextBoxIasButtonOn;
-                }
-                if (knob == MultiPanelPZ70Knobs.IAS_BUTTON && !whenTurnedOn)
-                {
-                    return TextBoxIasButtonOff;
-                }
-                if (knob == MultiPanelPZ70Knobs.ALT_BUTTON && whenTurnedOn)
-                {
-                    return TextBoxAltButtonOn;
-                }
-                if (knob == MultiPanelPZ70Knobs.ALT_BUTTON && !whenTurnedOn)
-                {
-                    return TextBoxAltButtonOff;
-                }
-                if (knob == MultiPanelPZ70Knobs.VS_BUTTON && whenTurnedOn)
-                {
-                    return TextBoxVsButtonOn;
-                }
-                if (knob == MultiPanelPZ70Knobs.VS_BUTTON && !whenTurnedOn)
-                {
-                    return TextBoxVsButtonOff;
-                }
-                if (knob == MultiPanelPZ70Knobs.APR_BUTTON && whenTurnedOn)
-                {
-                    return TextBoxAprButtonOn;
-                }
-                if (knob == MultiPanelPZ70Knobs.APR_BUTTON && !whenTurnedOn)
-                {
-                    return TextBoxAprButtonOff;
-                }
-                if (knob == MultiPanelPZ70Knobs.REV_BUTTON && whenTurnedOn)
-                {
-                    return TextBoxRevButtonOn;
-                }
-                if (knob == MultiPanelPZ70Knobs.REV_BUTTON && !whenTurnedOn)
-                {
-                    return TextBoxRevButtonOff;
-                }
-            }
-            catch (Exception ex)
-            {
-                Common.ShowErrorMessageBox(ex);
-            }
-            throw new Exception("Failed to find TextBox from MultiPanel Knob : " + knob);
+            return (knob, isTurnedOn) switch {
+                (MultiPanelPZ70Knobs.LCD_WHEEL_DEC, true) => TextBoxLcdKnobDecrease,
+                (MultiPanelPZ70Knobs.LCD_WHEEL_INC, true) => TextBoxLcdKnobIncrease,
+                (MultiPanelPZ70Knobs.AUTO_THROTTLE, true) => TextBoxAutoThrottleOn,
+                (MultiPanelPZ70Knobs.AUTO_THROTTLE, false) => TextBoxAutoThrottleOff,
+                (MultiPanelPZ70Knobs.FLAPS_LEVER_UP, true) => TextBoxFlapsUp,
+                (MultiPanelPZ70Knobs.FLAPS_LEVER_DOWN, true) => TextBoxFlapsDown,
+                (MultiPanelPZ70Knobs.PITCH_TRIM_WHEEL_UP, true) => TextBoxPitchTrimUp,
+                (MultiPanelPZ70Knobs.PITCH_TRIM_WHEEL_DOWN, true) => TextBoxPitchTrimUp,
+                (MultiPanelPZ70Knobs.AP_BUTTON, true) => TextBoxApButtonOn,
+                (MultiPanelPZ70Knobs.AP_BUTTON, false) => TextBoxApButtonOff,
+                (MultiPanelPZ70Knobs.HDG_BUTTON, true) => TextBoxHdgButtonOn,
+                (MultiPanelPZ70Knobs.HDG_BUTTON, false) => TextBoxHdgButtonOff,
+                (MultiPanelPZ70Knobs.NAV_BUTTON, true) => TextBoxNavButtonOn,
+                (MultiPanelPZ70Knobs.NAV_BUTTON, false) => TextBoxNavButtonOff,
+                (MultiPanelPZ70Knobs.IAS_BUTTON, true) => TextBoxIasButtonOn,
+                (MultiPanelPZ70Knobs.IAS_BUTTON, false) => TextBoxIasButtonOff,
+                (MultiPanelPZ70Knobs.ALT_BUTTON, true) => TextBoxAltButtonOn,
+                (MultiPanelPZ70Knobs.ALT_BUTTON, false) => TextBoxAltButtonOff,
+                (MultiPanelPZ70Knobs.VS_BUTTON, true) => TextBoxVsButtonOn,
+                (MultiPanelPZ70Knobs.VS_BUTTON, false) => TextBoxVsButtonOff,
+                (MultiPanelPZ70Knobs.APR_BUTTON, true) => TextBoxAprButtonOn,
+                (MultiPanelPZ70Knobs.APR_BUTTON, false) => TextBoxAprButtonOff,
+                (MultiPanelPZ70Knobs.REV_BUTTON, true) => TextBoxRevButtonOn,
+                (MultiPanelPZ70Knobs.REV_BUTTON, false) => TextBoxRevButtonOff,
+                _ => throw new Exception($"Failed to find TextBox for MultiPanel Knob: {knob} & value {isTurnedOn}")
+            };
         }
 
         private void ButtonIdentify_OnClick(object sender, RoutedEventArgs e)

--- a/Source/DCSFlightpanels/PanelUserControls/SwitchPanelPZ55UserControl.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/SwitchPanelPZ55UserControl.xaml.cs
@@ -1062,152 +1062,47 @@
 
 
 
-        public TextBox GetTextBox(object general_key, bool whenTurnedOn)
+        public TextBox GetTextBox(object general_key, bool isTurnedOn)
         {
-            var key = (SwitchPanelPZ55Keys) general_key;
-            try
+            var key = (SwitchPanelPZ55Keys)general_key;
+            return (key, isTurnedOn) switch
             {
-                if (key == SwitchPanelPZ55Keys.KNOB_ENGINE_OFF && whenTurnedOn)
-                {
-                    return TextBoxKnobOff;
-                }
-                if (key == SwitchPanelPZ55Keys.KNOB_ENGINE_RIGHT && whenTurnedOn)
-                {
-                    return TextBoxKnobR;
-                }
-                if (key == SwitchPanelPZ55Keys.KNOB_ENGINE_LEFT && whenTurnedOn)
-                {
-                    return TextBoxKnobL;
-                }
-                if (key == SwitchPanelPZ55Keys.KNOB_ENGINE_BOTH && whenTurnedOn)
-                {
-                    return TextBoxKnobAll;
-                }
-                if (key == SwitchPanelPZ55Keys.KNOB_ENGINE_START && whenTurnedOn)
-                {
-                    return TextBoxKnobStart;
-                }
-                if (key == SwitchPanelPZ55Keys.SWITCHKEY_CLOSE_COWL && !whenTurnedOn)
-                {
-                    return TextBoxCowlClose;
-                }
-                if (key == SwitchPanelPZ55Keys.SWITCHKEY_CLOSE_COWL && whenTurnedOn)
-                {
-                    return TextBoxCowlOpen;
-                }
-                if (key == SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_PANEL && !whenTurnedOn)
-                {
-                    return TextBoxPanelOff;
-                }
-                if (key == SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_PANEL && whenTurnedOn)
-                {
-                    return TextBoxPanelOn;
-                }
-                if (key == SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_BEACON && !whenTurnedOn)
-                {
-                    return TextBoxBeaconOff;
-                }
-                if (key == SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_BEACON && whenTurnedOn)
-                {
-                    return TextBoxBeaconOn;
-                }
-                if (key == SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_NAV && !whenTurnedOn)
-                {
-                    return TextBoxNavOff;
-                }
-                if (key == SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_NAV && whenTurnedOn)
-                {
-                    return TextBoxNavOn;
-                }
-                if (key == SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_STROBE && !whenTurnedOn)
-                {
-                    return TextBoxStrobeOff;
-                }
-                if (key == SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_STROBE && whenTurnedOn)
-                {
-                    return TextBoxStrobeOn;
-                }
-                if (key == SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_TAXI && !whenTurnedOn)
-                {
-                    return TextBoxTaxiOff;
-                }
-                if (key == SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_TAXI && whenTurnedOn)
-                {
-                    return TextBoxTaxiOn;
-                }
-                if (key == SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_LANDING && !whenTurnedOn)
-                {
-                    return TextBoxLandingOff;
-                }
-                if (key == SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_LANDING && whenTurnedOn)
-                {
-                    return TextBoxLandingOn;
-                }
-                if (key == SwitchPanelPZ55Keys.SWITCHKEY_MASTER_BAT && !whenTurnedOn)
-                {
-                    return TextBoxMasterBatOff;
-                }
-                if (key == SwitchPanelPZ55Keys.SWITCHKEY_MASTER_BAT && whenTurnedOn)
-                {
-                    return TextBoxMasterBatOn;
-                }
-                if (key == SwitchPanelPZ55Keys.SWITCHKEY_MASTER_ALT && !whenTurnedOn)
-                {
-                    return TextBoxMasterAltOff;
-                }
-                if (key == SwitchPanelPZ55Keys.SWITCHKEY_MASTER_ALT && whenTurnedOn)
-                {
-                    return TextBoxMasterAltOn;
-                }
-                if (key == SwitchPanelPZ55Keys.SWITCHKEY_AVIONICS_MASTER && !whenTurnedOn)
-                {
-                    return TextBoxAvionicsMasterOff;
-                }
-                if (key == SwitchPanelPZ55Keys.SWITCHKEY_AVIONICS_MASTER && whenTurnedOn)
-                {
-                    return TextBoxAvionicsMasterOn;
-                }
-                if (key == SwitchPanelPZ55Keys.SWITCHKEY_FUEL_PUMP && !whenTurnedOn)
-                {
-                    return TextBoxFuelPumpOff;
-                }
-                if (key == SwitchPanelPZ55Keys.SWITCHKEY_FUEL_PUMP && whenTurnedOn)
-                {
-                    return TextBoxFuelPumpOn;
-                }
-                if (key == SwitchPanelPZ55Keys.SWITCHKEY_DE_ICE && !whenTurnedOn)
-                {
-                    return TextBoxDeIceOff;
-                }
-                if (key == SwitchPanelPZ55Keys.SWITCHKEY_DE_ICE && whenTurnedOn)
-                {
-                    return TextBoxDeIceOn;
-                }
-                if (key == SwitchPanelPZ55Keys.SWITCHKEY_PITOT_HEAT && !whenTurnedOn)
-                {
-                    return TextBoxPitotHeatOff;
-                }
-                if (key == SwitchPanelPZ55Keys.SWITCHKEY_PITOT_HEAT && whenTurnedOn)
-                {
-                    return TextBoxPitotHeatOn;
-                }
-                if (key == SwitchPanelPZ55Keys.LEVER_GEAR_UP && whenTurnedOn)
-                {
-                    return TextBoxGearUp;
-                }
-                if (key == SwitchPanelPZ55Keys.LEVER_GEAR_DOWN && whenTurnedOn)
-                {
-                    return TextBoxGearDown;
-                }
-            }
-            catch (Exception ex)
-            {
-                Common.ShowErrorMessageBox(ex);
-            }
-            throw new Exception("Failed to find text box based on key (SwitchPanelPZ55UserControl)" + key);
+                (SwitchPanelPZ55Keys.KNOB_ENGINE_OFF, true) => TextBoxKnobOff,
+                (SwitchPanelPZ55Keys.KNOB_ENGINE_RIGHT, true) => TextBoxKnobR,
+                (SwitchPanelPZ55Keys.KNOB_ENGINE_LEFT, true) => TextBoxKnobL,
+                (SwitchPanelPZ55Keys.KNOB_ENGINE_BOTH, true) => TextBoxKnobAll,
+                (SwitchPanelPZ55Keys.KNOB_ENGINE_START, true) => TextBoxKnobStart,
+                (SwitchPanelPZ55Keys.SWITCHKEY_CLOSE_COWL, true) => TextBoxCowlOpen,
+                (SwitchPanelPZ55Keys.SWITCHKEY_CLOSE_COWL, false) => TextBoxCowlClose,
+                (SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_PANEL, true) => TextBoxPanelOn,
+                (SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_PANEL, false) => TextBoxPanelOff,
+                (SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_BEACON, true) => TextBoxBeaconOn,
+                (SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_BEACON, false) => TextBoxPanelOff,
+                (SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_NAV, true) => TextBoxNavOn,
+                (SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_NAV, false) => TextBoxNavOff,
+                (SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_STROBE, true) => TextBoxStrobeOn,
+                (SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_STROBE, false) => TextBoxStrobeOff,
+                (SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_TAXI, true) => TextBoxTaxiOn,
+                (SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_TAXI, false) => TextBoxTaxiOff,
+                (SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_LANDING, true) => TextBoxLandingOn,
+                (SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_LANDING, false) => TextBoxLandingOff,
+                (SwitchPanelPZ55Keys.SWITCHKEY_MASTER_BAT, true) => TextBoxMasterBatOn,
+                (SwitchPanelPZ55Keys.SWITCHKEY_MASTER_BAT, false) => TextBoxMasterBatOff,
+                (SwitchPanelPZ55Keys.SWITCHKEY_MASTER_ALT, true) => TextBoxMasterBatOn,
+                (SwitchPanelPZ55Keys.SWITCHKEY_MASTER_ALT, false) => TextBoxMasterAltOff,
+                (SwitchPanelPZ55Keys.SWITCHKEY_AVIONICS_MASTER, true) => TextBoxAvionicsMasterOn,
+                (SwitchPanelPZ55Keys.SWITCHKEY_AVIONICS_MASTER, false) => TextBoxAvionicsMasterOff,
+                (SwitchPanelPZ55Keys.SWITCHKEY_FUEL_PUMP, true) => TextBoxFuelPumpOn,
+                (SwitchPanelPZ55Keys.SWITCHKEY_FUEL_PUMP, false) => TextBoxFuelPumpOff,
+                (SwitchPanelPZ55Keys.SWITCHKEY_DE_ICE, true) => TextBoxDeIceOn,
+                (SwitchPanelPZ55Keys.SWITCHKEY_DE_ICE, false) => TextBoxDeIceOff,
+                (SwitchPanelPZ55Keys.SWITCHKEY_PITOT_HEAT, true) => TextBoxPitotHeatOn,
+                (SwitchPanelPZ55Keys.SWITCHKEY_PITOT_HEAT, false) => TextBoxPitotHeatOff,
+                (SwitchPanelPZ55Keys.LEVER_GEAR_UP, true) => TextBoxGearUp,
+                (SwitchPanelPZ55Keys.LEVER_GEAR_DOWN, false) => TextBoxGearDown,
+                _ => throw new Exception($"Failed to find text box based on key (SwitchPanelPZ55UserControl) {key} and value {isTurnedOn}")
+            };
         }
-
-
 
         private void ButtonDEV_OnClick(object sender, RoutedEventArgs e)
         {

--- a/Source/DCSFlightpanels/PanelUserControls/SwitchPanelPZ55UserControl.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/SwitchPanelPZ55UserControl.xaml.cs
@@ -918,149 +918,44 @@
 
         public PanelSwitchOnOff GetSwitch(TextBox textBox)
         {
-            try
+            return textBox switch
             {
-                if (textBox.Equals(TextBoxKnobOff))
-                {
-                    return new PZ55SwitchOnOff(SwitchPanelPZ55Keys.KNOB_ENGINE_OFF, true);
-                }
-                if (textBox.Equals(TextBoxKnobR))
-                {
-                    return new PZ55SwitchOnOff(SwitchPanelPZ55Keys.KNOB_ENGINE_RIGHT, true);
-                }
-                if (textBox.Equals(TextBoxKnobL))
-                {
-                    return new PZ55SwitchOnOff(SwitchPanelPZ55Keys.KNOB_ENGINE_LEFT, true);
-                }
-                if (textBox.Equals(TextBoxKnobAll))
-                {
-                    return new PZ55SwitchOnOff(SwitchPanelPZ55Keys.KNOB_ENGINE_BOTH, true);
-                }
-                if (textBox.Equals(TextBoxKnobStart))
-                {
-                    return new PZ55SwitchOnOff(SwitchPanelPZ55Keys.KNOB_ENGINE_START, true);
-                }
-                if (textBox.Equals(TextBoxCowlClose))
-                {
-                    return new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_CLOSE_COWL, false);
-                }
-                if (textBox.Equals(TextBoxCowlOpen))
-                {
-                    return new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_CLOSE_COWL, true);
-                }
-                if (textBox.Equals(TextBoxPanelOff))
-                {
-                    return new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_PANEL, false);
-                }
-                if (textBox.Equals(TextBoxPanelOn))
-                {
-                    return new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_PANEL, true);
-                }
-                if (textBox.Equals(TextBoxBeaconOff))
-                {
-                    return new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_BEACON, false);
-                }
-                if (textBox.Equals(TextBoxBeaconOn))
-                {
-                    return new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_BEACON, true);
-                }
-                if (textBox.Equals(TextBoxNavOff))
-                {
-                    return new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_NAV, false);
-                }
-                if (textBox.Equals(TextBoxNavOn))
-                {
-                    return new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_NAV, true);
-                }
-                if (textBox.Equals(TextBoxStrobeOff))
-                {
-                    return new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_STROBE, false);
-                }
-                if (textBox.Equals(TextBoxStrobeOn))
-                {
-                    return new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_STROBE, true);
-                }
-                if (textBox.Equals(TextBoxTaxiOff))
-                {
-                    return new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_TAXI, false);
-                }
-                if (textBox.Equals(TextBoxTaxiOn))
-                {
-                    return new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_TAXI, true);
-                }
-                if (textBox.Equals(TextBoxLandingOff))
-                {
-                    return new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_LANDING, false);
-                }
-                if (textBox.Equals(TextBoxLandingOn))
-                {
-                    return new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_LANDING, true);
-                }
-                if (textBox.Equals(TextBoxMasterBatOff))
-                {
-                    return new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_MASTER_BAT, false);
-                }
-                if (textBox.Equals(TextBoxMasterBatOn))
-                {
-                    return new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_MASTER_BAT, true);
-                }
-                if (textBox.Equals(TextBoxMasterAltOff))
-                {
-                    return new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_MASTER_ALT, false);
-                }
-                if (textBox.Equals(TextBoxMasterAltOn))
-                {
-                    return new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_MASTER_ALT, true);
-                }
-                if (textBox.Equals(TextBoxAvionicsMasterOff))
-                {
-                    return new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_AVIONICS_MASTER, false);
-                }
-                if (textBox.Equals(TextBoxAvionicsMasterOn))
-                {
-                    return new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_AVIONICS_MASTER, true);
-                }
-                if (textBox.Equals(TextBoxFuelPumpOff))
-                {
-                    return new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_FUEL_PUMP, false);
-                }
-                if (textBox.Equals(TextBoxFuelPumpOn))
-                {
-                    return new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_FUEL_PUMP, true);
-                }
-                if (textBox.Equals(TextBoxDeIceOff))
-                {
-                    return new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_DE_ICE, false);
-                }
-                if (textBox.Equals(TextBoxDeIceOn))
-                {
-                    return new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_DE_ICE, true);
-                }
-                if (textBox.Equals(TextBoxPitotHeatOff))
-                {
-                    return new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_PITOT_HEAT, false);
-                }
-                if (textBox.Equals(TextBoxPitotHeatOn))
-                {
-                    return new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_PITOT_HEAT, true);
-                }
-                if (textBox.Equals(TextBoxGearUp))
-                {
-                    return new PZ55SwitchOnOff(SwitchPanelPZ55Keys.LEVER_GEAR_UP, true);
-                }
-                if (textBox.Equals(TextBoxGearDown))
-                {
-                    return new PZ55SwitchOnOff(SwitchPanelPZ55Keys.LEVER_GEAR_DOWN, true);
-                }
-            }
-            catch (Exception ex)
-            {
-                Common.ShowErrorMessageBox(ex);
-            }
-            throw new Exception("Failed to find key based on text box (SwitchPanelPZ55UserControl) : " + textBox.Name);
+                TextBox t when t.Equals(TextBoxKnobOff) => new PZ55SwitchOnOff(SwitchPanelPZ55Keys.KNOB_ENGINE_OFF, true),
+                TextBox t when t.Equals(TextBoxKnobR) => new PZ55SwitchOnOff(SwitchPanelPZ55Keys.KNOB_ENGINE_RIGHT, true),
+                TextBox t when t.Equals(TextBoxKnobL) => new PZ55SwitchOnOff(SwitchPanelPZ55Keys.KNOB_ENGINE_LEFT, true),
+                TextBox t when t.Equals(TextBoxKnobAll) => new PZ55SwitchOnOff(SwitchPanelPZ55Keys.KNOB_ENGINE_BOTH, true),
+                TextBox t when t.Equals(TextBoxKnobStart) => new PZ55SwitchOnOff(SwitchPanelPZ55Keys.KNOB_ENGINE_START, true),
+                TextBox t when t.Equals(TextBoxCowlOpen) => new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_CLOSE_COWL, true),
+                TextBox t when t.Equals(TextBoxCowlClose) => new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_CLOSE_COWL, false),
+                TextBox t when t.Equals(TextBoxPanelOn) => new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_PANEL, true),
+                TextBox t when t.Equals(TextBoxPanelOff) => new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_PANEL, false),
+                TextBox t when t.Equals(TextBoxBeaconOn) => new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_BEACON, true),
+                TextBox t when t.Equals(TextBoxBeaconOff) => new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_BEACON, false),
+                TextBox t when t.Equals(TextBoxNavOn) => new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_NAV, true),
+                TextBox t when t.Equals(TextBoxNavOff) => new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_NAV, false),
+                TextBox t when t.Equals(TextBoxStrobeOn) => new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_STROBE, true),
+                TextBox t when t.Equals(TextBoxStrobeOff) => new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_STROBE, false),
+                TextBox t when t.Equals(TextBoxTaxiOn) => new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_TAXI, true),
+                TextBox t when t.Equals(TextBoxTaxiOff) => new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_TAXI, false),
+                TextBox t when t.Equals(TextBoxLandingOn) => new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_LANDING, true),
+                TextBox t when t.Equals(TextBoxLandingOff) => new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_LANDING, false),
+                TextBox t when t.Equals(TextBoxMasterBatOn) => new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_MASTER_BAT, true),
+                TextBox t when t.Equals(TextBoxMasterBatOff) => new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_MASTER_BAT, false),
+                TextBox t when t.Equals(TextBoxMasterAltOn) => new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_MASTER_ALT, true),
+                TextBox t when t.Equals(TextBoxMasterAltOff) => new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_MASTER_ALT, false),
+                TextBox t when t.Equals(TextBoxAvionicsMasterOn) => new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_AVIONICS_MASTER, true),
+                TextBox t when t.Equals(TextBoxAvionicsMasterOff) => new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_AVIONICS_MASTER, false),
+                TextBox t when t.Equals(TextBoxFuelPumpOn) => new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_FUEL_PUMP, true),
+                TextBox t when t.Equals(TextBoxFuelPumpOff) => new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_FUEL_PUMP, false),
+                TextBox t when t.Equals(TextBoxDeIceOn) => new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_DE_ICE, true),
+                TextBox t when t.Equals(TextBoxDeIceOff) => new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_DE_ICE, false),
+                TextBox t when t.Equals(TextBoxPitotHeatOn) => new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_PITOT_HEAT, true),
+                TextBox t when t.Equals(TextBoxPitotHeatOff) => new PZ55SwitchOnOff(SwitchPanelPZ55Keys.SWITCHKEY_PITOT_HEAT, false),
+                TextBox t when t.Equals(TextBoxGearUp) => new PZ55SwitchOnOff(SwitchPanelPZ55Keys.LEVER_GEAR_UP, true),
+                TextBox t when t.Equals(TextBoxGearDown) => new PZ55SwitchOnOff(SwitchPanelPZ55Keys.LEVER_GEAR_DOWN, true),
+                _ => throw new Exception($"Failed to find key based on text box (SwitchPanelPZ55UserControl) {textBox.Name}")
+            };
         }
-
-
 
         public TextBox GetTextBox(object general_key, bool isTurnedOn)
         {
@@ -1077,7 +972,7 @@
                 (SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_PANEL, true) => TextBoxPanelOn,
                 (SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_PANEL, false) => TextBoxPanelOff,
                 (SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_BEACON, true) => TextBoxBeaconOn,
-                (SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_BEACON, false) => TextBoxPanelOff,
+                (SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_BEACON, false) => TextBoxBeaconOff,
                 (SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_NAV, true) => TextBoxNavOn,
                 (SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_NAV, false) => TextBoxNavOff,
                 (SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_STROBE, true) => TextBoxStrobeOn,
@@ -1088,7 +983,7 @@
                 (SwitchPanelPZ55Keys.SWITCHKEY_LIGHTS_LANDING, false) => TextBoxLandingOff,
                 (SwitchPanelPZ55Keys.SWITCHKEY_MASTER_BAT, true) => TextBoxMasterBatOn,
                 (SwitchPanelPZ55Keys.SWITCHKEY_MASTER_BAT, false) => TextBoxMasterBatOff,
-                (SwitchPanelPZ55Keys.SWITCHKEY_MASTER_ALT, true) => TextBoxMasterBatOn,
+                (SwitchPanelPZ55Keys.SWITCHKEY_MASTER_ALT, true) => TextBoxMasterAltOn,
                 (SwitchPanelPZ55Keys.SWITCHKEY_MASTER_ALT, false) => TextBoxMasterAltOff,
                 (SwitchPanelPZ55Keys.SWITCHKEY_AVIONICS_MASTER, true) => TextBoxAvionicsMasterOn,
                 (SwitchPanelPZ55Keys.SWITCHKEY_AVIONICS_MASTER, false) => TextBoxAvionicsMasterOff,
@@ -1099,7 +994,7 @@
                 (SwitchPanelPZ55Keys.SWITCHKEY_PITOT_HEAT, true) => TextBoxPitotHeatOn,
                 (SwitchPanelPZ55Keys.SWITCHKEY_PITOT_HEAT, false) => TextBoxPitotHeatOff,
                 (SwitchPanelPZ55Keys.LEVER_GEAR_UP, true) => TextBoxGearUp,
-                (SwitchPanelPZ55Keys.LEVER_GEAR_DOWN, false) => TextBoxGearDown,
+                (SwitchPanelPZ55Keys.LEVER_GEAR_DOWN, true) => TextBoxGearDown,
                 _ => throw new Exception($"Failed to find text box based on key (SwitchPanelPZ55UserControl) {key} and value {isTurnedOn}")
             };
         }


### PR DESCRIPTION
Improves the following:
- on `ReceiveDataUdp` from DCSBios, I remarked that there was a lot of system. SocketException on timeout thrown. I added a check to see if there is any data available prior to `.Receive`. This seems to work well.

- Fix a "bug" introduced in commit 284ae0c4. The multi panel only showed the bindings values on the textboxes on the `CRS` knob position. I saw that it was because we made a `textbox.bindig..xx = null;` but I can't figure out why it reacts like that, the changes with the `= null;` seemed legit ?!

- Added Pattern matching on some long `if()` functions in Pz70 & Pz55 to reduce code size and improve readability.