### PR TITLE
[DCSBIOS] Code refacto & unit tests

### DIFF
--- a/Source/DCS-BIOS/DCS-BIOS.csproj
+++ b/Source/DCS-BIOS/DCS-BIOS.csproj
@@ -3,6 +3,7 @@
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <LangVersion>9.0</LangVersion>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{6EF4492F-D4B4-42BC-B209-98783098DB22}</ProjectGuid>
     <OutputType>Library</OutputType>

--- a/Source/DCS-BIOS/DCSBIOS.cs
+++ b/Source/DCS-BIOS/DCSBIOS.cs
@@ -37,59 +37,63 @@ namespace DCS_BIOS
         private UdpClient _udpReceiveClient;
         private UdpClient _udpSendClient;
         private Thread _dcsbiosListeningThread;
-        private string _dcsbiosReceiveFromIPUdp = "239.255.50.10";
-        private string _dcsbiosSendToIPUdp = "127.0.0.1";
-        private int _dcsbiosReceivePortUdp = 5010;
-        private int _dcsbiosSendPortUdp = 7778;
+        public string ReceiveFromIpUdp { get; set; } = "239.255.50.10";
+        public string SendToIpUdp { get; set; } = "127.0.0.1";
+        public int ReceivePortUdp { get; set; } = 5010;
+        public int SendPortUdp { get; set; } = 7778;
         private IPEndPoint _ipEndPointReceiverUdp;
         private readonly IPEndPoint _ipEndPointSenderUdp;
-        private readonly string _receivedDataUdp = null;
+        public string ReceivedDataUdp { get; } = null;
         /************************
         *************************
         ************************/
 
-        private readonly object _lockExceptionObject = new object();
+        private readonly object _lockExceptionObject = new();
         private Exception _lastException;
         private DCSBIOSProtocolParser _dcsProtocolParser;
         private readonly DcsBiosNotificationMode _dcsBiosNotificationMode;
-        private readonly object _lockObjectForSendingData = new object();
+        private readonly object _lockObjectForSendingData = new();
         private volatile bool _isRunning;
+        public bool IsRunning
+        {
+            get => _isRunning;
+        }
 
         public DCSBIOS(string ipFromUdp, string ipToUdp, int portFromUdp, int portToUdp, DcsBiosNotificationMode dcsNoficationMode)
         {
 
             if (!string.IsNullOrEmpty(ipFromUdp) && IPAddress.TryParse(ipFromUdp, out _))
             {
-                _dcsbiosReceiveFromIPUdp = ipFromUdp;
+                ReceiveFromIpUdp = ipFromUdp;
             }
 
             if (!string.IsNullOrEmpty(ipToUdp) && IPAddress.TryParse(ipToUdp, out _))
             {
-                _dcsbiosSendToIPUdp = ipToUdp;
+                SendToIpUdp = ipToUdp;
             }
 
             if (portFromUdp > 0)
             {
-                _dcsbiosReceivePortUdp = portFromUdp;
+                ReceivePortUdp = portFromUdp;
             }
 
             if (portToUdp > 0)
             {
-                _dcsbiosSendPortUdp = portToUdp;
+                SendPortUdp = portToUdp;
             }
 
             _dcsBiosNotificationMode = dcsNoficationMode;
 
             _dcsProtocolParser = DCSBIOSProtocolParser.GetParser();
 
-            _ipEndPointReceiverUdp = new IPEndPoint(IPAddress.Any, ReceivePort);
-            _ipEndPointSenderUdp = new IPEndPoint(IPAddress.Parse(SendToIp), SendPort);
+            _ipEndPointReceiverUdp = new IPEndPoint(IPAddress.Any, ReceivePortUdp);
+            _ipEndPointSenderUdp = new IPEndPoint(IPAddress.Parse(SendToIpUdp), SendPortUdp);
 
             _udpReceiveClient = new UdpClient();
             _udpReceiveClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
             _udpReceiveClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReceiveTimeout, 200);
             _udpReceiveClient.Client.Bind(_ipEndPointReceiverUdp);
-            _udpReceiveClient.JoinMulticastGroup(IPAddress.Parse(ReceiveFromIp));
+            _udpReceiveClient.JoinMulticastGroup(IPAddress.Parse(ReceiveFromIpUdp));
 
             _udpSendClient = new UdpClient();
             _udpSendClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
@@ -201,11 +205,6 @@ namespace DCS_BIOS
             }
         }
 
-        public bool IsRunning
-        {
-            get => _isRunning;
-        }
-
         public static DCSBIOS GetInstance()
         {
             return _dcsBIOSInstance;
@@ -296,35 +295,6 @@ namespace DCS_BIOS
             {
                 return _lastException != null;
             }
-        }
-
-        public string ReceivedData
-        {
-            get { return _receivedDataUdp; }
-        }
-
-        public int SendPort
-        {
-            get { return _dcsbiosSendPortUdp; }
-            set { _dcsbiosSendPortUdp = value; }
-        }
-
-        public int ReceivePort
-        {
-            get { return _dcsbiosReceivePortUdp; }
-            set { _dcsbiosReceivePortUdp = value; }
-        }
-
-        public string SendToIp
-        {
-            get { return _dcsbiosSendToIPUdp; }
-            set { _dcsbiosSendToIPUdp = value; }
-        }
-
-        public string ReceiveFromIp
-        {
-            get { return _dcsbiosReceiveFromIPUdp; }
-            set { _dcsbiosReceiveFromIPUdp = value; }
         }
     }
 }

--- a/Source/DCS-BIOS/DCSBIOS.cs
+++ b/Source/DCS-BIOS/DCSBIOS.cs
@@ -10,6 +10,7 @@ namespace DCS_BIOS
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net;
     using System.Net.Sockets;
     using System.Text;
@@ -21,7 +22,6 @@ namespace DCS_BIOS
         AddressValue = 2,
         ByteArray = 4
     }
-
 
     public class DCSBIOS : IDisposable
     {
@@ -216,14 +216,11 @@ namespace DCS_BIOS
             return _dcsBIOSInstance.SendDataFunction(stringData);
         }
 
-        public static void Send(string[] stringData)
+        public static void Send(string[] stringArray)
         {
-            if (stringData != null)
+            if (stringArray != null)
             {
-                foreach (var s in stringData)
-                {
-                    _dcsBIOSInstance.SendDataFunction(s);
-                }
+                Send(stringArray.ToList());
             }
         }
 
@@ -231,10 +228,7 @@ namespace DCS_BIOS
         {
             if (stringList != null)
             {
-                foreach (var s in stringList)
-                {
-                    _dcsBIOSInstance.SendDataFunction(s);
-                }
+                stringList.ForEach(s => _dcsBIOSInstance.SendDataFunction(s));
             }
         }
 

--- a/Source/DCS-BIOS/DCSBIOSControlLocator.cs
+++ b/Source/DCS-BIOS/DCSBIOSControlLocator.cs
@@ -16,8 +16,8 @@ namespace DCS_BIOS
     {
         internal static Logger logger = LogManager.GetCurrentClassLogger();
 
-        private static readonly List<DCSBIOSControl> DCSBIOSControls = new List<DCSBIOSControl>();
-        private static readonly object LockObject = new object();
+        private static readonly List<DCSBIOSControl> DCSBIOSControls = new();
+        private static readonly object LockObject = new();
         private static DCSFPProfile _dcsfpProfile;
         private static string _jsonDirectory;
         public static readonly string DCSBIOSNotFoundErrorMessage = "Error loading DCS-BIOS. Check that the DCS-BIOS location setting points to the JSON directory.";
@@ -58,14 +58,14 @@ namespace DCS_BIOS
                     PrintDuplicateControlIdentifiers(_dcsbiosControls, true);*/
                     if (!DCSBIOSControls.Exists(controlObject => controlObject.Identifier.Equals(controlId)))
                     {
-                        throw new Exception("Error, control " + controlId + " does not exist. (" + Profile.Description + ")");
+                        throw new Exception($"Error, control {controlId} does not exist. ({Profile.Description})");
                     }
 
                     return DCSBIOSControls.Single(controlObject => controlObject.Identifier.Equals(controlId));
                 }
                 catch (InvalidOperationException ioe)
                 {
-                    throw new Exception("Check DCS-BIOS version. Failed to find control " + controlId + " for airframe " + Profile.Description + " (" + Profile.JSONFilename + ". Did you switch airframe type for the profile and have existing control(s) for the previous type saved?" + Environment.NewLine + ioe.Message);
+                    throw new Exception($"Check DCS-BIOS version. Failed to find control {controlId} for airframe {Profile.Description} ({Profile.JSONFilename}). Did you switch airframe type for the profile and have existing control(s) for the previous type saved?{Environment.NewLine}{ioe.Message}");
                 }
             }
         }
