### PR TITLE
Use NewtonSoft for DeepClone & fix Interface serialization.

### DIFF
--- a/Source/DCSFlightpanels/DCSFlightpanels.csproj
+++ b/Source/DCSFlightpanels/DCSFlightpanels.csproj
@@ -28,7 +28,7 @@
     </Authors>
     <PackageId>DCSFlightpanels (DCSFP)</PackageId>
     <Version>1.0.0</Version>
-    <AssemblyVersion>4.6.8086.4</AssemblyVersion>
+    <AssemblyVersion>4.6.8117.1</AssemblyVersion>
     <FileVersion>
     </FileVersion>
     <ApplicationIcon>flightpanels02_8Rc_icon.ico</ApplicationIcon>

--- a/Source/NonVisuals/Extensions.cs
+++ b/Source/NonVisuals/Extensions.cs
@@ -1,19 +1,14 @@
-﻿using Newtonsoft.Json;
-using NonVisuals.StreamDeck.Panels;
+﻿using NonVisuals.StreamDeck.Panels;
 
 namespace NonVisuals
 {
     using System;
     using System.Collections.Generic;
     using System.Globalization;
-    using System.IO;
-    using System.Runtime.Serialization.Formatters.Binary;
-    using System.Text.Json;
     using System.Windows.Forms;
-
     using NonVisuals.StreamDeck;
-
     using TextBox = System.Windows.Controls.TextBox;
+    using Newtonsoft.Json;
 
     public static class Extensions
     {
@@ -34,13 +29,20 @@ namespace NonVisuals
         /// <returns>The copied object.</returns>
         public static T CloneJson<T>(this T source)
         {
+            //Note to devs: Use Newtonsoft.Json to clone the object, not System.Text.Json; because there are a lot of Newtonsoft.Json [JsonIgnore] attributes that are ignored
+            //by the System.Text.Json serializer. This could lead to recursive serialization of unwanted properties that raises an exception.
+
             if (!typeof(T).IsSerializable)
             {
                 throw new ArgumentException($"DeepClone error. The type must be serializable");
             }
 
-            string jsonString = JsonSerializer.Serialize(source);
-            return JsonSerializer.Deserialize<T>(jsonString);
+            //Following line fixes "Could not create an instance of type xxx Type is an interface or abstract class and cannot be instantiated."
+            //when deepcloning IKeyPressInfo from  AddKeySequence(string description, SortedList<int, IKeyPressInfo> keySequence)
+            var settings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Auto };
+
+            var jsonString = JsonConvert.SerializeObject(source, settings);
+            return JsonConvert.DeserializeObject<T>(jsonString, settings);
         }
 
         public static bool ValidateDouble(this TextBox textBox, bool ignoreIfEmpty)


### PR DESCRIPTION
Use NewtonSoft for DeepClone & fix Interface serialization.

* Ignored attributes during serialization because of using System.Text .Json:
_Hi is anyone else having the same following issue as me. I am using DCSFP 4.6.8086.4. I am using the latest DCS BIOS which includes the completed Apache. Making a new Apache profile was going well until i tried to place a button image using DCS-Bios decoder. i get these following messages and included error log below. checked with other module profiles and get the same. Previously i have not had this problem. Any help greatly appreciated._
![image](https://user-images.githubusercontent.com/67550369/159648350-92a907be-9020-4511-b550-f07eaaaeb256.png)
![image](https://user-images.githubusercontent.com/67550369/159648413-5c7c3f38-ea03-4c29-ae86-1a234b3f8c12.png)


* Interface serialization error:
_Hi and thank you for getting back to me. The error happens on my PZ55 and PZ70 and it doesn't seem to matter what combo i use under key sequence, whether it be G and E or Shift+R + VKNULL. Heres a grab of the error:_
![image](https://user-images.githubusercontent.com/67550369/159648053-90ce32fc-6739-4e14-9111-2359ae47a6b8.png)

