### PR TITLE
Feature/simplify & move some radios enums

### DIFF
--- a/Source/MEF/Switches.cs
+++ b/Source/MEF/Switches.cs
@@ -254,47 +254,6 @@
     /*
      *
      */
-    public enum CurrentUH1HRadioMode
-    {
-        INTERCOMM = 0,
-        VHFCOMM = 2,
-        UHF = 4,
-        VHFFM = 8,
-        VHFNAV = 16,
-        ADF = 32
-    }
-
-    public enum RadioPanelPZ69KnobsUH1H
-    {
-        UPPER_VHFCOMM = 0,
-        UPPER_UHF = 2,
-        UPPER_VHFNAV = 4,
-        UPPER_VHFFM = 8,
-        UPPER_ADF = 16,
-        UPPER_DME = 32,
-        UPPER_INTERCOMM = 64,
-        UPPER_SMALL_FREQ_WHEEL_INC = 128,
-        UPPER_SMALL_FREQ_WHEEL_DEC = 256,
-        UPPER_LARGE_FREQ_WHEEL_INC = 512,
-        UPPER_LARGE_FREQ_WHEEL_DEC = 1024,
-        UPPER_FREQ_SWITCH = 2056,
-        LOWER_VHFCOMM = 4096,
-        LOWER_UHF = 8192,
-        LOWER_VHFNAV = 16384,
-        LOWER_VHFFM = 32768,
-        LOWER_ADF = 65536,
-        LOWER_DME = 131072,
-        LOWER_INTERCOMM = 262144,
-        LOWER_SMALL_FREQ_WHEEL_INC = 8388608,
-        LOWER_SMALL_FREQ_WHEEL_DEC = 524288,
-        LOWER_LARGE_FREQ_WHEEL_INC = 1048576,
-        LOWER_LARGE_FREQ_WHEEL_DEC = 2097152,
-        LOWER_FREQ_SWITCH = 4194304
-    }
-
-    /*
-     *
-     */
     public enum CurrentSRSRadioMode
     {
         COM1 = 0,

--- a/Source/MEF/Switches.cs
+++ b/Source/MEF/Switches.cs
@@ -924,45 +924,4 @@
         LOWER_LARGE_FREQ_WHEEL_DEC = 2097152,
         LOWER_FREQ_SWITCH = 4194304
     }
-
-
-    public enum CurrentMi24PRadioMode
-    {
-        R863_MANUAL = 0,
-        R863_PRESET = 2,
-        YADRO1A = 4,
-        R828_PRESETS = 8,
-        ADF_ARK15_HIGH = 16,
-        DME_ARK15_LOW = 32,
-        SPU8 = 64,
-        NOUSE = 128
-    }
-
-    public enum RadioPanelPZ69KnobsMi24P
-    {
-        UPPER_R863_MANUAL = 0,      //COM1
-        UPPER_R863_PRESET = 2,      //COM2
-        UPPER_YADRO1A = 4,          //NAV1
-        UPPER_R828 = 8,             //NAV2
-        UPPER_ADF_ARK15 = 16,       //ADF
-        UPPER_ARK_UD = 32,          //DME_
-        UPPER_SPU8 = 64,            //XPDR
-        UPPER_SMALL_FREQ_WHEEL_INC = 128,
-        UPPER_SMALL_FREQ_WHEEL_DEC = 256,
-        UPPER_LARGE_FREQ_WHEEL_INC = 512,
-        UPPER_LARGE_FREQ_WHEEL_DEC = 1024,
-        UPPER_FREQ_SWITCH = 2056,
-        LOWER_R863_MANUAL = 4096,   //COM1
-        LOWER_R863_PRESET = 8192,   //COM2
-        LOWER_YADRO1A = 16384,      //NAV1
-        LOWER_R828 = 32768,          //NAV2
-        LOWER_ADF_ARK15 = 65536,    //ADF
-        LOWER_ARK_UD = 131072,      //DME_
-        LOWER_SPU8 = 262144,        //XPDR
-        LOWER_SMALL_FREQ_WHEEL_INC = 8388608,
-        LOWER_SMALL_FREQ_WHEEL_DEC = 524288,
-        LOWER_LARGE_FREQ_WHEEL_INC = 1048576,
-        LOWER_LARGE_FREQ_WHEEL_DEC = 2097152,
-        LOWER_FREQ_SWITCH = 4194304
-    }
 }

--- a/Source/MEF/Switches.cs
+++ b/Source/MEF/Switches.cs
@@ -528,48 +528,6 @@
         LowerFreqSwitch = 4194304
     }
 