@@ -81,14 +81,14 @@ namespace DCS_BIOS
 
                 try
                 {
-                    var control = GetControl(controlId);
+                    DCSBIOSControl control = GetControl(controlId);
                     var dcsBIOSOutput = new DCSBIOSOutput();
                     dcsBIOSOutput.Consume(control);
                     return dcsBIOSOutput;
                 }
                 catch (InvalidOperationException ioe)
                 {
-                    throw new Exception("Check DCS-BIOS version. Failed to create DCSBIOSOutput based on control " + controlId + " for profile " + Profile.JSONFilename + Environment.NewLine + ioe.Message);
+                    throw new Exception($"Check DCS-BIOS version. Failed to create DCSBIOSOutput based on control {controlId} for profile {Profile.JSONFilename}{Environment.NewLine}{ioe.Message}");
                 }
             }
         }
@@ -112,7 +112,7 @@ namespace DCS_BIOS
                     }
                     catch (Exception ex)
                     {
-                        throw new Exception("Failed to find DCS-BIOS files. -> " + Environment.NewLine + ex.Message);
+                        throw new Exception($"Failed to find DCS-BIOS files. -> {Environment.NewLine}{ex.Message}");
                     }
 
                     foreach (var file in files)
@@ -127,7 +127,7 @@ namespace DCS_BIOS
             }
             catch (Exception ex)
             {
-                throw new Exception(DCSBIOSNotFoundErrorMessage + " ==>[" + _jsonDirectory + "]<==" + Environment.NewLine + ex.Message + Environment.NewLine + ex.StackTrace);
+                throw new Exception($"{DCSBIOSNotFoundErrorMessage} ==>[{_jsonDirectory}]<=={Environment.NewLine}{ex.Message}{Environment.NewLine}{ex.StackTrace}");
             }
         }
 
@@ -204,8 +204,8 @@ namespace DCS_BIOS
 
         private static void PrintDuplicateControlIdentifiers(List<DCSBIOSControl> dcsbiosControls, bool printAll = false)
         {
-            var result = new List<string>();
-            var dupes = new List<string>();
+            List<string> result = new();
+            List<string> dupes = new();
             foreach (var dcsbiosControl in dcsbiosControls)
             {
                 if (printAll)
@@ -214,7 +214,7 @@ namespace DCS_BIOS
                 }
 
                 // Debug.Print(dcsbiosControl.identifier);
-                var found = false;
+                bool found = false;
                 foreach (var str in result)
                 {
                     if (str.Trim() == dcsbiosControl.Identifier.Trim())
@@ -236,7 +236,7 @@ namespace DCS_BIOS
 
             if (dupes.Count > 0)
             {
-                var message = new StringBuilder();
+                StringBuilder message = new();
                 message.AppendLine($"Below is a list of duplicate identifiers found in the {Profile.JSONFilename} profile (DCS-BIOS)");
                 message.AppendLine($"The identifier must be unique, please correct the profile {Profile.JSONFilename} in the DCS-BIOS lib folder");
                 message.AppendLine("---------------------------------------------");
@@ -264,7 +264,7 @@ namespace DCS_BIOS
             }
             catch (Exception ex)
             {
-                throw new Exception(DCSBIOSNotFoundErrorMessage + " ==>[" + jsonDirectory + "]<==" + Environment.NewLine + ex.Message + Environment.NewLine + ex.StackTrace);
+                throw new Exception($"{DCSBIOSNotFoundErrorMessage} ==>[{jsonDirectory}]<=={Environment.NewLine}{ex.Message}{Environment.NewLine}{ex.StackTrace}");
             }
         }
 
@@ -296,7 +296,7 @@ namespace DCS_BIOS
             }
             catch (Exception ex)
             {
-                throw new Exception(DCSBIOSNotFoundErrorMessage + " ==>[" + jsonDirectory + "]<==" + Environment.NewLine + ex.Message + Environment.NewLine + ex.StackTrace);
+                throw new Exception($"{DCSBIOSNotFoundErrorMessage} ==>[{jsonDirectory}]<=={Environment.NewLine}{ex.Message}{Environment.NewLine}{ex.StackTrace}");
             }
         }
 
@@ -347,8 +347,7 @@ namespace DCS_BIOS
             }
 
             LoadControls();
-            var result = DCSBIOSControls.Where(controlObject => (controlObject.Outputs.Count > 0) && controlObject.Outputs[0].OutputDataType == DCSBiosOutputType.StringType);
-            return result;
+            return DCSBIOSControls.Where(controlObject => (controlObject.Outputs.Count > 0) && controlObject.Outputs[0].OutputDataType == DCSBiosOutputType.StringType);
         }
 
         public static IEnumerable<DCSBIOSControl> GetIntegerOutputControls()

--- a/Source/DCS-BIOS/DCSBIOSInput.cs
+++ b/Source/DCS-BIOS/DCSBIOSInput.cs
@@ -171,14 +171,7 @@ namespace DCS_BIOS
             // AAP_EGIPWR|ACTION|TOGGLE
             var entries = value.Split(new[] { "|" }, StringSplitOptions.RemoveEmptyEntries);
             _controlId = entries[0];
-            if (entries.Length == 4)
-            {
-                Delay = int.Parse(entries[3]);
-            }
-            else
-            {
-                Delay = 0;
-            }
+            Delay = entries.Length == 4 ? int.Parse(entries[3]) : 0;
 
             var dcsBIOSControl = DCSBIOSControlLocator.GetControl(_controlId);
             Consume(dcsBIOSControl);
@@ -193,19 +186,10 @@ namespace DCS_BIOS
                             {
                                 dcsbiosInputObject.SpecifiedFixedStepArgument = (DCSBIOSFixedStepInput)Enum.Parse(typeof(DCSBIOSFixedStepInput), entries[2]);
                                 SelectedDCSBIOSInput = dcsbiosInputObject;
-                                if (entries.Length == 4)
-                                {
-                                    SelectedDCSBIOSInput.Delay = int.Parse(entries[3]);
-                                }
-                                else
-                                {
-                                    SelectedDCSBIOSInput.Delay = 0;
-                                }
-
+                                SelectedDCSBIOSInput.Delay = entries.Length == 4 ? int.Parse(entries[3]) : 0;
                                 break;
                             }
                         }
-
                         break;
                     }
 
@@ -217,19 +201,10 @@ namespace DCS_BIOS
                             {
                                 dcsbiosInputObject.SpecifiedSetStateArgument = uint.Parse(entries[2]);
                                 SelectedDCSBIOSInput = dcsbiosInputObject;
-                                if (entries.Length == 4)
-                                {
-                                    SelectedDCSBIOSInput.Delay = int.Parse(entries[3]);
-                                }
-                                else
-                                {
-                                    SelectedDCSBIOSInput.Delay = 0;
-                                }
-
+                                SelectedDCSBIOSInput.Delay = entries.Length == 4 ? int.Parse(entries[3]) : 0;
                                 break;
                             }
                         }
-
                         break;
                     }
 
@@ -241,19 +216,10 @@ namespace DCS_BIOS
                             {
                                 dcsbiosInputObject.SpecifiedActionArgument = entries[2];
                                 SelectedDCSBIOSInput = dcsbiosInputObject;
-                                if (entries.Length == 4)
-                                {
-                                    SelectedDCSBIOSInput.Delay = int.Parse(entries[3]);
-                                }
-                                else
-                                {
-                                    SelectedDCSBIOSInput.Delay = 0;
-                                }
-
+                                SelectedDCSBIOSInput.Delay = entries.Length == 4 ? int.Parse(entries[3]) : 0;         
                                 break;
                             }
                         }
-
                         break;
                     }
 
@@ -265,19 +231,10 @@ namespace DCS_BIOS
                             {
                                 dcsbiosInputObject.SpecifiedVariableStepArgument = int.Parse(entries[2]);
                                 SelectedDCSBIOSInput = dcsbiosInputObject;
-                                if (entries.Length == 4)
-                                {
-                                    SelectedDCSBIOSInput.Delay = int.Parse(entries[3]);
-                                }
-                                else
-                                {
-                                    SelectedDCSBIOSInput.Delay = 0;
-                                }
-
+                                SelectedDCSBIOSInput.Delay = entries.Length == 4 ? int.Parse(entries[3]) : 0;
                                 break;
                             }
                         }
-
                         break;
                     }
             }

--- a/Source/DCS-BIOS/DCSBIOSInputObject.cs
+++ b/Source/DCS-BIOS/DCSBIOSInputObject.cs
@@ -51,35 +51,35 @@ namespace DCS_BIOS
             {
                 case DCSBIOSInputType.FIXED_STEP:
                     {
-                        result = _controlId + " " + _specifiedFixedStepArgument + "\n";
+                        result = $"{_controlId} {_specifiedFixedStepArgument}\n";
                         break;
                     }
                 case DCSBIOSInputType.SET_STATE:
                     {
-                        result = _controlId + " " + _specifiedSetStateArgument + "\n";
+                        result = $"{_controlId} {_specifiedSetStateArgument}\n";
                         break;
                     }
                 case DCSBIOSInputType.ACTION:
                     {
-                        result = _controlId + " " + _specifiedActionArgument + "\n";
+                        result = $"{_controlId} {_specifiedActionArgument}\n";
                         break;
                     }
                 case DCSBIOSInputType.VARIABLE_STEP:
                     {
                         if (_specifiedVariableStepArgument > 0)
                         {
-                            result = _controlId + " +" + _specifiedVariableStepArgument + "\n";
+                            result = $"{_controlId} +{_specifiedVariableStepArgument}\n";
                         }
                         else
                         {
-                            result = _controlId + " " + _specifiedVariableStepArgument + "\n";
+                            result = $"{_controlId} {_specifiedVariableStepArgument}\n";
                         }
                         break;
                     }
             }
             if (string.IsNullOrWhiteSpace(result))
             {
-                throw new Exception("Error getting DCS-BIOSInput command. ControlId = " + _controlId + " Interface = " + _interface);
+                throw new Exception($"Error getting DCS-BIOSInput command. ControlId = {_controlId} Interface = {_interface}");
             }
             return result;
         }

--- a/Source/DCS-BIOS/DCSBIOSInputObject.cs
+++ b/Source/DCS-BIOS/DCSBIOSInputObject.cs
@@ -46,42 +46,23 @@ namespace DCS_BIOS
 
         public string GetDCSBIOSCommand()
         {
-            var result = string.Empty;
-            switch (_interface)
+            string command = _interface switch
             {
-                case DCSBIOSInputType.FIXED_STEP:
-                    {
-                        result = $"{_controlId} {_specifiedFixedStepArgument}\n";
-                        break;
-                    }
-                case DCSBIOSInputType.SET_STATE:
-                    {
-                        result = $"{_controlId} {_specifiedSetStateArgument}\n";
-                        break;
-                    }
-                case DCSBIOSInputType.ACTION:
-                    {
-                        result = $"{_controlId} {_specifiedActionArgument}\n";
-                        break;
-                    }
-                case DCSBIOSInputType.VARIABLE_STEP:
-                    {
-                        if (_specifiedVariableStepArgument > 0)
-                        {
-                            result = $"{_controlId} +{_specifiedVariableStepArgument}\n";
-                        }
-                        else
-                        {
-                            result = $"{_controlId} {_specifiedVariableStepArgument}\n";
-                        }
-                        break;
-                    }
-            }
-            if (string.IsNullOrWhiteSpace(result))
+                DCSBIOSInputType.FIXED_STEP => $"{_controlId} {_specifiedFixedStepArgument}\n",
+                DCSBIOSInputType.SET_STATE  => $"{_controlId} {_specifiedSetStateArgument}\n",
+                DCSBIOSInputType.ACTION     => $"{_controlId} {_specifiedActionArgument}\n",
+                DCSBIOSInputType.VARIABLE_STEP => 
+                    _specifiedVariableStepArgument > 0 ?
+                      $"{_controlId} +{_specifiedVariableStepArgument}\n"
+                    : $"{_controlId} {_specifiedVariableStepArgument}\n",
+                _ => throw new Exception("Unexpected DCSBIOSInputType value")
+            };
+
+            if (string.IsNullOrWhiteSpace(command))
             {
                 throw new Exception($"Error getting DCS-BIOSInput command. ControlId = {_controlId} Interface = {_interface}");
             }
-            return result;
+            return command;
         }
 
         public int Delay

--- a/Source/DCS-BIOS/DCSBIOSInputObject.cs
+++ b/Source/DCS-BIOS/DCSBIOSInputObject.cs
@@ -28,23 +28,14 @@ namespace DCS_BIOS
             _controlId = controlId;
             _description = dcsbiosControlInput.Description;
 
-            if (dcsbiosControlInput.ControlInterface.Equals("fixed_step"))
+            _interface = dcsbiosControlInput.ControlInterface switch
             {
-                _interface = DCSBIOSInputType.FIXED_STEP;
-            }
-            else if (dcsbiosControlInput.ControlInterface.Equals("set_state"))
-            {
-                _interface = DCSBIOSInputType.SET_STATE;
-            }
-            else if (dcsbiosControlInput.ControlInterface.Equals("action"))
-            {
-                _interface = DCSBIOSInputType.ACTION;
-            }
-            else if (dcsbiosControlInput.ControlInterface.Equals("variable_step"))
-            {
-                _interface = DCSBIOSInputType.VARIABLE_STEP;
-            }
-
+                "fixed_step" => DCSBIOSInputType.FIXED_STEP,
+                "set_state" => DCSBIOSInputType.SET_STATE,
+                "action" => DCSBIOSInputType.ACTION,
+                "variable_step" => DCSBIOSInputType.VARIABLE_STEP,
+                _ => throw new SystemException($"Unexpected ControlInterface value [{dcsbiosControlInput.ControlInterface}]")
+            };
             _maxValue = dcsbiosControlInput.MaxValue.GetValueOrDefault();
             _specifiedActionArgument = dcsbiosControlInput.Argument;
             //Set by user