-    /*
-     *
-     */
-    public enum CurrentMi8RadioMode
-    {
-        R863_MANUAL = 0,
-        R863_PRESET = 2,
-        YADRO1A = 4,
-        R828_PRESETS = 8,
-        ADF_ARK9 = 16,
-        ARK_UD = 32,
-        SPU7 = 64,
-        NOUSE = 128
-    }
-
-    public enum RadioPanelPZ69KnobsMi8
-    {
-        UPPER_R863_MANUAL = 0,      //COM1
-        UPPER_R863_PRESET = 2,      //COM2
-        UPPER_YADRO1A = 4,          //NAV1
-        UPPER_R828 = 8,             //NAV2
-        UPPER_ADF_ARK9 = 16,       //ADF
-        UPPER_ARK_UD = 32,          //DME_
-        UPPER_SPU7 = 64,            //XPDR
-        UPPER_SMALL_FREQ_WHEEL_INC = 128,
-        UPPER_SMALL_FREQ_WHEEL_DEC = 256,
-        UPPER_LARGE_FREQ_WHEEL_INC = 512,
-        UPPER_LARGE_FREQ_WHEEL_DEC = 1024,
-        UPPER_FREQ_SWITCH = 2056,
-        LOWER_R863_MANUAL = 4096,   //COM1
-        LOWER_R863_PRESET = 8192,   //COM2
-        LOWER_YADRO1A = 16384,      //NAV1
-        LOWER_R828 = 32768,          //NAV2
-        LOWER_ADF_ARK9 = 65536,    //ADF
-        LOWER_ARK_UD = 131072,      //DME_
-        LOWER_SPU7 = 262144,        //XPDR
-        LOWER_SMALL_FREQ_WHEEL_INC = 8388608,
-        LOWER_SMALL_FREQ_WHEEL_DEC = 524288,
-        LOWER_LARGE_FREQ_WHEEL_INC = 1048576,
-        LOWER_LARGE_FREQ_WHEEL_DEC = 2097152,
-        LOWER_FREQ_SWITCH = 4194304
-    }
 
     /*
      *

--- a/Source/MEF/Switches.cs
+++ b/Source/MEF/Switches.cs
@@ -925,45 +925,6 @@
         LOWER_FREQ_SWITCH = 4194304
     }
 
-    /*
-     *
-     */
-    public enum CurrentA10RadioMode
-    {
-        UHF = 0,
-        VHFFM = 2,
-        VHFAM = 4,
-        TACAN = 8,
-        ILS = 16
-    }
-
-    public enum RadioPanelPZ69KnobsA10C
-    {
-        UPPER_VHFAM = 0,
-        UPPER_UHF = 2,
-        UPPER_VHFFM = 4,
-        UPPER_ILS = 8,
-        UPPER_TACAN = 16,
-        UPPER_DME = 32,
-        UPPER_XPDR = 64,
-        UPPER_SMALL_FREQ_WHEEL_INC = 128,
-        UPPER_SMALL_FREQ_WHEEL_DEC = 256,
-        UPPER_LARGE_FREQ_WHEEL_INC = 512,
-        UPPER_LARGE_FREQ_WHEEL_DEC = 1024,
-        UPPER_FREQ_SWITCH = 2056,
-        LOWER_VHFAM = 4096,
-        LOWER_UHF = 8192,
-        LOWER_VHFFM = 16384,
-        LOWER_ILS = 32768,
-        LOWER_TACAN = 65536,
-        LOWER_DME = 131072,
-        LOWER_XPDR = 262144,
-        LOWER_SMALL_FREQ_WHEEL_INC = 8388608,
-        LOWER_SMALL_FREQ_WHEEL_DEC = 524288,
-        LOWER_LARGE_FREQ_WHEEL_INC = 1048576,
-        LOWER_LARGE_FREQ_WHEEL_DEC = 2097152,
-        LOWER_FREQ_SWITCH = 4194304
-    }
 
     public enum CurrentMi24PRadioMode
     {

--- a/Source/NonVisuals/Radios/Knobs/RadioPanelKnobA10C.cs
+++ b/Source/NonVisuals/Radios/Knobs/RadioPanelKnobA10C.cs
@@ -3,9 +3,35 @@
     using System;
     using System.Collections.Generic;
 
-    using MEF;
-
     using NonVisuals.Interfaces;
+
+    public enum RadioPanelPZ69KnobsA10C
+    {
+        UPPER_VHFAM,
+        UPPER_UHF,
+        UPPER_VHFFM,
+        UPPER_ILS,
+        UPPER_TACAN,
+        UPPER_DME,
+        UPPER_XPDR,
+        UPPER_SMALL_FREQ_WHEEL_INC,
+        UPPER_SMALL_FREQ_WHEEL_DEC,
+        UPPER_LARGE_FREQ_WHEEL_INC,
+        UPPER_LARGE_FREQ_WHEEL_DEC,
+        UPPER_FREQ_SWITCH,
+        LOWER_VHFAM,
+        LOWER_UHF,
+        LOWER_VHFFM,
+        LOWER_ILS,
+        LOWER_TACAN,
+        LOWER_DME,
+        LOWER_XPDR,
+        LOWER_SMALL_FREQ_WHEEL_INC,
+        LOWER_SMALL_FREQ_WHEEL_DEC,
+        LOWER_LARGE_FREQ_WHEEL_INC,
+        LOWER_LARGE_FREQ_WHEEL_DEC,
+        LOWER_FREQ_SWITCH
+    }
 
     public class RadioPanelKnobA10C : ISaitekPanelKnob
     {
@@ -36,32 +62,32 @@
             var result = new HashSet<ISaitekPanelKnob>
             {
                 // Group 0
-                new RadioPanelKnobA10C(2, Convert.ToInt32("1", 2), true, RadioPanelPZ69KnobsA10C.UPPER_SMALL_FREQ_WHEEL_INC),
-                new RadioPanelKnobA10C(2, Convert.ToInt32("10", 2), false, RadioPanelPZ69KnobsA10C.UPPER_SMALL_FREQ_WHEEL_DEC),
-                new RadioPanelKnobA10C(2, Convert.ToInt32("100", 2), true, RadioPanelPZ69KnobsA10C.UPPER_LARGE_FREQ_WHEEL_INC),
-                new RadioPanelKnobA10C(2, Convert.ToInt32("1000", 2), false, RadioPanelPZ69KnobsA10C.UPPER_LARGE_FREQ_WHEEL_DEC),
-                new RadioPanelKnobA10C(2, Convert.ToInt32("10000", 2), true, RadioPanelPZ69KnobsA10C.LOWER_SMALL_FREQ_WHEEL_INC),
-                new RadioPanelKnobA10C(2, Convert.ToInt32("100000", 2), false, RadioPanelPZ69KnobsA10C.LOWER_SMALL_FREQ_WHEEL_DEC),
-                new RadioPanelKnobA10C(2, Convert.ToInt32("1000000", 2), true, RadioPanelPZ69KnobsA10C.LOWER_LARGE_FREQ_WHEEL_INC),
-                new RadioPanelKnobA10C(2, Convert.ToInt32("10000000", 2), false, RadioPanelPZ69KnobsA10C.LOWER_LARGE_FREQ_WHEEL_DEC),
+                new RadioPanelKnobA10C(2, 1 << 0, true, RadioPanelPZ69KnobsA10C.UPPER_SMALL_FREQ_WHEEL_INC),
+                new RadioPanelKnobA10C(2, 1 << 1, false, RadioPanelPZ69KnobsA10C.UPPER_SMALL_FREQ_WHEEL_DEC),
+                new RadioPanelKnobA10C(2, 1 << 2, true, RadioPanelPZ69KnobsA10C.UPPER_LARGE_FREQ_WHEEL_INC),
+                new RadioPanelKnobA10C(2, 1 << 3, false, RadioPanelPZ69KnobsA10C.UPPER_LARGE_FREQ_WHEEL_DEC),
+                new RadioPanelKnobA10C(2, 1 << 4, true, RadioPanelPZ69KnobsA10C.LOWER_SMALL_FREQ_WHEEL_INC),
+                new RadioPanelKnobA10C(2, 1 << 5, false, RadioPanelPZ69KnobsA10C.LOWER_SMALL_FREQ_WHEEL_DEC),
+                new RadioPanelKnobA10C(2, 1 << 6, true, RadioPanelPZ69KnobsA10C.LOWER_LARGE_FREQ_WHEEL_INC),
+                new RadioPanelKnobA10C(2, 1 << 7, false, RadioPanelPZ69KnobsA10C.LOWER_LARGE_FREQ_WHEEL_DEC),
                 // Group 1
-                new RadioPanelKnobA10C(1, Convert.ToInt32("1", 2), true, RadioPanelPZ69KnobsA10C.LOWER_UHF),
-                new RadioPanelKnobA10C(1, Convert.ToInt32("10", 2), true, RadioPanelPZ69KnobsA10C.LOWER_VHFFM),
-                new RadioPanelKnobA10C(1, Convert.ToInt32("100", 2), true, RadioPanelPZ69KnobsA10C.LOWER_ILS),
-                new RadioPanelKnobA10C(1, Convert.ToInt32("1000", 2), true, RadioPanelPZ69KnobsA10C.LOWER_TACAN),
-                new RadioPanelKnobA10C(1, Convert.ToInt32("10000", 2), true, RadioPanelPZ69KnobsA10C.LOWER_DME),
-                new RadioPanelKnobA10C(1, Convert.ToInt32("100000", 2), true, RadioPanelPZ69KnobsA10C.LOWER_XPDR),
-                new RadioPanelKnobA10C(1, Convert.ToInt32("1000000", 2), true, RadioPanelPZ69KnobsA10C.UPPER_FREQ_SWITCH),
-                new RadioPanelKnobA10C(1, Convert.ToInt32("10000000", 2), true, RadioPanelPZ69KnobsA10C.LOWER_FREQ_SWITCH),
+                new RadioPanelKnobA10C(1, 1 << 0, true, RadioPanelPZ69KnobsA10C.LOWER_UHF),
+                new RadioPanelKnobA10C(1, 1 << 1, true, RadioPanelPZ69KnobsA10C.LOWER_VHFFM),
+                new RadioPanelKnobA10C(1, 1 << 2, true, RadioPanelPZ69KnobsA10C.LOWER_ILS),
+                new RadioPanelKnobA10C(1, 1 << 3, true, RadioPanelPZ69KnobsA10C.LOWER_TACAN),
+                new RadioPanelKnobA10C(1, 1 << 4, true, RadioPanelPZ69KnobsA10C.LOWER_DME),
+                new RadioPanelKnobA10C(1, 1 << 5, true, RadioPanelPZ69KnobsA10C.LOWER_XPDR),
+                new RadioPanelKnobA10C(1, 1 << 6, true, RadioPanelPZ69KnobsA10C.UPPER_FREQ_SWITCH),
+                new RadioPanelKnobA10C(1, 1 << 7, true, RadioPanelPZ69KnobsA10C.LOWER_FREQ_SWITCH),
                 // Group 2
-                new RadioPanelKnobA10C(0, Convert.ToInt32("1", 2), true, RadioPanelPZ69KnobsA10C.UPPER_VHFAM), // UPPER COM 1
-                new RadioPanelKnobA10C(0, Convert.ToInt32("10", 2), true, RadioPanelPZ69KnobsA10C.UPPER_UHF), // UPPER COM 2
-                new RadioPanelKnobA10C(0, Convert.ToInt32("100", 2), true, RadioPanelPZ69KnobsA10C.UPPER_VHFFM), // UPPER NAV 1
-                new RadioPanelKnobA10C(0, Convert.ToInt32("1000", 2), true, RadioPanelPZ69KnobsA10C.UPPER_ILS), // UPPER NAV 2
-                new RadioPanelKnobA10C(0, Convert.ToInt32("10000", 2), true, RadioPanelPZ69KnobsA10C.UPPER_TACAN), // UPPER ADF
-                new RadioPanelKnobA10C(0, Convert.ToInt32("100000", 2), true, RadioPanelPZ69KnobsA10C.UPPER_DME), // UPPER DME
-                new RadioPanelKnobA10C(0, Convert.ToInt32("1000000", 2), true, RadioPanelPZ69KnobsA10C.UPPER_XPDR), // UPPER XPDR
-                new RadioPanelKnobA10C(0, Convert.ToInt32("10000000", 2), true, RadioPanelPZ69KnobsA10C.LOWER_VHFAM) // LOWER COM 1 
+                new RadioPanelKnobA10C(0, 1 << 0, true, RadioPanelPZ69KnobsA10C.UPPER_VHFAM), // UPPER COM 1
+                new RadioPanelKnobA10C(0, 1 << 1, true, RadioPanelPZ69KnobsA10C.UPPER_UHF), // UPPER COM 2
+                new RadioPanelKnobA10C(0, 1 << 2, true, RadioPanelPZ69KnobsA10C.UPPER_VHFFM), // UPPER NAV 1
+                new RadioPanelKnobA10C(0, 1 << 3, true, RadioPanelPZ69KnobsA10C.UPPER_ILS), // UPPER NAV 2
+                new RadioPanelKnobA10C(0, 1 << 4, true, RadioPanelPZ69KnobsA10C.UPPER_TACAN), // UPPER ADF
+                new RadioPanelKnobA10C(0, 1 << 5, true, RadioPanelPZ69KnobsA10C.UPPER_DME), // UPPER DME
+                new RadioPanelKnobA10C(0, 1 << 6, true, RadioPanelPZ69KnobsA10C.UPPER_XPDR), // UPPER XPDR
+                new RadioPanelKnobA10C(0, 1 << 7, true, RadioPanelPZ69KnobsA10C.LOWER_VHFAM) // LOWER COM 1 
             };
 
             return result;

--- a/Source/NonVisuals/Radios/Knobs/RadioPanelKnobMi24P.cs
+++ b/Source/NonVisuals/Radios/Knobs/RadioPanelKnobMi24P.cs
@@ -1,10 +1,35 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using NonVisuals.Interfaces;
 
 namespace NonVisuals.Radios.Knobs
 {
-    using MEF;
+    public enum RadioPanelPZ69KnobsMi24P
+    {
+        UPPER_R863_MANUAL,      //COM1
+        UPPER_R863_PRESET,      //COM2
+        UPPER_YADRO1A,          //NAV1
+        UPPER_R828,             //NAV2
+        UPPER_ADF_ARK15,       //ADF
+        UPPER_ARK_UD,          //DME_
+        UPPER_SPU8,            //XPDR
+        UPPER_SMALL_FREQ_WHEEL_INC,
+        UPPER_SMALL_FREQ_WHEEL_DEC,
+        UPPER_LARGE_FREQ_WHEEL_INC,
+        UPPER_LARGE_FREQ_WHEEL_DEC,
+        UPPER_FREQ_SWITCH,
+        LOWER_R863_MANUAL,   //COM1
+        LOWER_R863_PRESET,   //COM2
+        LOWER_YADRO1A,      //NAV1
+        LOWER_R828,          //NAV2
+        LOWER_ADF_ARK15,    //ADF
+        LOWER_ARK_UD,      //DME_
+        LOWER_SPU8,        //XPDR
+        LOWER_SMALL_FREQ_WHEEL_INC,
+        LOWER_SMALL_FREQ_WHEEL_DEC,
+        LOWER_LARGE_FREQ_WHEEL_INC,
+        LOWER_LARGE_FREQ_WHEEL_DEC,
+        LOWER_FREQ_SWITCH
+    }
 
     public class RadioPanelKnobMi24P : ISaitekPanelKnob
     {
@@ -30,41 +55,34 @@ namespace NonVisuals.Radios.Knobs
             var result = new HashSet<ISaitekPanelKnob>
             {
                 //Group 0
-                new RadioPanelKnobMi24P(2, Convert.ToInt32("1", 2), true, RadioPanelPZ69KnobsMi24P.UPPER_SMALL_FREQ_WHEEL_INC),
-                new RadioPanelKnobMi24P(2, Convert.ToInt32("10", 2), false, RadioPanelPZ69KnobsMi24P.UPPER_SMALL_FREQ_WHEEL_DEC),
-                new RadioPanelKnobMi24P(2, Convert.ToInt32("100", 2), true, RadioPanelPZ69KnobsMi24P.UPPER_LARGE_FREQ_WHEEL_INC),
-                new RadioPanelKnobMi24P(2, Convert.ToInt32("1000", 2), false, RadioPanelPZ69KnobsMi24P.UPPER_LARGE_FREQ_WHEEL_DEC),
-                new RadioPanelKnobMi24P(2, Convert.ToInt32("10000", 2), true, RadioPanelPZ69KnobsMi24P.LOWER_SMALL_FREQ_WHEEL_INC),
-                new RadioPanelKnobMi24P(2, Convert.ToInt32("100000", 2), false, RadioPanelPZ69KnobsMi24P.LOWER_SMALL_FREQ_WHEEL_DEC),
-                new RadioPanelKnobMi24P(2, Convert.ToInt32("1000000", 2), true, RadioPanelPZ69KnobsMi24P.LOWER_LARGE_FREQ_WHEEL_INC),
-                new RadioPanelKnobMi24P(2, Convert.ToInt32("10000000", 2), false, RadioPanelPZ69KnobsMi24P.LOWER_LARGE_FREQ_WHEEL_DEC),
+                new RadioPanelKnobMi24P(2, 1 << 0, true, RadioPanelPZ69KnobsMi24P.UPPER_SMALL_FREQ_WHEEL_INC),
+                new RadioPanelKnobMi24P(2, 1 << 1, false, RadioPanelPZ69KnobsMi24P.UPPER_SMALL_FREQ_WHEEL_DEC),
+                new RadioPanelKnobMi24P(2, 1 << 2, true, RadioPanelPZ69KnobsMi24P.UPPER_LARGE_FREQ_WHEEL_INC),
+                new RadioPanelKnobMi24P(2, 1 << 3, false, RadioPanelPZ69KnobsMi24P.UPPER_LARGE_FREQ_WHEEL_DEC),
+                new RadioPanelKnobMi24P(2, 1 << 4, true, RadioPanelPZ69KnobsMi24P.LOWER_SMALL_FREQ_WHEEL_INC),
+                new RadioPanelKnobMi24P(2, 1 << 5, false, RadioPanelPZ69KnobsMi24P.LOWER_SMALL_FREQ_WHEEL_DEC),
+                new RadioPanelKnobMi24P(2, 1 << 6, true, RadioPanelPZ69KnobsMi24P.LOWER_LARGE_FREQ_WHEEL_INC),
+                new RadioPanelKnobMi24P(2, 1 << 7, false, RadioPanelPZ69KnobsMi24P.LOWER_LARGE_FREQ_WHEEL_DEC),
                 //Group 1
-                new RadioPanelKnobMi24P(1, Convert.ToInt32("1", 2), true, RadioPanelPZ69KnobsMi24P.LOWER_R863_PRESET), //LOWER COM2
-                new RadioPanelKnobMi24P(1, Convert.ToInt32("10", 2), true, RadioPanelPZ69KnobsMi24P.LOWER_YADRO1A), //LOWER NAV1
-                new RadioPanelKnobMi24P(1, Convert.ToInt32("100", 2), true, RadioPanelPZ69KnobsMi24P.LOWER_R828), //LOWER NAV2
-                new RadioPanelKnobMi24P(1, Convert.ToInt32("1000", 2), true, RadioPanelPZ69KnobsMi24P.LOWER_ADF_ARK15), //LOWER ADF
-                new RadioPanelKnobMi24P(1, Convert.ToInt32("10000", 2), true, RadioPanelPZ69KnobsMi24P.LOWER_ARK_UD), //LOWER DME
-                new RadioPanelKnobMi24P(1, Convert.ToInt32("100000", 2), true, RadioPanelPZ69KnobsMi24P.LOWER_SPU8), //LOWER XPDR
-                new RadioPanelKnobMi24P(1, Convert.ToInt32("1000000", 2), true, RadioPanelPZ69KnobsMi24P.UPPER_FREQ_SWITCH),
-                new RadioPanelKnobMi24P(1, Convert.ToInt32("10000000", 2), true, RadioPanelPZ69KnobsMi24P.LOWER_FREQ_SWITCH),
+                new RadioPanelKnobMi24P(1, 1 << 0, true, RadioPanelPZ69KnobsMi24P.LOWER_R863_PRESET), //LOWER COM2
+                new RadioPanelKnobMi24P(1, 1 << 1, true, RadioPanelPZ69KnobsMi24P.LOWER_YADRO1A), //LOWER NAV1
+                new RadioPanelKnobMi24P(1, 1 << 2, true, RadioPanelPZ69KnobsMi24P.LOWER_R828), //LOWER NAV2
+                new RadioPanelKnobMi24P(1, 1 << 3, true, RadioPanelPZ69KnobsMi24P.LOWER_ADF_ARK15), //LOWER ADF
+                new RadioPanelKnobMi24P(1, 1 << 4, true, RadioPanelPZ69KnobsMi24P.LOWER_ARK_UD), //LOWER DME
+                new RadioPanelKnobMi24P(1, 1 << 5, true, RadioPanelPZ69KnobsMi24P.LOWER_SPU8), //LOWER XPDR
+                new RadioPanelKnobMi24P(1, 1 << 6, true, RadioPanelPZ69KnobsMi24P.UPPER_FREQ_SWITCH),
+                new RadioPanelKnobMi24P(1, 1 << 7, true, RadioPanelPZ69KnobsMi24P.LOWER_FREQ_SWITCH),
                 //Group 2
-                new RadioPanelKnobMi24P(0, Convert.ToInt32("1", 2), true, RadioPanelPZ69KnobsMi24P.UPPER_R863_MANUAL), //UPPER COM1
-                new RadioPanelKnobMi24P(0, Convert.ToInt32("10", 2), true, RadioPanelPZ69KnobsMi24P.UPPER_R863_PRESET), //UPPER COM2
-                new RadioPanelKnobMi24P(0, Convert.ToInt32("100", 2), true, RadioPanelPZ69KnobsMi24P.UPPER_YADRO1A), //UPPER NAV1
-                new RadioPanelKnobMi24P(0, Convert.ToInt32("1000", 2), true, RadioPanelPZ69KnobsMi24P.UPPER_R828), //UPPER NAV2
-                new RadioPanelKnobMi24P(0, Convert.ToInt32("10000", 2), true, RadioPanelPZ69KnobsMi24P.UPPER_ADF_ARK15), //UPPER ADF
-                new RadioPanelKnobMi24P(0, Convert.ToInt32("100000", 2), true, RadioPanelPZ69KnobsMi24P.UPPER_ARK_UD), //UPPER DME
-                new RadioPanelKnobMi24P(0, Convert.ToInt32("1000000", 2), true, RadioPanelPZ69KnobsMi24P.UPPER_SPU8), //UPPER XPDR
-                new RadioPanelKnobMi24P(0, Convert.ToInt32("10000000", 2), true, RadioPanelPZ69KnobsMi24P.LOWER_R863_MANUAL) //LOWER COM1
+                new RadioPanelKnobMi24P(0, 1 << 0, true, RadioPanelPZ69KnobsMi24P.UPPER_R863_MANUAL), //UPPER COM1
+                new RadioPanelKnobMi24P(0, 1 << 1, true, RadioPanelPZ69KnobsMi24P.UPPER_R863_PRESET), //UPPER COM2
+                new RadioPanelKnobMi24P(0, 1 << 2, true, RadioPanelPZ69KnobsMi24P.UPPER_YADRO1A), //UPPER NAV1
+                new RadioPanelKnobMi24P(0, 1 << 3, true, RadioPanelPZ69KnobsMi24P.UPPER_R828), //UPPER NAV2
+                new RadioPanelKnobMi24P(0, 1 << 4, true, RadioPanelPZ69KnobsMi24P.UPPER_ADF_ARK15), //UPPER ADF
+                new RadioPanelKnobMi24P(0, 1 << 5, true, RadioPanelPZ69KnobsMi24P.UPPER_ARK_UD), //UPPER DME
+                new RadioPanelKnobMi24P(0, 1 << 6, true, RadioPanelPZ69KnobsMi24P.UPPER_SPU8), //UPPER XPDR
+                new RadioPanelKnobMi24P(0, 1 << 7, true, RadioPanelPZ69KnobsMi24P.LOWER_R863_MANUAL) //LOWER COM1
             };
-
             return result;
         }
-
-
-
-
     }
-
-
 }

--- a/Source/NonVisuals/Radios/Knobs/RadioPanelKnobMi8.cs
+++ b/Source/NonVisuals/Radios/Knobs/RadioPanelKnobMi8.cs
@@ -1,14 +1,41 @@
 ﻿namespace NonVisuals.Radios.Knobs
 {
-    using System;
     using System.Collections.Generic;
-
-    using MEF;
 
     using NonVisuals.Interfaces;
 
+    public enum RadioPanelPZ69KnobsMi8
+    {
+        UPPER_R863_MANUAL,      //COM1
+        UPPER_R863_PRESET,      //COM2
+        UPPER_YADRO1A,          //NAV1
+        UPPER_R828,             //NAV2
+        UPPER_ADF_ARK9,       //ADF
+        UPPER_ARK_UD,          //DME_
+        UPPER_SPU7,            //XPDR
+        UPPER_SMALL_FREQ_WHEEL_INC,
+        UPPER_SMALL_FREQ_WHEEL_DEC,
+        UPPER_LARGE_FREQ_WHEEL_INC,
+        UPPER_LARGE_FREQ_WHEEL_DEC,
+        UPPER_FREQ_SWITCH,
+        LOWER_R863_MANUAL,   //COM1
+        LOWER_R863_PRESET,   //COM2
+        LOWER_YADRO1A,      //NAV1
+        LOWER_R828,          //NAV2
+        LOWER_ADF_ARK9,    //ADF
+        LOWER_ARK_UD,      //DME_
+        LOWER_SPU7,        //XPDR
+        LOWER_SMALL_FREQ_WHEEL_INC,
+        LOWER_SMALL_FREQ_WHEEL_DEC,
+        LOWER_LARGE_FREQ_WHEEL_INC,
+        LOWER_LARGE_FREQ_WHEEL_DEC,
+        LOWER_FREQ_SWITCH
+    }
+
     public class RadioPanelKnobMi8 : ISaitekPanelKnob
     {
+      
+
         public RadioPanelKnobMi8(int group, int mask, bool isOn, RadioPanelPZ69KnobsMi8 radioPanelPZ69Knob)
         {
             Group = group;
@@ -31,32 +58,32 @@
             var result = new HashSet<ISaitekPanelKnob>
             {
                 // Group 0
-                new RadioPanelKnobMi8(2, Convert.ToInt32("1", 2), true, RadioPanelPZ69KnobsMi8.UPPER_SMALL_FREQ_WHEEL_INC),
-                new RadioPanelKnobMi8(2, Convert.ToInt32("10", 2), false, RadioPanelPZ69KnobsMi8.UPPER_SMALL_FREQ_WHEEL_DEC),
-                new RadioPanelKnobMi8(2, Convert.ToInt32("100", 2), true, RadioPanelPZ69KnobsMi8.UPPER_LARGE_FREQ_WHEEL_INC),
-                new RadioPanelKnobMi8(2, Convert.ToInt32("1000", 2), false, RadioPanelPZ69KnobsMi8.UPPER_LARGE_FREQ_WHEEL_DEC),
-                new RadioPanelKnobMi8(2, Convert.ToInt32("10000", 2), true, RadioPanelPZ69KnobsMi8.LOWER_SMALL_FREQ_WHEEL_INC),
-                new RadioPanelKnobMi8(2, Convert.ToInt32("100000", 2), false, RadioPanelPZ69KnobsMi8.LOWER_SMALL_FREQ_WHEEL_DEC),
-                new RadioPanelKnobMi8(2, Convert.ToInt32("1000000", 2), true, RadioPanelPZ69KnobsMi8.LOWER_LARGE_FREQ_WHEEL_INC),
-                new RadioPanelKnobMi8(2, Convert.ToInt32("10000000", 2), false, RadioPanelPZ69KnobsMi8.LOWER_LARGE_FREQ_WHEEL_DEC),
+                new RadioPanelKnobMi8(2, 1 << 0, true, RadioPanelPZ69KnobsMi8.UPPER_SMALL_FREQ_WHEEL_INC),
+                new RadioPanelKnobMi8(2, 1 << 1, false, RadioPanelPZ69KnobsMi8.UPPER_SMALL_FREQ_WHEEL_DEC),
+                new RadioPanelKnobMi8(2, 1 << 2, true, RadioPanelPZ69KnobsMi8.UPPER_LARGE_FREQ_WHEEL_INC),
+                new RadioPanelKnobMi8(2, 1 << 3, false, RadioPanelPZ69KnobsMi8.UPPER_LARGE_FREQ_WHEEL_DEC),
+                new RadioPanelKnobMi8(2, 1 << 4, true, RadioPanelPZ69KnobsMi8.LOWER_SMALL_FREQ_WHEEL_INC),
+                new RadioPanelKnobMi8(2, 1 << 5, false, RadioPanelPZ69KnobsMi8.LOWER_SMALL_FREQ_WHEEL_DEC),
+                new RadioPanelKnobMi8(2, 1 << 6, true, RadioPanelPZ69KnobsMi8.LOWER_LARGE_FREQ_WHEEL_INC),
+                new RadioPanelKnobMi8(2, 1 << 7, false, RadioPanelPZ69KnobsMi8.LOWER_LARGE_FREQ_WHEEL_DEC),
                 // Group 1
-                new RadioPanelKnobMi8(1, Convert.ToInt32("1", 2), true, RadioPanelPZ69KnobsMi8.LOWER_R863_PRESET), // LOWER COM2
-                new RadioPanelKnobMi8(1, Convert.ToInt32("10", 2), true, RadioPanelPZ69KnobsMi8.LOWER_YADRO1A), // LOWER NAV1
-                new RadioPanelKnobMi8(1, Convert.ToInt32("100", 2), true, RadioPanelPZ69KnobsMi8.LOWER_R828), // LOWER NAV2
-                new RadioPanelKnobMi8(1, Convert.ToInt32("1000", 2), true, RadioPanelPZ69KnobsMi8.LOWER_ADF_ARK9), // LOWER ADF
-                new RadioPanelKnobMi8(1, Convert.ToInt32("10000", 2), true, RadioPanelPZ69KnobsMi8.LOWER_ARK_UD), // LOWER DME
-                new RadioPanelKnobMi8(1, Convert.ToInt32("100000", 2), true, RadioPanelPZ69KnobsMi8.LOWER_SPU7), // LOWER XPDR
-                new RadioPanelKnobMi8(1, Convert.ToInt32("1000000", 2), true, RadioPanelPZ69KnobsMi8.UPPER_FREQ_SWITCH),
-                new RadioPanelKnobMi8(1, Convert.ToInt32("10000000", 2), true, RadioPanelPZ69KnobsMi8.LOWER_FREQ_SWITCH),
+                new RadioPanelKnobMi8(1, 1 << 0, true, RadioPanelPZ69KnobsMi8.LOWER_R863_PRESET), // LOWER COM2
+                new RadioPanelKnobMi8(1, 1 << 1, true, RadioPanelPZ69KnobsMi8.LOWER_YADRO1A), // LOWER NAV1
+                new RadioPanelKnobMi8(1, 1 << 2, true, RadioPanelPZ69KnobsMi8.LOWER_R828), // LOWER NAV2
+                new RadioPanelKnobMi8(1, 1 << 3, true, RadioPanelPZ69KnobsMi8.LOWER_ADF_ARK9), // LOWER ADF
+                new RadioPanelKnobMi8(1, 1 << 4, true, RadioPanelPZ69KnobsMi8.LOWER_ARK_UD), // LOWER DME
+                new RadioPanelKnobMi8(1, 1 << 5, true, RadioPanelPZ69KnobsMi8.LOWER_SPU7), // LOWER XPDR
+                new RadioPanelKnobMi8(1, 1 << 6, true, RadioPanelPZ69KnobsMi8.UPPER_FREQ_SWITCH),
+                new RadioPanelKnobMi8(1, 1 << 7, true, RadioPanelPZ69KnobsMi8.LOWER_FREQ_SWITCH),
                 // Group 2
-                new RadioPanelKnobMi8(0, Convert.ToInt32("1", 2), true, RadioPanelPZ69KnobsMi8.UPPER_R863_MANUAL), // UPPER COM1
-                new RadioPanelKnobMi8(0, Convert.ToInt32("10", 2), true, RadioPanelPZ69KnobsMi8.UPPER_R863_PRESET), // UPPER COM2
-                new RadioPanelKnobMi8(0, Convert.ToInt32("100", 2), true, RadioPanelPZ69KnobsMi8.UPPER_YADRO1A), // UPPER NAV1
-                new RadioPanelKnobMi8(0, Convert.ToInt32("1000", 2), true, RadioPanelPZ69KnobsMi8.UPPER_R828), // UPPER NAV2
-                new RadioPanelKnobMi8(0, Convert.ToInt32("10000", 2), true, RadioPanelPZ69KnobsMi8.UPPER_ADF_ARK9), // UPPER ADF
-                new RadioPanelKnobMi8(0, Convert.ToInt32("100000", 2), true, RadioPanelPZ69KnobsMi8.UPPER_ARK_UD), // UPPER DME
-                new RadioPanelKnobMi8(0, Convert.ToInt32("1000000", 2), true, RadioPanelPZ69KnobsMi8.UPPER_SPU7), // UPPER XPDR
-                new RadioPanelKnobMi8(0, Convert.ToInt32("10000000", 2), true, RadioPanelPZ69KnobsMi8.LOWER_R863_MANUAL) // LOWER COM1
+                new RadioPanelKnobMi8(0, 1 << 0, true, RadioPanelPZ69KnobsMi8.UPPER_R863_MANUAL), // UPPER COM1
+                new RadioPanelKnobMi8(0, 1 << 1, true, RadioPanelPZ69KnobsMi8.UPPER_R863_PRESET), // UPPER COM2
+                new RadioPanelKnobMi8(0, 1 << 2, true, RadioPanelPZ69KnobsMi8.UPPER_YADRO1A), // UPPER NAV1
+                new RadioPanelKnobMi8(0, 1 << 3, true, RadioPanelPZ69KnobsMi8.UPPER_R828), // UPPER NAV2
+                new RadioPanelKnobMi8(0, 1 << 4, true, RadioPanelPZ69KnobsMi8.UPPER_ADF_ARK9), // UPPER ADF
+                new RadioPanelKnobMi8(0, 1 << 5, true, RadioPanelPZ69KnobsMi8.UPPER_ARK_UD), // UPPER DME
+                new RadioPanelKnobMi8(0, 1 << 6, true, RadioPanelPZ69KnobsMi8.UPPER_SPU7), // UPPER XPDR
+                new RadioPanelKnobMi8(0, 1 << 7, true, RadioPanelPZ69KnobsMi8.LOWER_R863_MANUAL) // LOWER COM1
             };
 
             return result;

--- a/Source/NonVisuals/Radios/Knobs/RadioPanelKnobUH1H.cs
+++ b/Source/NonVisuals/Radios/Knobs/RadioPanelKnobUH1H.cs
@@ -1,11 +1,36 @@
 namespace NonVisuals.Radios.Knobs
 {
-    using System;
     using System.Collections.Generic;
 
-    using MEF;
-
     using NonVisuals.Interfaces;
+
+    public enum RadioPanelPZ69KnobsUH1H
+    {
+        UPPER_VHFCOMM,
+        UPPER_UHF,
+        UPPER_VHFNAV,
+        UPPER_VHFFM,
+        UPPER_ADF,
+        UPPER_DME,
+        UPPER_INTERCOMM,
+        UPPER_SMALL_FREQ_WHEEL_INC,
+        UPPER_SMALL_FREQ_WHEEL_DEC,
+        UPPER_LARGE_FREQ_WHEEL_INC,
+        UPPER_LARGE_FREQ_WHEEL_DEC,
+        UPPER_FREQ_SWITCH,
+        LOWER_VHFCOMM,
+        LOWER_UHF,
+        LOWER_VHFNAV,
+        LOWER_VHFFM,
+        LOWER_ADF,
+        LOWER_DME,
+        LOWER_INTERCOMM,
+        LOWER_SMALL_FREQ_WHEEL_INC,
+        LOWER_SMALL_FREQ_WHEEL_DEC,
+        LOWER_LARGE_FREQ_WHEEL_INC,
+        LOWER_LARGE_FREQ_WHEEL_DEC,
+        LOWER_FREQ_SWITCH
+    }
 
     public class RadioPanelKnobUH1H : ISaitekPanelKnob
     {
@@ -18,48 +43,43 @@ namespace NonVisuals.Radios.Knobs
         }
 
         public int Group { get; set; }
-
         public int Mask { get; set; }
-
         public bool IsOn { get; set; }
-
         public RadioPanelPZ69KnobsUH1H RadioPanelPZ69Knob { get; set; }
         
         public static HashSet<ISaitekPanelKnob> GetRadioPanelKnobs()
         {
             // true means clockwise turn
-            var result = new HashSet<ISaitekPanelKnob>
+            return new HashSet<ISaitekPanelKnob>
             {
                 // Group 0
-                new RadioPanelKnobUH1H(2, Convert.ToInt32("1", 2), true, RadioPanelPZ69KnobsUH1H.UPPER_SMALL_FREQ_WHEEL_INC),
-                new RadioPanelKnobUH1H(2, Convert.ToInt32("10", 2), false, RadioPanelPZ69KnobsUH1H.UPPER_SMALL_FREQ_WHEEL_DEC),
-                new RadioPanelKnobUH1H(2, Convert.ToInt32("100", 2), true, RadioPanelPZ69KnobsUH1H.UPPER_LARGE_FREQ_WHEEL_INC),
-                new RadioPanelKnobUH1H(2, Convert.ToInt32("1000", 2), false, RadioPanelPZ69KnobsUH1H.UPPER_LARGE_FREQ_WHEEL_DEC),
-                new RadioPanelKnobUH1H(2, Convert.ToInt32("10000", 2), true, RadioPanelPZ69KnobsUH1H.LOWER_SMALL_FREQ_WHEEL_INC),
-                new RadioPanelKnobUH1H(2, Convert.ToInt32("100000", 2), false, RadioPanelPZ69KnobsUH1H.LOWER_SMALL_FREQ_WHEEL_DEC),
-                new RadioPanelKnobUH1H(2, Convert.ToInt32("1000000", 2), true, RadioPanelPZ69KnobsUH1H.LOWER_LARGE_FREQ_WHEEL_INC),
-                new RadioPanelKnobUH1H(2, Convert.ToInt32("10000000", 2), false, RadioPanelPZ69KnobsUH1H.LOWER_LARGE_FREQ_WHEEL_DEC),
+                new RadioPanelKnobUH1H(2, 1 << 0, true, RadioPanelPZ69KnobsUH1H.UPPER_SMALL_FREQ_WHEEL_INC),
+                new RadioPanelKnobUH1H(2, 1 << 1, false, RadioPanelPZ69KnobsUH1H.UPPER_SMALL_FREQ_WHEEL_DEC),
+                new RadioPanelKnobUH1H(2, 1 << 2, true, RadioPanelPZ69KnobsUH1H.UPPER_LARGE_FREQ_WHEEL_INC),
+                new RadioPanelKnobUH1H(2, 1 << 3, false, RadioPanelPZ69KnobsUH1H.UPPER_LARGE_FREQ_WHEEL_DEC),
+                new RadioPanelKnobUH1H(2, 1 << 4, true, RadioPanelPZ69KnobsUH1H.LOWER_SMALL_FREQ_WHEEL_INC),
+                new RadioPanelKnobUH1H(2, 1 << 5, false, RadioPanelPZ69KnobsUH1H.LOWER_SMALL_FREQ_WHEEL_DEC),
+                new RadioPanelKnobUH1H(2, 1 << 6, true, RadioPanelPZ69KnobsUH1H.LOWER_LARGE_FREQ_WHEEL_INC),
+                new RadioPanelKnobUH1H(2, 1 << 7, false, RadioPanelPZ69KnobsUH1H.LOWER_LARGE_FREQ_WHEEL_DEC),
                 // Group 1
-                new RadioPanelKnobUH1H(1, Convert.ToInt32("1", 2), true, RadioPanelPZ69KnobsUH1H.LOWER_UHF),
-                new RadioPanelKnobUH1H(1, Convert.ToInt32("10", 2), true, RadioPanelPZ69KnobsUH1H.LOWER_VHFNAV),
-                new RadioPanelKnobUH1H(1, Convert.ToInt32("100", 2), true, RadioPanelPZ69KnobsUH1H.LOWER_VHFFM),
-                new RadioPanelKnobUH1H(1, Convert.ToInt32("1000", 2), true, RadioPanelPZ69KnobsUH1H.LOWER_ADF),
-                new RadioPanelKnobUH1H(1, Convert.ToInt32("10000", 2), true, RadioPanelPZ69KnobsUH1H.LOWER_DME),
-                new RadioPanelKnobUH1H(1, Convert.ToInt32("100000", 2), true, RadioPanelPZ69KnobsUH1H.LOWER_INTERCOMM),
-                new RadioPanelKnobUH1H(1, Convert.ToInt32("1000000", 2), true, RadioPanelPZ69KnobsUH1H.UPPER_FREQ_SWITCH),
-                new RadioPanelKnobUH1H(1, Convert.ToInt32("10000000", 2), true, RadioPanelPZ69KnobsUH1H.LOWER_FREQ_SWITCH),
+                new RadioPanelKnobUH1H(1, 1 << 0, true, RadioPanelPZ69KnobsUH1H.LOWER_UHF),
+                new RadioPanelKnobUH1H(1, 1 << 1, true, RadioPanelPZ69KnobsUH1H.LOWER_VHFNAV),
+                new RadioPanelKnobUH1H(1, 1 << 2, true, RadioPanelPZ69KnobsUH1H.LOWER_VHFFM),
+                new RadioPanelKnobUH1H(1, 1 << 3, true, RadioPanelPZ69KnobsUH1H.LOWER_ADF),
+                new RadioPanelKnobUH1H(1, 1 << 4, true, RadioPanelPZ69KnobsUH1H.LOWER_DME),
+                new RadioPanelKnobUH1H(1, 1 << 5, true, RadioPanelPZ69KnobsUH1H.LOWER_INTERCOMM),
+                new RadioPanelKnobUH1H(1, 1 << 6, true, RadioPanelPZ69KnobsUH1H.UPPER_FREQ_SWITCH),
+                new RadioPanelKnobUH1H(1, 1 << 7, true, RadioPanelPZ69KnobsUH1H.LOWER_FREQ_SWITCH),
                 // Group 2
-                new RadioPanelKnobUH1H(0, Convert.ToInt32("1", 2), true, RadioPanelPZ69KnobsUH1H.UPPER_VHFCOMM),
-                new RadioPanelKnobUH1H(0, Convert.ToInt32("10", 2), true, RadioPanelPZ69KnobsUH1H.UPPER_UHF),
-                new RadioPanelKnobUH1H(0, Convert.ToInt32("100", 2), true, RadioPanelPZ69KnobsUH1H.UPPER_VHFNAV),
-                new RadioPanelKnobUH1H(0, Convert.ToInt32("1000", 2), true, RadioPanelPZ69KnobsUH1H.UPPER_VHFFM),
-                new RadioPanelKnobUH1H(0, Convert.ToInt32("10000", 2), true, RadioPanelPZ69KnobsUH1H.UPPER_ADF),
-                new RadioPanelKnobUH1H(0, Convert.ToInt32("100000", 2), true, RadioPanelPZ69KnobsUH1H.UPPER_DME),
-                new RadioPanelKnobUH1H(0, Convert.ToInt32("1000000", 2), true, RadioPanelPZ69KnobsUH1H.UPPER_INTERCOMM),
-                new RadioPanelKnobUH1H(0, Convert.ToInt32("10000000", 2), true, RadioPanelPZ69KnobsUH1H.LOWER_VHFCOMM)
+                new RadioPanelKnobUH1H(0, 1 << 0, true, RadioPanelPZ69KnobsUH1H.UPPER_VHFCOMM),
+                new RadioPanelKnobUH1H(0, 1 << 1, true, RadioPanelPZ69KnobsUH1H.UPPER_UHF),
+                new RadioPanelKnobUH1H(0, 1 << 2, true, RadioPanelPZ69KnobsUH1H.UPPER_VHFNAV),
+                new RadioPanelKnobUH1H(0, 1 << 3, true, RadioPanelPZ69KnobsUH1H.UPPER_VHFFM),
+                new RadioPanelKnobUH1H(0, 1 << 4, true, RadioPanelPZ69KnobsUH1H.UPPER_ADF),
+                new RadioPanelKnobUH1H(0, 1 << 5, true, RadioPanelPZ69KnobsUH1H.UPPER_DME),
+                new RadioPanelKnobUH1H(0, 1 << 6, true, RadioPanelPZ69KnobsUH1H.UPPER_INTERCOMM),
+                new RadioPanelKnobUH1H(0, 1 << 7, true, RadioPanelPZ69KnobsUH1H.LOWER_VHFCOMM)
             };
-
-            return result;
         }
     }
 }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69A10C.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69A10C.cs
@@ -18,6 +18,15 @@
 
     public class RadioPanelPZ69A10C : RadioPanelPZ69Base, IDCSBIOSStringListener
     {
+        private enum CurrentA10RadioMode
+        {
+            UHF,
+            VHFFM,
+            VHFAM,
+            TACAN,
+            ILS
+        }
+
         private CurrentA10RadioMode _currentUpperRadioMode = CurrentA10RadioMode.UHF;
         private CurrentA10RadioMode _currentLowerRadioMode = CurrentA10RadioMode.UHF;
 

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Mi24P.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Mi24P.cs
@@ -16,6 +16,18 @@
 
     public class RadioPanelPZ69Mi24P : RadioPanelPZ69Base, IDCSBIOSStringListener
     {
+        private enum CurrentMi24PRadioMode
+        {
+            R863_MANUAL,
+            R863_PRESET,
+            YADRO1A,
+            R828_PRESETS,
+            ADF_ARK15_HIGH,
+            DME_ARK15_LOW,
+            SPU8,
+            NOUSE
+        }
+
         private CurrentMi24PRadioMode _currentUpperRadioMode = CurrentMi24PRadioMode.R863_MANUAL;
         private CurrentMi24PRadioMode _currentLowerRadioMode = CurrentMi24PRadioMode.R863_MANUAL;
         const int CHANGE_VALUE = 10;

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Mi8.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Mi8.cs
@@ -19,6 +19,18 @@
 
     public class RadioPanelPZ69Mi8 : RadioPanelPZ69Base, IDCSBIOSStringListener
     {
+        private enum CurrentMi8RadioMode
+        {
+            R863_MANUAL,
+            R863_PRESET,
+            YADRO1A,
+            R828_PRESETS,
+            ADF_ARK9,
+            ARK_UD,
+            SPU7,
+            NOUSE
+        }
+
         private CurrentMi8RadioMode _currentUpperRadioMode = CurrentMi8RadioMode.R863_MANUAL;
         private CurrentMi8RadioMode _currentLowerRadioMode = CurrentMi8RadioMode.R863_MANUAL;
 

--- a/Source/NonVisuals/Radios/RadioPanelPZ69UH1H.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69UH1H.cs
@@ -19,6 +19,16 @@ namespace NonVisuals.Radios
 
     public class RadioPanelPZ69UH1H : RadioPanelPZ69Base, IDCSBIOSStringListener
     {
+        private enum CurrentUH1HRadioMode
+        {
+            INTERCOMM,
+            VHFCOMM,
+            UHF,
+            VHFFM,
+            VHFNAV,
+            ADF
+        }
+
         private CurrentUH1HRadioMode _currentUpperRadioMode = CurrentUH1HRadioMode.UHF;
         private CurrentUH1HRadioMode _currentLowerRadioMode = CurrentUH1HRadioMode.UHF;
 


### PR DESCRIPTION
Moving & simplifying some radio enum:

- Remove 1 dependency to MEF lib in RadioPanelKnobXXXX.cs
- Increase security with private for CurrentXXXXRadiomode enum
- Removed unnecessary bit flags (imho) for those enums
- Reduce the file size of the Switches.cs file
- Change group init with left shift instead of Convert.ToInt32("100000", 2). More clearer code 

I tested on The Mi24p and everything looks fine.
In this PR I already made the changes for testing to :
* UH1H 
* MI24P
* A10C
* MI8

If it's OK, I'll do the rest of the airframes in the next PR. 