--- a/Source/DCS-BIOS/DCSBIOSOutput.cs
+++ b/Source/DCS-BIOS/DCSBIOSOutput.cs
@@ -126,33 +126,15 @@ namespace DCS_BIOS
         {
             var tmpData = data;
             var value = (tmpData & Mask) >> ShiftValue;
-            var resultComparison = false;
-            switch (DCSBiosOutputComparison)
+
+            bool resultComparison = DCSBiosOutputComparison switch
             {
-                case DCSBiosOutputComparison.BiggerThan:
-                    {
-                        resultComparison = value > _specifiedValueInt;
-                        break;
-                    }
-
-                case DCSBiosOutputComparison.LessThan:
-                    {
-                        resultComparison = value < _specifiedValueInt;
-                        break;
-                    }
-
-                case DCSBiosOutputComparison.NotEquals:
-                    {
-                        resultComparison = value != _specifiedValueInt;
-                        break;
-                    }
-
-                case DCSBiosOutputComparison.Equals:
-                    {
-                        resultComparison = value == _specifiedValueInt;
-                        break;
-                    }
-            }
+                DCSBiosOutputComparison.BiggerThan  => value > _specifiedValueInt,
+                DCSBiosOutputComparison.LessThan    => value < _specifiedValueInt,
+                DCSBiosOutputComparison.NotEquals   => value != _specifiedValueInt,
+                DCSBiosOutputComparison.Equals      => value == _specifiedValueInt,
+                _ => throw new Exception("Unexpected DCSBiosOutputComparison value"),
+            };
 
             var resultChange = !value.Equals(_lastIntValue);
             if (resultChange)
@@ -168,21 +150,11 @@ namespace DCS_BIOS
             //todo change not processed
             lock (_lockObject)
             {
-                var result = false;
-                if (DCSBiosOutputType == DCSBiosOutputType.IntegerType && data is uint u)
-                {
-                    result = CheckForValueMatch(u);
-                }
-                else if (DCSBiosOutputType == DCSBiosOutputType.StringType && data is string s)
-                {
-                    result = CheckForValueMatch(s);
-                }
-                else
-                {
-                    throw new Exception($"Invalid DCSBiosOutput. Data is of type {data.GetType()} but DCSBiosOutputType set to {DCSBiosOutputType}");
-                }
-
-                return result;
+                return true switch {
+                  _ when DCSBiosOutputType == DCSBiosOutputType.IntegerType && data is uint u => CheckForValueMatch(u),
+                  _ when DCSBiosOutputType == DCSBiosOutputType.StringType && data is string s => CheckForValueMatch(s),
+                  _ => throw new Exception($"Invalid DCSBiosOutput. Data is of type {data.GetType()} but DCSBiosOutputType set to {DCSBiosOutputType}")
+                };
             }
         }
 
@@ -190,35 +162,14 @@ namespace DCS_BIOS
         {
             var tmpData = data;
             var value = (tmpData & Mask) >> ShiftValue;
-            var result = false;
-            switch (DCSBiosOutputComparison)
-            {
-                case DCSBiosOutputComparison.BiggerThan:
-                    {
-                        result = value > _specifiedValueInt;
-                        break;
-                    }
 
-                case DCSBiosOutputComparison.LessThan:
-                    {
-                        result = value < _specifiedValueInt;
-                        break;
-                    }
-
-                case DCSBiosOutputComparison.NotEquals:
-                    {
-                        result = value != _specifiedValueInt;
-                        break;
-                    }
-
-                case DCSBiosOutputComparison.Equals:
-                    {
-                        result = value == _specifiedValueInt;
-                        break;
-                    }
-            }
-
-            return result;
+            return DCSBiosOutputComparison switch {
+                DCSBiosOutputComparison.BiggerThan =>   value > _specifiedValueInt,
+                DCSBiosOutputComparison.LessThan =>     value < _specifiedValueInt,
+                DCSBiosOutputComparison.NotEquals =>    value != _specifiedValueInt,
+                DCSBiosOutputComparison.Equals =>       value == _specifiedValueInt,
+                _ => throw new Exception("Unexpected DCSBiosOutputComparison value")
+            };
         }
 
         public uint GetUIntValue(uint data)
@@ -343,7 +294,6 @@ namespace DCS_BIOS
         public uint Address
         {
             get => _address;
-
             set
             {
                 _address = value;

--- a/Source/DCS-BIOS/DCSBIOSOutput.cs
+++ b/Source/DCS-BIOS/DCSBIOSOutput.cs
@@ -115,7 +115,7 @@ namespace DCS_BIOS
                 }
                 else
                 {
-                    throw new Exception("Invalid DCSBiosOutput. Data is of type " + data.GetType() + " but DCSBiosOutputType set to " + DCSBiosOutputType);
+                    throw new Exception($"Invalid DCSBiosOutput. Data is of type {data.GetType()} but DCSBiosOutputType set to {DCSBiosOutputType}");
                 }
 
                 return result;

--- a/Source/DCS-BIOS/DCSBIOSOutput.cs
+++ b/Source/DCS-BIOS/DCSBIOSOutput.cs
@@ -179,7 +179,7 @@ namespace DCS_BIOS
                 }
                 else
                 {
-                    throw new Exception("Invalid DCSBiosOutput. Data is of type " + data.GetType() + " but DCSBiosOutputType set to " + DCSBiosOutputType);
+                    throw new Exception($"Invalid DCSBiosOutput. Data is of type {data.GetType()} but DCSBiosOutputType set to {DCSBiosOutputType}");
                 }
 
                 return result;
@@ -276,7 +276,7 @@ namespace DCS_BIOS
             }
             catch (Exception)
             {
-                throw new Exception("Failed to copy control " + _controlId + ". Control output is missing." + Environment.NewLine);
+                throw new Exception($"Failed to copy control {_controlId}. Control output is missing.{Environment.NewLine}");
             }
         }
 
@@ -311,7 +311,7 @@ namespace DCS_BIOS
 
             if (!str.StartsWith("DCSBiosOutput{") || !str.EndsWith("}"))
             {
-                throw new Exception("DCSBiosOutput cannot import string : " + str);
+                throw new Exception($"DCSBiosOutput cannot import string : {str}");
             }
 
             value = value.Replace("DCSBiosOutput{", string.Empty).Replace("}", string.Empty);
@@ -387,7 +387,7 @@ namespace DCS_BIOS
             {
                 if (DCSBiosOutputType != DCSBiosOutputType.IntegerType)
                 {
-                    throw new Exception("Invalid DCSBiosOutput. Specified value (trigger value) set to [int] but DCSBiosOutputType set to " + DCSBiosOutputType);
+                    throw new Exception($"Invalid DCSBiosOutput. Specified value (trigger value) set to [int] but DCSBiosOutputType set to {DCSBiosOutputType}");
                 }
 
                 _specifiedValueInt = value;
@@ -402,7 +402,7 @@ namespace DCS_BIOS
             {
                 if (DCSBiosOutputType != DCSBiosOutputType.StringType)
                 {
-                    throw new Exception("Invalid DCSBiosOutput. Specified value (trigger value) set to [String] but DCSBiosOutputType set to " + DCSBiosOutputType);
+                    throw new Exception($"Invalid DCSBiosOutput. Specified value (trigger value) set to [String] but DCSBiosOutputType set to {DCSBiosOutputType}");
                 }
 
                 _specifiedValueString = value;

--- a/Source/DCS-BIOS/DCSBIOSOutputFormula.cs
+++ b/Source/DCS-BIOS/DCSBIOSOutputFormula.cs
@@ -11,11 +11,11 @@ namespace DCS_BIOS
     {
         [NonSerialized]
         internal static Logger logger = LogManager.GetCurrentClassLogger();
-        private readonly List<DCSBIOSOutput> _dcsbiosOutputs = new List<DCSBIOSOutput>();
-        private readonly Dictionary<string, double> _variables = new Dictionary<string, double>();
+        private readonly List<DCSBIOSOutput> _dcsbiosOutputs = new();
+        private readonly Dictionary<string, double> _variables = new();
 
         [NonSerialized]
-        private readonly JaceExtended _jaceExtended = new JaceExtended();
+        private readonly JaceExtended _jaceExtended = new();
         private string _formula;
         
         [NonSerialized]

--- a/Source/DCS-BIOS/DCSBIOSProfileLoadStatus.cs
+++ b/Source/DCS-BIOS/DCSBIOSProfileLoadStatus.cs
@@ -7,7 +7,7 @@ namespace DCS_BIOS
     {
         private string Profile { get; set; }
         private bool Loaded { get; set; }
-        private static readonly List<DCSBIOSProfileLoadStatus> LoadStatusList = new List<DCSBIOSProfileLoadStatus>();
+        private static readonly List<DCSBIOSProfileLoadStatus> LoadStatusList = new();
 
         private DCSBIOSProfileLoadStatus(string profile, bool loaded)
         {
@@ -39,26 +39,12 @@ namespace DCS_BIOS
 
         public static bool IsLoaded(string profile)
         {
-            foreach (var loadStatus in LoadStatusList)
-            {
-                if (loadStatus.Profile == profile && loadStatus.Loaded)
-                {
-                    return true;
-                }
-            }
-            return false;
+            return LoadStatusList.Exists(loadStatus => loadStatus.Profile == profile && loadStatus.Loaded);
         }
 
         private static bool IsRegistered(string profile)
         {
-            foreach (var loadStatus in LoadStatusList)
-            {
-                if (loadStatus.Profile == profile)
-                {
-                    return true;
-                }
-            }
-            return false;
+            return LoadStatusList.Exists(loadStatus => loadStatus.Profile == profile);
         }
 
         public static void Remove(string profile)

--- a/Source/DCS-BIOS/DCSBIOSProtocolParser.cs
+++ b/Source/DCS-BIOS/DCSBIOSProtocolParser.cs
@@ -30,7 +30,7 @@ namespace DCS_BIOS
     {
         internal static Logger logger = LogManager.GetCurrentClassLogger();
 
-        private readonly List<string> _errorsLogged = new List<string>(10);
+        private readonly List<string> _errorsLogged = new(10);
         
         private DCSBiosStateEnum _state;
         private uint _address;
@@ -38,15 +38,15 @@ namespace DCS_BIOS
         private uint _data;
         private byte _syncByteCount;
         private bool _shutdown;
-        private static readonly object _lockListOfAddressesToBroascastObject = new object();
-        private readonly List<uint> _listOfAddressesToBroascast = new List<uint>();
+        private static readonly object _lockListOfAddressesToBroascastObject = new();
+        private readonly List<uint> _listOfAddressesToBroascast = new();
         public static DCSBIOSProtocolParser DCSBIOSProtocolParserSO;
-        private AutoResetEvent _autoResetEvent = new AutoResetEvent(false);
+        private AutoResetEvent _autoResetEvent = new(false);
 
 
         //private object _lockArrayToProcess = new object();
         //private List<byte[]> _arraysToProcess = new List<byte[]>();
-        private readonly ConcurrentQueue<byte[]> _arraysToProcess = new ConcurrentQueue<byte[]>();
+        private readonly ConcurrentQueue<byte[]> _arraysToProcess = new();
         private Thread _processingThread;
 
         private DCSBIOSProtocolParser()

--- a/Source/DCS-BIOS/DCSBIOSString.cs
+++ b/Source/DCS-BIOS/DCSBIOSString.cs
@@ -5,12 +5,24 @@
     public class DCSBIOSString
     {
         // Use this, some strings need to be fully contructed before being broadcasted
-        private readonly List<uint> _receivedAddresses = new List<uint>();
-
+        private readonly List<uint> _receivedAddresses = new();
         private readonly string[] _internalBuffer;
         private readonly int _length;
         private uint _address;
         
+        public int Length { get; set; }
+        public bool IsComplete => _receivedAddresses.Count == 0;
+        public string StringValue => string.Join(string.Empty, _internalBuffer);
+        public uint Address
+        {
+            get => _address;
+            set
+            {
+                _address = value;
+                DCSBIOSProtocolParser.RegisterAddressToBroadCast(_address);
+            }
+        }
+
         public DCSBIOSString(uint address, int length)
         {
             _address = address;
@@ -33,20 +45,6 @@
                 _receivedAddresses.Add(i);
             }
         }
-
-        public int Length { get; set; }
-
-        public uint Address
-        {
-            get => _address;
-            set
-            {
-                _address = value;
-                DCSBIOSProtocolParser.RegisterAddressToBroadCast(_address);
-            }
-        }
-
-        public string StringValue => string.Join(string.Empty, _internalBuffer);
 
         public bool IsMatch(uint address)
         {
@@ -129,7 +127,5 @@
                 // Debug.WriteLine("*******************************************************");
             }
         }
-
-        public bool IsComplete => _receivedAddresses.Count == 0;
     }
 }

--- a/Source/DCS-BIOS/DCSBIOSStringListener.cs
+++ b/Source/DCS-BIOS/DCSBIOSStringListener.cs
@@ -16,8 +16,8 @@ namespace DCS_BIOS
     {
         internal static Logger logger = LogManager.GetCurrentClassLogger();
 
-        private readonly List<KeyValuePair<uint, DCSBIOSString>> _dcsBiosStrings = new List<KeyValuePair<uint, DCSBIOSString>>();
-        private readonly object _lockObject = new object();
+        private readonly List<KeyValuePair<uint, DCSBIOSString>> _dcsBiosStrings = new();
+        private readonly object _lockObject = new();
         private readonly Encoding _iso8859_1 = Encoding.GetEncoding("ISO-8859-1");
         
 

--- a/Source/DCS-BIOS/DCSBIOSStringManager.cs
+++ b/Source/DCS-BIOS/DCSBIOSStringManager.cs
@@ -1,7 +1,5 @@
 ﻿namespace DCS_BIOS
 {
-    using DCS_BIOS.Interfaces;
-
     public static class DCSBIOSStringManager
     {
         private static DCSBIOSStringListener _dcsbiosStringListener;

--- a/Source/DCS-BIOS/JaceExtended.cs
+++ b/Source/DCS-BIOS/JaceExtended.cs
@@ -8,8 +8,8 @@ namespace DCS_BIOS
     {
         internal static Logger logger = LogManager.GetCurrentClassLogger();
 
-        private readonly object _lockObject = new object();
-        private readonly CalculationEngine _calculationEngine = new CalculationEngine();
+        private readonly object _lockObject = new();
+        private readonly CalculationEngine _calculationEngine = new();
 
         public JaceExtended()
         {

--- a/Source/DCS-BIOS/Json/DCSBIOSControlOutput.cs
+++ b/Source/DCS-BIOS/Json/DCSBIOSControlOutput.cs
@@ -34,14 +34,12 @@ namespace DCS_BIOS.Json
             set
             {
                 _type = value;
-                if (_type.Equals("string"))
+                OutputDataType = _type switch
                 {
-                    OutputDataType = DCSBiosOutputType.StringType;
-                }
-                if (_type.Equals("integer"))
-                {
-                    OutputDataType = DCSBiosOutputType.IntegerType;
-                }
+                    "string" => DCSBiosOutputType.StringType,
+                    "integer" => DCSBiosOutputType.IntegerType,
+                    _ => throw new System.Exception($"Unexpected DCSBiosOutputType [{_type}]")
+                };
             }
         }
 

--- a/Source/DCSFlightpanels/MainWindow.xaml.cs
+++ b/Source/DCSFlightpanels/MainWindow.xaml.cs
@@ -1769,10 +1769,10 @@
                 {
                     // Refresh, make sure they are using the latest settings
                     DCSBIOSControlLocator.JSONDirectory = Settings.Default.DCSBiosJSONLocation;
-                    _dcsBios.ReceiveFromIp = Settings.Default.DCSBiosIPFrom;
-                    _dcsBios.ReceivePort = int.Parse(Settings.Default.DCSBiosPortFrom);
-                    _dcsBios.SendToIp = Settings.Default.DCSBiosIPTo;
-                    _dcsBios.SendPort = int.Parse(Settings.Default.DCSBiosPortTo);
+                    _dcsBios.ReceiveFromIpUdp = Settings.Default.DCSBiosIPFrom;
+                    _dcsBios.ReceivePortUdp = int.Parse(Settings.Default.DCSBiosPortFrom);
+                    _dcsBios.SendToIpUdp = Settings.Default.DCSBiosIPTo;
+                    _dcsBios.SendPortUdp = int.Parse(Settings.Default.DCSBiosPortTo);
                     _dcsBios.Shutdown();
                     _dcsBios.Startup();
                     _profileHandler.DCSBIOSJSONDirectory = Settings.Default.DCSBiosJSONLocation;

--- a/Source/Tests/DcsBios/DCSBIOSInputObjectTests.cs
+++ b/Source/Tests/DcsBios/DCSBIOSInputObjectTests.cs
@@ -1,5 +1,6 @@
 ﻿using DCS_BIOS;
 using DCS_BIOS.Json;
+using System;
 using Xunit;
 
 namespace Tests.DcsBios
@@ -14,8 +15,6 @@ namespace Tests.DcsBios
         public void Cosume_ShouldSet_4_Properties(string givenControlInterface, DCSBIOSInputType expectedDCSBIOSInputType)
         {
             string controlId = "ThisIsAControlId";
-
-            DCSBIOSInputObject inputObject = new();
             DCSBIOSControlInput controlInput = new()
             {
                 Description = "Test",
@@ -23,6 +22,7 @@ namespace Tests.DcsBios
                 MaxValue = 666,
                 Argument = "ThisIsAnArgument"
             };
+            DCSBIOSInputObject inputObject = new();
             inputObject.Consume(controlId, controlInput);
 
             Assert.Equal(controlId, inputObject.ControlId);
@@ -31,5 +31,112 @@ namespace Tests.DcsBios
             Assert.Equal(controlInput.Argument, inputObject.SpecifiedActionArgument);
         }
 
+        [Theory]
+        [InlineData("ThisIsAControlId", DCSBIOSFixedStepInput.INC, "ThisIsAControlId INC\n")]
+        [InlineData("ThisIsAControlId", DCSBIOSFixedStepInput.DEC, "ThisIsAControlId DEC\n")]
+        [InlineData("ThisIsAControlId", null, "ThisIsAControlId INC\n")]
+        [InlineData("", DCSBIOSFixedStepInput.DEC, " DEC\n")]
+        [InlineData(null, DCSBIOSFixedStepInput.DEC, " DEC\n")]
+        [InlineData(null, null, " INC\n")]
+        public void GetDCSBIOSCommand_FixedStep_ShouldReturn_ExpectedResult(string controlId, DCSBIOSFixedStepInput? specifiedFixedStepArgument, string expectedResult) {
+            DCSBIOSInputObject inputObject = new()
+            {
+                ControlId = controlId,
+                Interface = DCSBIOSInputType.FIXED_STEP
+            };
+            if (specifiedFixedStepArgument != null)
+                inputObject.SpecifiedFixedStepArgument = (DCSBIOSFixedStepInput)specifiedFixedStepArgument;
+
+            Assert.Equal(expectedResult, inputObject.GetDCSBIOSCommand());
+        }
+
+        [Theory]
+        [InlineData("ThisIsAControlId", (uint)123, "ThisIsAControlId 123\n")]
+        [InlineData("ThisIsAControlId", (uint)456, "ThisIsAControlId 456\n")]
+        [InlineData("ThisIsAControlId", null, "ThisIsAControlId 0\n")]
+        [InlineData("", (uint)789, " 789\n")]
+        [InlineData("", null, " 0\n")]
+        [InlineData(null, null, " 0\n")]
+        public void GetDCSBIOSCommand_SetState_ShouldReturn_ExpectedResult(string controlId, uint? specifiedSetStateArgument, string expectedResult)
+        {
+            DCSBIOSInputObject inputObject = new()
+            {
+                ControlId = controlId,
+                Interface = DCSBIOSInputType.SET_STATE
+            };
+            if (specifiedSetStateArgument != null)
+                inputObject.SpecifiedSetStateArgument = (uint)specifiedSetStateArgument;
+
+            Assert.Equal(expectedResult, inputObject.GetDCSBIOSCommand());
+        }
+
+        [Theory]
+        [InlineData("ThisIsAControlId", "AbC", "ThisIsAControlId AbC\n")]
+        [InlineData("ThisIsAControlId", "", "ThisIsAControlId \n")]
+        [InlineData("ThisIsAControlId", null, "ThisIsAControlId \n")]
+        [InlineData("", "AbC", " AbC\n")]
+        [InlineData(null, "AbC", " AbC\n")]
+        //[InlineData("", "", "  \n")]
+        //[InlineData("", null, " 0\n")]
+        public void GetDCSBIOSCommand_Action_ShouldReturn_ExpectedResult(string controlId, string specifiedActionArgument, string expectedResult)
+        {
+            DCSBIOSInputObject inputObject = new()
+            {
+                ControlId = controlId,
+                Interface = DCSBIOSInputType.ACTION,
+                SpecifiedActionArgument = specifiedActionArgument
+            };
+
+            Assert.Equal(expectedResult, inputObject.GetDCSBIOSCommand());
+        }
+
+        [Theory]
+        [InlineData("ThisIsAControlId", 1, "ThisIsAControlId +1\n")]
+        [InlineData("ThisIsAControlId", 0, "ThisIsAControlId 0\n")]
+        [InlineData("ThisIsAControlId", -1, "ThisIsAControlId -1\n")]
+        [InlineData("ThisIsAControlId", 123, "ThisIsAControlId +123\n")]
+        [InlineData("ThisIsAControlId", 456, "ThisIsAControlId +456\n")]
+        [InlineData("ThisIsAControlId", -123, "ThisIsAControlId -123\n")]
+        [InlineData("ThisIsAControlId", null, "ThisIsAControlId 0\n")]
+        [InlineData("", 789, " +789\n")]
+        [InlineData("", null, " 0\n")]
+        [InlineData(null, null, " 0\n")]
+        public void GetDCSBIOSCommand_VariableStep_ShouldReturn_ExpectedResult(string controlId, int? specifiedVariableStepArgument, string expectedResult)
+        {
+            DCSBIOSInputObject inputObject = new()
+            {
+                ControlId = controlId,
+                Interface = DCSBIOSInputType.VARIABLE_STEP
+            };
+            if (specifiedVariableStepArgument != null)
+                inputObject.SpecifiedVariableStepArgument = (int)specifiedVariableStepArgument;
+
+            Assert.Equal(expectedResult, inputObject.GetDCSBIOSCommand());
+        }
+
+        [Fact]
+        public void GetDCSBIOSCommand_WithoutAnyPropertiesSet_ReturnsDefaultValueOfFixedStep()
+        {
+            DCSBIOSInputObject inputObject = new();
+            Assert.Equal(" INC\n", inputObject.GetDCSBIOSCommand());
+        }
+
+        [Theory]
+        [InlineData("", "", DCSBIOSInputType.ACTION)]
+        [InlineData("", null, DCSBIOSInputType.ACTION)]
+        public void GetDCSBIOSCommand_ShouldThrowException_InThoseCases(string controlId, object argument, DCSBIOSInputType? inputType)
+        {
+            DCSBIOSInputObject inputObject = new()
+            {
+                ControlId = controlId,
+            };
+
+            if (inputType == DCSBIOSInputType.ACTION) 
+            {
+                inputObject.SpecifiedActionArgument = (string)argument;
+                inputObject.Interface = DCSBIOSInputType.ACTION;
+            }
+            Assert.Throws<Exception>(() => inputObject.GetDCSBIOSCommand());
+        }
     }
 }

--- a/Source/Tests/DcsBios/DCSBIOSInputObjectTests.cs
+++ b/Source/Tests/DcsBios/DCSBIOSInputObjectTests.cs
@@ -1,0 +1,35 @@
+﻿using DCS_BIOS;
+using DCS_BIOS.Json;
+using Xunit;
+
+namespace Tests.DcsBios
+{
+    public class DCSBIOSInputObjectTests
+    {
+        [Theory]
+        [InlineData("fixed_step", DCSBIOSInputType.FIXED_STEP)]
+        [InlineData("set_state", DCSBIOSInputType.SET_STATE)]
+        [InlineData("action", DCSBIOSInputType.ACTION)]
+        [InlineData("variable_step", DCSBIOSInputType.VARIABLE_STEP)]
+        public void Cosume_ShouldSet_4_Properties(string givenControlInterface, DCSBIOSInputType expectedDCSBIOSInputType)
+        {
+            string controlId = "ThisIsAControlId";
+
+            DCSBIOSInputObject inputObject = new();
+            DCSBIOSControlInput controlInput = new()
+            {
+                Description = "Test",
+                ControlInterface = givenControlInterface,
+                MaxValue = 666,
+                Argument = "ThisIsAnArgument"
+            };
+            inputObject.Consume(controlId, controlInput);
+
+            Assert.Equal(controlId, inputObject.ControlId);
+            Assert.Equal(controlInput.Description, inputObject.Description);
+            Assert.Equal(expectedDCSBIOSInputType, inputObject.Interface);
+            Assert.Equal(controlInput.Argument, inputObject.SpecifiedActionArgument);
+        }
+
+    }
+}

--- a/Source/Tests/DcsBios/DCSBIOSOutputTests.cs
+++ b/Source/Tests/DcsBios/DCSBIOSOutputTests.cs
@@ -76,5 +76,112 @@ namespace Tests.DcsBios
             else
                 Assert.Throws<Exception>(() => dcsOutput.CheckForValueMatch(obj));
         }
+
+        [Theory]
+        [InlineData((uint)100, DCSBiosOutputComparison.BiggerThan, (uint)99, true)]
+        [InlineData((uint)99, DCSBiosOutputComparison.BiggerThan, (uint)100, false)]
+        [InlineData((uint)123455, DCSBiosOutputComparison.BiggerThan, (uint)123456, false)]
+        [InlineData((uint)100, DCSBiosOutputComparison.BiggerThan, (uint)100, false)]
+
+        [InlineData((uint)100, DCSBiosOutputComparison.LessThan, (uint)99, false)]
+        [InlineData((uint)99, DCSBiosOutputComparison.LessThan, (uint)100, true)]
+        [InlineData((uint)123455, DCSBiosOutputComparison.LessThan, (uint)123456, true)]
+        [InlineData((uint)100, DCSBiosOutputComparison.LessThan, (uint)100, false)]
+
+        [InlineData((uint)100, DCSBiosOutputComparison.Equals, (uint)99, false)]
+        [InlineData((uint)99, DCSBiosOutputComparison.Equals, (uint)100, false)]
+        [InlineData((uint)123455, DCSBiosOutputComparison.Equals, (uint)123456, false)]
+        [InlineData((uint)100, DCSBiosOutputComparison.Equals, (uint)100, false)] //<-- ?? != compared to CheckForValueMatch_WithUint 
+
+        [InlineData((uint)100, DCSBiosOutputComparison.NotEquals, (uint)99, true)]
+        [InlineData((uint)99, DCSBiosOutputComparison.NotEquals, (uint)100, true)]
+        [InlineData((uint)123455, DCSBiosOutputComparison.NotEquals, (uint)123456, true)]
+        [InlineData((uint)100, DCSBiosOutputComparison.NotEquals, (uint)100, false)]
+        public void CheckForValueMatchAndChange_WithUint_LastIntValue_Is_OriginalValue(uint valueToCompare, DCSBiosOutputComparison comparisonType, uint OriginalValue, bool expectedResult)
+        {
+            DCSBIOSOutput dcsOutput = new()
+            {
+                DCSBiosOutputType = DCSBiosOutputType.IntegerType,
+                Mask = valueToCompare,
+                SpecifiedValueInt = OriginalValue,
+                DCSBiosOutputComparison = comparisonType,
+                LastIntValue = OriginalValue, //<-- != compared to CheckForValueMatch_WithUint 
+            };
+
+            Assert.Equal(expectedResult, dcsOutput.CheckForValueMatchAndChange(valueToCompare));
+            Assert.Equal(valueToCompare, dcsOutput.LastIntValue);
+        }
+
+        [Theory]
+        [InlineData((uint)100, DCSBiosOutputComparison.BiggerThan, (uint)99)]  
+        [InlineData((uint)99, DCSBiosOutputComparison.BiggerThan, (uint)100)]
+        [InlineData((uint)123455, DCSBiosOutputComparison.BiggerThan, (uint)123456)]
+        [InlineData((uint)100, DCSBiosOutputComparison.BiggerThan, (uint)100)]
+
+        [InlineData((uint)100, DCSBiosOutputComparison.LessThan, (uint)99)]
+        [InlineData((uint)99, DCSBiosOutputComparison.LessThan, (uint)100)] 
+        [InlineData((uint)123455, DCSBiosOutputComparison.LessThan, (uint)123456)] 
+        [InlineData((uint)100, DCSBiosOutputComparison.LessThan, (uint)100)]
+
+        [InlineData((uint)100, DCSBiosOutputComparison.Equals, (uint)99)]
+        [InlineData((uint)99, DCSBiosOutputComparison.Equals, (uint)100)]
+        [InlineData((uint)123455, DCSBiosOutputComparison.Equals, (uint)123456)]
+        [InlineData((uint)100, DCSBiosOutputComparison.Equals, (uint)100)] 
+
+        [InlineData((uint)100, DCSBiosOutputComparison.NotEquals, (uint)99)] 
+        [InlineData((uint)99, DCSBiosOutputComparison.NotEquals, (uint)100)] 
+        [InlineData((uint)123455, DCSBiosOutputComparison.NotEquals, (uint)123456)] 
+        [InlineData((uint)100, DCSBiosOutputComparison.NotEquals, (uint)100)]
+        public void CheckForValueMatchAndChange_WithUint_LastIntValue_Is_ValueToCompare(uint valueToCompare, DCSBiosOutputComparison comparisonType, uint OriginalValue)
+        {
+            DCSBIOSOutput dcsOutput = new()
+            {
+                DCSBiosOutputType = DCSBiosOutputType.IntegerType,
+                Mask = valueToCompare,
+                SpecifiedValueInt = OriginalValue,
+                DCSBiosOutputComparison = comparisonType,
+                LastIntValue = valueToCompare, //<-- != compared to CheckForValueMatch_WithUint 
+            };
+            //always returns false
+            Assert.False(dcsOutput.CheckForValueMatchAndChange(valueToCompare));
+            Assert.Equal(valueToCompare, dcsOutput.LastIntValue);
+        }
+
+        [Theory]
+        [InlineData((uint)100, DCSBiosOutputComparison.BiggerThan, (uint)99, (uint)1, true)]
+        [InlineData((uint)99, DCSBiosOutputComparison.BiggerThan, (uint)100, (uint)5, false)]
+        [InlineData((uint)123455, DCSBiosOutputComparison.BiggerThan, (uint)123456, (uint)8, false)]
+        [InlineData((uint)100, DCSBiosOutputComparison.BiggerThan, (uint)100, (uint)555, false)]
+
+        [InlineData((uint)100, DCSBiosOutputComparison.LessThan, (uint)99, (uint)9991, false)]
+        [InlineData((uint)99, DCSBiosOutputComparison.LessThan, (uint)100, (uint)231, true)]
+        [InlineData((uint)123455, DCSBiosOutputComparison.LessThan, (uint)123456, (uint)1, true)]
+        [InlineData((uint)100, DCSBiosOutputComparison.LessThan, (uint)100, (uint)0, false)]
+
+        [InlineData((uint)100, DCSBiosOutputComparison.Equals, (uint)99, (uint)888, false)]
+        [InlineData((uint)99, DCSBiosOutputComparison.Equals, (uint)100, (uint)789, false)]
+        [InlineData((uint)123455, DCSBiosOutputComparison.Equals, (uint)123456, (uint)12, false)]
+        [InlineData((uint)100, DCSBiosOutputComparison.Equals, (uint)100, (uint)99, true)] //<-- != compared to CheckForValueMatch_WithUint 
+        [InlineData((uint)100, DCSBiosOutputComparison.Equals, (uint)100, (uint)101, true)] //<-- != compared to CheckForValueMatch_WithUint 
+
+        [InlineData((uint)100, DCSBiosOutputComparison.NotEquals, (uint)99, (uint)78121, true)]
+        [InlineData((uint)99, DCSBiosOutputComparison.NotEquals, (uint)100, (uint)111, true)]
+        [InlineData((uint)123455, DCSBiosOutputComparison.NotEquals, (uint)123456, (uint)2, true)]
+        [InlineData((uint)100, DCSBiosOutputComparison.NotEquals, (uint)100, (uint)55, false)]
+        public void CheckForValueMatchAndChange_WithUint_LastIntValue_Is_Random(uint valueToCompare, DCSBiosOutputComparison comparisonType, uint OriginalValue, uint lastIntValue, bool expectedResult)
+        {
+            DCSBIOSOutput dcsOutput = new()
+            {
+                DCSBiosOutputType = DCSBiosOutputType.IntegerType,
+                Mask = valueToCompare,
+                SpecifiedValueInt = OriginalValue,
+                DCSBiosOutputComparison = comparisonType,
+                LastIntValue = lastIntValue, //<-- != compared to CheckForValueMatch_WithUint 
+            };
+
+            Assert.Equal(expectedResult, dcsOutput.CheckForValueMatchAndChange(valueToCompare));
+            Assert.Equal(valueToCompare, dcsOutput.LastIntValue);
+        }
+
     }
 }

--- a/Source/Tests/DcsBios/DCSBIOSOutputTests.cs
+++ b/Source/Tests/DcsBios/DCSBIOSOutputTests.cs
@@ -1,0 +1,80 @@
+﻿using DCS_BIOS;
+using System;
+using Xunit;
+
+namespace Tests.DcsBios
+{
+    public class DCSBIOSOutputTests
+    {
+
+        [Theory]
+        [InlineData((uint)100, DCSBiosOutputComparison.BiggerThan, (uint)99, true)]
+        [InlineData((uint)99, DCSBiosOutputComparison.BiggerThan, (uint)100, false)]
+        [InlineData((uint)123455, DCSBiosOutputComparison.BiggerThan, (uint)123456, false)]
+        [InlineData((uint)100, DCSBiosOutputComparison.BiggerThan, (uint)100, false)]
+
+        [InlineData((uint)100, DCSBiosOutputComparison.LessThan, (uint)99, false)]
+        [InlineData((uint)99, DCSBiosOutputComparison.LessThan, (uint)100, true)]
+        [InlineData((uint)123455, DCSBiosOutputComparison.LessThan, (uint)123456, true)]
+        [InlineData((uint)100, DCSBiosOutputComparison.LessThan, (uint)100, false)]
+
+        [InlineData((uint)100, DCSBiosOutputComparison.Equals, (uint)99, false)]
+        [InlineData((uint)99, DCSBiosOutputComparison.Equals, (uint)100, false)]
+        [InlineData((uint)123455, DCSBiosOutputComparison.Equals, (uint)123456, false)]
+        [InlineData((uint)100, DCSBiosOutputComparison.Equals, (uint)100, true)]
+
+        [InlineData((uint)100, DCSBiosOutputComparison.NotEquals, (uint)99, true)]
+        [InlineData((uint)99, DCSBiosOutputComparison.NotEquals, (uint)100, true)]
+        [InlineData((uint)123455, DCSBiosOutputComparison.NotEquals, (uint)123456, true)]
+        [InlineData((uint)100, DCSBiosOutputComparison.NotEquals, (uint)100, false)]
+        public void CheckForValueMatch_WithUint(uint valueToCompare, DCSBiosOutputComparison comparisonType, uint OriginalValue, bool expectedResult)
+        {
+            DCSBIOSOutput dcsOutput = new() {
+                DCSBiosOutputType = DCSBiosOutputType.IntegerType,
+                Mask = valueToCompare,
+                SpecifiedValueInt = OriginalValue,
+                DCSBiosOutputComparison = comparisonType,
+            };
+
+            Assert.Equal(expectedResult, dcsOutput.CheckForValueMatch(valueToCompare));
+        }
+
+        [Theory]
+        [InlineData("AbC", "AbC", true)]
+        [InlineData("AbC", "ABC", false)]
+        [InlineData("ABC", "AbC", false)]
+        [InlineData("AbC", "DeF", false)]
+        [InlineData("(-Something Ugly&£µLike That%$^)- ", "(-Something Ugly&£µLike That%$^)- ", true)]
+        [InlineData("", "", false)]
+        //NullReferenceException [InlineData(null, null, true)]
+        public void CheckForValueMatch_WithString(string valueToCompare, string OriginalValue, bool expectedResult)
+        {
+            DCSBIOSOutput dcsOutput = new()
+            {
+                DCSBiosOutputType = DCSBiosOutputType.StringType,
+                SpecifiedValueString = OriginalValue, //should set DCSBiosOutputType before assign !
+            };
+
+            Assert.Equal(expectedResult, dcsOutput.CheckForValueMatch(valueToCompare));
+        }
+
+        [Theory]
+        [InlineData(null, "AbC")]
+        [InlineData(DCSBiosOutputType.IntegerType, "Abc")]
+        [InlineData(DCSBiosOutputType.StringType, (uint)123)]
+        [InlineData(null, null)]
+        [InlineData(DCSBiosOutputType.IntegerType, (float)555.666)]
+        [InlineData(DCSBiosOutputType.StringType, true)]
+        public void CheckForValueMatch_WithObject_ShouldThrowException_InThoseCases(DCSBiosOutputType? dcsBiosOutputType, object obj)
+        {
+            DCSBIOSOutput dcsOutput = new();
+            if (dcsBiosOutputType != null)
+                dcsOutput.DCSBiosOutputType = (DCSBiosOutputType)dcsBiosOutputType;
+
+            if (obj == null)
+                Assert.Throws<NullReferenceException>(() => dcsOutput.CheckForValueMatch(obj));
+            else
+                Assert.Throws<Exception>(() => dcsOutput.CheckForValueMatch(obj));
+        }
+    }
+}

--- a/Source/Tests/Tests.csproj
+++ b/Source/Tests/Tests.csproj
@@ -41,4 +41,8 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="DcsBios\" />
+  </ItemGroup>
+
 </Project>

--- a/Source/Tests/Tests.csproj
+++ b/Source/Tests/Tests.csproj
@@ -41,8 +41,4 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="DcsBios\" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Code refactorization in DCSBios folder.
* Added a bunch of Unit tests on some testable & critical functions.
* Mainly syntax changes, use of auto properties, more usage of Linq, pattern matching...
* No logic changes. Tested and everything is looking good & works as expected. Don't hesitate to test it yourself before merging, we never know.

-> **When testing, I did find a bug but it has nothing to do with the refactorization (it's already present in master on this day):**

* When changing something in the Setting/DcsBios page (like the IP for example) and clicking on `OK`
* In the `DCSBIOS.Startup()` function there is a null reference on `_dcsProtocolParser.Startup();`
* It's due to the call to `shutdown` & `startup` function in `MenuItemSettings_OnClick`
* Also in the `ShutDown` function there are 2 calls on `_udpReceiveClient?.Close() & = null` ?, maybe one should be on `_udpSendClient` 
* My guess is that we need to re-instantiate `_udpReceiveClient` & `_udpSendClient` like in the constructor of `DCSBIOS` in the `Startup()` function

Unfortunately, due to time constrain, I have no time to investigate this more & fix it right now, maybe you can check it or I'll check it myself later ;-) 
