### PR TITLE
[Radios] Reduce line count - Standardize

### DIFF
--- a/Source/NonVisuals/Radios/RadioPanelPZ69A10C.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69A10C.cs
@@ -700,7 +700,6 @@
                                     {
                                         SendVhfAmToDCSBIOS();
                                     }
-
                                     break;
                                 }
 
@@ -710,7 +709,6 @@
                                     {
                                         SendUhfToDCSBIOS();
                                     }
-
                                     break;
                                 }
 
@@ -720,7 +718,6 @@
                                     {
                                         SendVhfFmToDCSBIOS();
                                     }
-
                                     break;
                                 }
 
@@ -749,7 +746,6 @@
                                     {
                                         SendVhfAmToDCSBIOS();
                                     }
-
                                     break;
                                 }
 
@@ -759,7 +755,6 @@
                                     {
                                         SendUhfToDCSBIOS();
                                     }
-
                                     break;
                                 }
 
@@ -769,7 +764,6 @@
                                     {
                                         SendVhfFmToDCSBIOS();
                                     }
-
                                     break;
                                 }
 
@@ -844,39 +838,14 @@
                 tmp = int.Parse(frequencyAsString.Substring(5, 1));
             }
 
-            switch (tmp)
+            desiredPositionDial4 = tmp switch
             {
-                case 0:
-                    {
-                        desiredPositionDial4 = 0;
-                        break;
-                    }
-
-                case 2:
-                    {
-                        desiredPositionDial4 = 1;
-                        break;
-                    }
-
-                case 5:
-                    {
-                        desiredPositionDial4 = 2;
-                        break;
-                    }
-
-                case 7:
-                    {
-                        desiredPositionDial4 = 3;
-                        break;
-                    }
-
-                default:
-                    {
-                        // Safeguard in case it is in a invalid position
-                        desiredPositionDial4 = 0;
-                        break;
-                    }
-            }
+                0 => 0,
+                2 => 1,
+                5 => 2,
+                7 => 3,
+                _ => 0
+            };
 
             // #1
             _shutdownVHFAMThread = true;
@@ -1149,7 +1118,7 @@
 
                 default:
                     {
-                        throw new Exception("Failed to find separator in frequency string " + frequencyAsString);
+                        throw new Exception($"Failed to find separator in frequency string {frequencyAsString}");
                     }
             }
 
@@ -1494,32 +1463,15 @@
                 desiredPositionDial2 = int.Parse(frequencyAsString.Substring(1, 1));
                 desiredPositionDial3 = int.Parse(frequencyAsString.Substring(3, 1));
                 var tmpPosition = int.Parse(frequencyAsString.Substring(4, 2));
-                switch (tmpPosition)
+
+                desiredPositionDial4 = tmpPosition switch
                 {
-                    case 0:
-                        {
-                            desiredPositionDial4 = 0;
-                            break;
-                        }
+                    0 => 0,
+                    25 => 1,
+                    50 => 2,
+                    75 => 3
+                };
 
-                    case 25:
-                        {
-                            desiredPositionDial4 = 1;
-                            break;
-                        }
-
-                    case 50:
-                        {
-                            desiredPositionDial4 = 2;
-                            break;
-                        }
-
-                    case 75:
-                        {
-                            desiredPositionDial4 = 3;
-                            break;
-                        }
-                }
             }
             else
             {
@@ -2823,71 +2775,19 @@
                                     case CurrentA10RadioMode.ILS:
                                         {
                                             // "10" "15" "30" "35" "50" "55" "70" "75" "90" "95"
-                                            switch (_ilsSmallFrequencyStandby)
-                                            {
-                                                case 10:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 15;
-                                                        break;
-                                                    }
-
-                                                case 15:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 30;
-                                                        break;
-                                                    }
-
-                                                case 30:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 35;
-                                                        break;
-                                                    }
-
-                                                case 35:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 50;
-                                                        break;
-                                                    }
-
-                                                case 50:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 55;
-                                                        break;
-                                                    }
-
-                                                case 55:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 70;
-                                                        break;
-                                                    }
-
-                                                case 70:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 75;
-                                                        break;
-                                                    }
-
-                                                case 75:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 90;
-                                                        break;
-                                                    }
-
-                                                case 90:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 95;
-                                                        break;
-                                                    }
-
-                                                case 95:
-                                                case 100:
-                                                case 105:
-                                                    {
-                                                        // Just safe guard in case it pops above the limit. Happened to VHF AM for some !?!?!? reason.
-                                                        _ilsSmallFrequencyStandby = 10;
-                                                        break;
-                                                    }
-                                            }
+                                            _ilsSmallFrequencyStandby = _ilsSmallFrequencyStandby switch 
+                                            { 
+                                                10 => 15,
+                                                15 => 30,
+                                                30 => 35,
+                                                35 => 50,
+                                                50 => 55,
+                                                55 => 70,
+                                                70 => 75,
+                                                75 => 90,
+                                                90 => 95,
+                                                95 or 100 or 105 => 10 // Just safe guard in case it pops above the limit. Happened to VHF AM for some !?!?!? reason.
+                                            };
                                             break;
                                         }
 
@@ -2984,70 +2884,19 @@
                                     case CurrentA10RadioMode.ILS:
                                         {
                                             // "10" "15" "30" "35" "50" "55" "70" "75" "90" "95"
-                                            switch (_ilsSmallFrequencyStandby)
+                                            _ilsSmallFrequencyStandby = _ilsSmallFrequencyStandby switch
                                             {
-                                                case 0:
-                                                case 5:
-                                                case 10:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 95;
-                                                        break;
-                                                    }
-
-                                                case 15:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 10;
-                                                        break;
-                                                    }
-
-                                                case 30:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 15;
-                                                        break;
-                                                    }
-
-                                                case 35:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 30;
-                                                        break;
-                                                    }
-
-                                                case 50:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 35;
-                                                        break;
-                                                    }
-
-                                                case 55:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 50;
-                                                        break;
-                                                    }
-
-                                                case 70:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 55;
-                                                        break;
-                                                    }
-
-                                                case 75:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 70;
-                                                        break;
-                                                    }
-
-                                                case 90:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 75;
-                                                        break;
-                                                    }
-
-                                                case 95:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 90;
-                                                        break;
-                                                    }
-                                            }
+                                                0 or 5 or 10 => 95,
+                                                15 => 10,
+                                                30 => 15,
+                                                35 => 30,
+                                                50 => 35,
+                                                55 => 50,
+                                                70 => 55,
+                                                75 => 70,
+                                                90 => 75,
+                                                95 => 90
+                                            };
                                             break;
                                         }
 
@@ -3401,71 +3250,19 @@
                                     case CurrentA10RadioMode.ILS:
                                         {
                                             // "10" "15" "30" "35" "50" "55" "70" "75" "90" "95"
-                                            switch (_ilsSmallFrequencyStandby)
+                                            _ilsSmallFrequencyStandby = _ilsSmallFrequencyStandby switch
                                             {
-                                                case 10:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 15;
-                                                        break;
-                                                    }
-
-                                                case 15:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 30;
-                                                        break;
-                                                    }
-
-                                                case 30:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 35;
-                                                        break;
-                                                    }
-
-                                                case 35:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 50;
-                                                        break;
-                                                    }
-
-                                                case 50:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 55;
-                                                        break;
-                                                    }
-
-                                                case 55:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 70;
-                                                        break;
-                                                    }
-
-                                                case 70:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 75;
-                                                        break;
-                                                    }
-
-                                                case 75:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 90;
-                                                        break;
-                                                    }
-
-                                                case 90:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 95;
-                                                        break;
-                                                    }
-
-                                                case 95:
-                                                case 100:
-                                                case 105:
-                                                    {
-                                                        // Just safe guard in case it pops above the limit. Happened to VHF AM for some !?!?!? reason.
-                                                        _ilsSmallFrequencyStandby = 10;
-                                                        break;
-                                                    }
-                                            }
+                                                10 => 15,
+                                                15 => 30,
+                                                30 => 35,
+                                                35 => 50,
+                                                50 => 55,
+                                                55 => 70,
+                                                70 => 75,
+                                                75 => 90,
+                                                90 => 95,
+                                                95 or 100 or 105 => 10 // Just safe guard in case it pops above the limit. Happened to VHF AM for some !?!?!? reason.
+                                            };
                                             break;
                                         }
 
@@ -3562,70 +3359,19 @@
                                     case CurrentA10RadioMode.ILS:
                                         {
                                             // "10" "15" "30" "35" "50" "55" "70" "75" "90" "95"
-                                            switch (_ilsSmallFrequencyStandby)
+                                            _ilsSmallFrequencyStandby = _ilsSmallFrequencyStandby switch
                                             {
-                                                case 0:
-                                                case 5:
-                                                case 10:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 95;
-                                                        break;
-                                                    }
-
-                                                case 15:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 10;
-                                                        break;
-                                                    }
-
-                                                case 30:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 15;
-                                                        break;
-                                                    }
-
-                                                case 35:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 30;
-                                                        break;
-                                                    }
-
-                                                case 50:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 35;
-                                                        break;
-                                                    }
-
-                                                case 55:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 50;
-                                                        break;
-                                                    }
-
-                                                case 70:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 55;
-                                                        break;
-                                                    }
-
-                                                case 75:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 70;
-                                                        break;
-                                                    }
-
-                                                case 90:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 75;
-                                                        break;
-                                                    }
-
-                                                case 95:
-                                                    {
-                                                        _ilsSmallFrequencyStandby = 90;
-                                                        break;
-                                                    }
-                                            }
+                                                0 or 5 or 10 => 95,
+                                                15 => 10,
+                                                30 => 15,
+                                                35 => 30,
+                                                50 => 35,
+                                                55 => 50,
+                                                70 => 55,
+                                                75 => 70,
+                                                90 => 75,
+                                                95 => 90
+                                            };
                                             break;
                                         }
 
@@ -4153,74 +3899,22 @@
             {
                 case 1:
                     {
-                        switch (position)
+                        return position switch
                         {
-                            case 0:
-                                {
-                                    return "3";
-                                }
-
-                            case 1:
-                                {
-                                    return "4";
-                                }
-
-                            case 2:
-                                {
-                                    return "5";
-                                }
-
-                            case 3:
-                                {
-                                    return "6";
-                                }
-
-                            case 4:
-                                {
-                                    return "7";
-                                }
-
-                            case 5:
-                                {
-                                    return "8";
-                                }
-
-                            case 6:
-                                {
-                                    return "9";
-                                }
-
-                            case 7:
-                                {
-                                    return "10";
-                                }
-
-                            case 8:
-                                {
-                                    return "11";
-                                }
-
-                            case 9:
-                                {
-                                    return "12";
-                                }
-
-                            case 10:
-                                {
-                                    return "13";
-                                }
-
-                            case 11:
-                                {
-                                    return "14";
-                                }
-
-                            case 12:
-                                {
-                                    return "15";
-                                }
-                        }
-                        break;
+                            0 => "3",
+                            1 => "4",
+                            2 => "5",
+                            3 => "6",
+                            4 => "7",
+                            5 => "8",
+                            6 => "9",
+                            7 => "10",
+                            8 => "11",
+                            9 => "12",
+                            10 => "13",
+                            11 => "14",
+                            12 => "15"
+                        };
                     }
 
                 case 2:
@@ -4235,33 +3929,16 @@
 
                 case 4:
                     {
-                        switch (position)
+                        // "00" "25" "50" "75", 0 2 5 7 used.
+                        // Pos     0    1    2    3
+                        return position switch
                         {
-                            // "00" "25" "50" "75", 0 2 5 7 used.
-                            // Pos     0    1    2    3
-                            case 0:
-                                {
-                                    return "0";
-                                }
-
-                            case 1:
-                                {
-                                    return "2";
-                                }
-
-                            case 2:
-                                {
-                                    return "5";
-                                }
-
-                            case 3:
-                                {
-                                    return "7";
-                                }
-                        }
+                            0 => "0",
+                            1 => "2",
+                            2 => "5",
+                            3 => "7"                        
+                        };
                     }
-
-                    break;
             }
             return string.Empty;
         }
@@ -4289,25 +3966,12 @@
             {
                 case 1:
                     {
-                        switch (position)
+                        return position switch
                         {
-                            case 0:
-                                {
-                                    return "2";
-                                }
-
-                            case 1:
-                                {
-                                    return "3";
-                                }
-
-                            case 2:
-                                {
-                                    // throw new NotImplementedException("check how A should be treated.");
-                                    return "0";// should be "A"
-                                }
-                        }
-                        break;
+                            0 => "2",
+                            1 => "3",
+                            2 => "0" // should be "A" // throw new NotImplementedException("check how A should be treated.");
+                        };
                     }
 
                 case 2:
@@ -4319,33 +3983,16 @@
 
                 case 5:
                     {
-                        switch (position)
+                        // "00" "25" "50" "75", only "00" and "50" used.
+                        // Pos     0    1    2    3
+                        return position switch
                         {
-                            // "00" "25" "50" "75", only "00" and "50" used.
-                            // Pos     0    1    2    3
-                            case 0:
-                                {
-                                    return "00";
-                                }
-
-                            case 1:
-                                {
-                                    return "25";
-                                }
-
-                            case 2:
-                                {
-                                    return "50";
-                                }
-
-                            case 3:
-                                {
-                                    return "75";
-                                }
-                        }
+                            0 => "00",
+                            1 => "25",
+                            2 => "50",
+                            3 => "75"
+                        };
                     }
-
-                    break;
             }
 
             return string.Empty;
@@ -4371,74 +4018,22 @@
             {
                 case 1:
                     {
-                        switch (position)
+                        return position switch
                         {
-                            case 0:
-                                {
-                                    return "3";
-                                }
-
-                            case 1:
-                                {
-                                    return "4";
-                                }
-
-                            case 2:
-                                {
-                                    return "5";
-                                }
-
-                            case 3:
-                                {
-                                    return "6";
-                                }
-
-                            case 4:
-                                {
-                                    return "7";
-                                }
-
-                            case 5:
-                                {
-                                    return "8";
-                                }
-
-                            case 6:
-                                {
-                                    return "9";
-                                }
-
-                            case 7:
-                                {
-                                    return "10";
-                                }
-
-                            case 8:
-                                {
-                                    return "11";
-                                }
-
-                            case 9:
-                                {
-                                    return "12";
-                                }
-
-                            case 10:
-                                {
-                                    return "13";
-                                }
-
-                            case 11:
-                                {
-                                    return "14";
-                                }
-
-                            case 12:
-                                {
-                                    return "15";
-                                }
-                        }
-                        break;
+                            0 => "3",
+                            1 => "4",
+                            2 => "5",
+                            3 => "6",
+                            4 => "7",
+                            5 => "8",
+                            6 => "9",
+                            7 => "10",
+                            8 => "11",
+                            9 => "12",
+                            10 => "13",
+                            11 => "14",
+                            12 => "15"
+                        };                   
                     }
 
                 case 2:
@@ -4453,33 +4048,16 @@
 
                 case 4:
                     {
-                        switch (position)
+                        // "00" "25" "50" "75"
+                        // Pos     0    1    2    3
+                        return position switch
                         {
-                            // "00" "25" "50" "75"
-                            // Pos     0    1    2    3
-                            case 0:
-                                {
-                                    return "0";
-                                }
-
-                            case 1:
-                                {
-                                    return "25";
-                                }
-
-                            case 2:
-                                {
-                                    return "50";
-                                }
-
-                            case 3:
-                                {
-                                    return "75";
-                                }
-                        }
+                            0 => "00",
+                            1 => "25",
+                            2 => "50",
+                            3 => "75"
+                        };
                     }
-
-                    break;
             }
 
             return string.Empty;
@@ -4495,92 +4073,34 @@
             {
                 case 1:
                     {
-                        switch (position)
+                        return position switch
                         {
-                            case 0:
-                                {
-                                    return "108";
-                                }
-
-                            case 1:
-                                {
-                                    return "109";
-                                }
-
-                            case 2:
-                                {
-                                    return "110";
-                                }
-
-                            case 3:
-                                {
-                                    return "111";
-                                }
-                        }
-                        break;
+                            0 => "108",
+                            1 => "109",
+                            2 => "110",
+                            3 => "111"
+                        };
                     }
 
                 case 2:
                     {
                         // 2 Khz   "10" "15" "30" "35" "50" "55" "70" "75" "90" "95"
                         // 0    1    2    3    4    5    6    7    8    9
-                        switch (position)
+                        return position switch
                         {
-                            case 0:
-                                {
-                                    return "10";
-                                }
-
-                            case 1:
-                                {
-                                    return "15";
-                                }
-
-                            case 2:
-                                {
-                                    return "30";
-                                }
-
-                            case 3:
-                                {
-                                    return "35";
-                                }
-
-                            case 4:
-                                {
-                                    return "50";
-                                }
-
-                            case 5:
-                                {
-                                    return "55";
-                                }
-
-                            case 6:
-                                {
-                                    return "70";
-                                }
-
-                            case 7:
-                                {
-                                    return "75";
-                                }
-
-                            case 8:
-                                {
-                                    return "90";
-                                }
-
-                            case 9:
-                                {
-                                    return "95";
-                                }
-                        }
+                            0 => "10",
+                            1 => "15",
+                            2 => "30",
+                            3 => "35",
+                            4 => "50",
+                            5 => "55",
+                            6 => "70",
+                            7 => "75",
+                            8 => "90",
+                            9 => "95"
+                        };
                     }
-
-                    break;
             }
-
             return string.Empty;
         }
 
@@ -4594,90 +4114,33 @@
             {
                 case 1:
                     {
-                        switch (freq)
+                        return freq switch
                         {
-                            case 108:
-                                {
-                                    return 0;
-                                }
-
-                            case 109:
-                                {
-                                    return 1;
-                                }
-
-                            case 110:
-                                {
-                                    return 2;
-                                }
-
-                            case 111:
-                                {
-                                    return 3;
-                                }
-                        }
-                        break;
+                            108 => 0,
+                            109 => 1,
+                            110 => 2,
+                            111 => 3
+                        };
                     }
 
                 case 2:
                     {
                         // 2 Khz   "10" "15" "30" "35" "50" "55" "70" "75" "90" "95"
                         // 0    1    2    3    4    5    6    7    8    9
-                        switch (freq)
+                        return freq switch
                         {
-                            case 10:
-                                {
-                                    return 0;
-                                }
-
-                            case 15:
-                                {
-                                    return 1;
-                                }
-
-                            case 30:
-                                {
-                                    return 2;
-                                }
-
-                            case 35:
-                                {
-                                    return 3;
-                                }
-
-                            case 50:
-                                {
-                                    return 4;
-                                }
-
-                            case 55:
-                                {
-                                    return 5;
-                                }
-
-                            case 70:
-                                {
-                                    return 6;
-                                }
-
-                            case 75:
-                                {
-                                    return 7;
-                                }
-
-                            case 90:
-                                {
-                                    return 8;
-                                }
-
-                            case 95:
-                                {
-                                    return 9;
-                                }
-                        }
+                            10 => 0,
+                            15 => 1,
+                            30 => 2,
+                            35 => 3,
+                            50 => 4,
+                            55 => 5,
+                            70 => 6,
+                            75 => 7,
+                            90 => 8,
+                            95 => 9
+                        };
                     }
-
-                    break;
             }
             return 0;
         }
@@ -5529,33 +4992,13 @@
                         {
                             uint dial4 = 0;
 
-                            switch (_vhfAmCockpitFreq4DialPos)
+                            dial4 = _vhfAmCockpitFreq4DialPos switch
                             {
-                                case 0:
-                                    {
-                                        dial4 = 0;
-                                        break;
-                                    }
-
-                                case 1:
-                                    {
-                                        dial4 = 25;
-                                        break;
-                                    }
-
-                                case 2:
-                                    {
-                                        // 25
-                                        dial4 = 50;
-                                        break;
-                                    }
-
-                                case 3:
-                                    {
-                                        dial4 = 75;
-                                        break;
-                                    }
-                            }
+                                0 => 0,
+                                1 => 25,
+                                2 => 50,
+                                3 => 75
+                            };                            
                             _vhfAmSavedCockpitBigFrequency = double.Parse((_vhfAmCockpitFreq1DialPos + 3) + _vhfAmCockpitFreq2DialPos.ToString(), NumberFormatInfoFullDisplay);
                             _vhfAmSavedCockpitSmallFrequency = double.Parse(_vhfAmCockpitFreq3DialPos + dial4.ToString(NumberFormatInfoFullDisplay).PadLeft(2, '0'), NumberFormatInfoFullDisplay);
                         }
@@ -5670,32 +5113,14 @@
                         lock (_lockVhfFmDialsObject4)
                         {
                             uint dial4 = 0;
-                            switch (_vhfFmCockpitFreq4DialPos)
+                            dial4 = _vhfFmCockpitFreq4DialPos switch
                             {
-                                case 0:
-                                    {
-                                        dial4 = 0;
-                                        break;
-                                    }
-
-                                case 1:
-                                    {
-                                        dial4 = 25;
-                                        break;
-                                    }
-
-                                case 2:
-                                    {
-                                        dial4 = 50;
-                                        break;
-                                    }
-
-                                case 3:
-                                    {
-                                        dial4 = 75;
-                                        break;
-                                    }
-                            }
+                                0 => 0,
+                                1 => 25,
+                                2 => 50,
+                                3 => 75
+                            };
+                           
                             _vhfFmSavedCockpitBigFrequency = uint.Parse((_vhfFmCockpitFreq1DialPos + 3) + _vhfFmCockpitFreq2DialPos.ToString(), NumberFormatInfoFullDisplay);
                             _vhfFmSavedCockpitSmallFrequency = uint.Parse((_vhfFmCockpitFreq3DialPos.ToString() + dial4).PadLeft(3, '0'), NumberFormatInfoFullDisplay);
                         }
@@ -5824,7 +5249,5 @@
         public override void AddOrUpdateOSCommandBinding(PanelSwitchOnOff panelSwitchOnOff, OSCommand operatingSystemCommand)
         {
         }
-
     }
-
 }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69A10C.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69A10C.cs
@@ -42,10 +42,10 @@
         private double _vhfAmSmallFrequencyStandby;
         private double _vhfAmSavedCockpitBigFrequency;
         private double _vhfAmSavedCockpitSmallFrequency;
-        private readonly object _lockVhfAmDialsObject1 = new object();
-        private readonly object _lockVhfAmDialsObject2 = new object();
-        private readonly object _lockVhfAmDialsObject3 = new object();
-        private readonly object _lockVhfAmDialsObject4 = new object();
+        private readonly object _lockVhfAmDialsObject1 = new();
+        private readonly object _lockVhfAmDialsObject2 = new();
+        private readonly object _lockVhfAmDialsObject3 = new();
+        private readonly object _lockVhfAmDialsObject4 = new();
         private DCSBIOSOutput _vhfAmDcsbiosOutputFreqDial1;
         private DCSBIOSOutput _vhfAmDcsbiosOutputFreqDial2;
         private DCSBIOSOutput _vhfAmDcsbiosOutputFreqDial3;
@@ -88,11 +88,11 @@
         private double _uhfSmallFrequencyStandby;
         private double _uhfSavedCockpitBigFrequency;
         private double _uhfSavedCockpitSmallFrequency;
-        private readonly object _lockUhfDialsObject1 = new object();
-        private readonly object _lockUhfDialsObject2 = new object();
-        private readonly object _lockUhfDialsObject3 = new object();
-        private readonly object _lockUhfDialsObject4 = new object();
-        private readonly object _lockUhfDialsObject5 = new object();
+        private readonly object _lockUhfDialsObject1 = new();
+        private readonly object _lockUhfDialsObject2 = new();
+        private readonly object _lockUhfDialsObject3 = new();
+        private readonly object _lockUhfDialsObject4 = new();
+        private readonly object _lockUhfDialsObject5 = new();
         private DCSBIOSOutput _uhfDcsbiosOutputFreqDial1;
         private DCSBIOSOutput _uhfDcsbiosOutputFreqDial2;
         private DCSBIOSOutput _uhfDcsbiosOutputFreqDial3;
@@ -139,10 +139,10 @@
         private uint _vhfFmSmallFrequencyStandby;
         private uint _vhfFmSavedCockpitBigFrequency;
         private uint _vhfFmSavedCockpitSmallFrequency;
-        private readonly object _lockVhfFmDialsObject1 = new object();
-        private readonly object _lockVhfFmDialsObject2 = new object();
-        private readonly object _lockVhfFmDialsObject3 = new object();
-        private readonly object _lockVhfFmDialsObject4 = new object();
+        private readonly object _lockVhfFmDialsObject1 = new();
+        private readonly object _lockVhfFmDialsObject2 = new();
+        private readonly object _lockVhfFmDialsObject3 = new();
+        private readonly object _lockVhfFmDialsObject4 = new();
         private DCSBIOSOutput _vhfFmDcsbiosOutputFreqDial1;
         private DCSBIOSOutput _vhfFmDcsbiosOutputFreqDial2;
         private DCSBIOSOutput _vhfFmDcsbiosOutputFreqDial3;
@@ -185,8 +185,8 @@
         private uint _ilsSmallFrequencyStandby = 10; // "10" "15" "30" "35" "50" "55" "70" "75" "90" "95"
         private uint _ilsSavedCockpitBigFrequency = 108; // "108" "109" "110" "111"
         private uint _ilsSavedCockpitSmallFrequency = 10; // "10" "15" "30" "35" "50" "55" "70" "75" "90" "95"
-        private readonly object _lockIlsDialsObject1 = new object();
-        private readonly object _lockIlsDialsObject2 = new object();
+        private readonly object _lockIlsDialsObject1 = new();
+        private readonly object _lockIlsDialsObject2 = new();
         private DCSBIOSOutput _ilsDcsbiosOutputFreqDial1;
         private DCSBIOSOutput _ilsDcsbiosOutputFreqDial2;
         private volatile uint _ilsCockpitFreq1DialPos = 1;
@@ -209,9 +209,9 @@
         private int _tacanSavedCockpitBigFrequency = 6;
         private int _tacanSavedCockpitSmallFrequency = 5;
         private int _tacanSavedCockpitXY;
-        private readonly object _lockTacanDialsObject1 = new object();
-        private readonly object _lockTacanDialsObject2 = new object();
-        private readonly object _lockTacanDialsObject3 = new object();
+        private readonly object _lockTacanDialsObject1 = new();
+        private readonly object _lockTacanDialsObject2 = new();
+        private readonly object _lockTacanDialsObject3 = new();
         private DCSBIOSOutput _tacanDcsbiosOutputFreqChannel;
         private volatile uint _tacanCockpitFreq1DialPos = 1;
         private volatile uint _tacanCockpitFreq2DialPos = 1;
@@ -225,7 +225,7 @@
         private long _tacanDial2WaitingForFeedback;
         private long _tacanDial3WaitingForFeedback;
 
-        private readonly object _lockShowFrequenciesOnPanelObject = new object();
+        private readonly object _lockShowFrequenciesOnPanelObject = new();
 
         private long _doUpdatePanelLCD;
 

--- a/Source/NonVisuals/Radios/RadioPanelPZ69AJS37.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69AJS37.cs
@@ -65,9 +65,9 @@
         private volatile uint _tilsChannelCockpitValue;
         private volatile uint _tilsChannelLayerSelectorCockpitValue;
         private volatile uint _masterModeSelectorCockpitValue;
-        private readonly object _lockTilsChannelSelectorDialObject1 = new object();
-        private readonly object _lockTilsChannelLayerSelectorObject2 = new object();
-        private readonly object _lockMasterModeSelectorObject = new object();
+        private readonly object _lockTilsChannelSelectorDialObject1 = new();
+        private readonly object _lockTilsChannelLayerSelectorObject2 = new();
+        private readonly object _lockMasterModeSelectorObject = new();
         private DCSBIOSOutput _tilsChannelSelectorDcsbiosOutput;
         private DCSBIOSOutput _tilsChannelLayerSelectorDcsbiosOutput;
         private DCSBIOSOutput _masterModeSelectorDcsbiosOutput;
@@ -79,7 +79,7 @@
         private int _tilsChannelDialSkipper;
         private int _masterModeSelectorDialSkipper;
 
-        private readonly object _lockShowFrequenciesOnPanelObject = new object();
+        private readonly object _lockShowFrequenciesOnPanelObject = new();
         private long _doUpdatePanelLCD;
 
         public RadioPanelPZ69AJS37(HIDSkeleton hidSkeleton) : base(hidSkeleton)

--- a/Source/NonVisuals/Radios/RadioPanelPZ69AJS37.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69AJS37.cs
@@ -51,7 +51,6 @@
         private const string FR22_RIGHT_BIG_DIAL_DECREASE_COMMAND = "FR22_OUTER_RIGHT_KNOB -8000\n";
         private const string FR22_RIGHT_SMALL_DIAL_DECREASE_COMMAND = "FR22_INNER_RIGHT_KNOB -8000\n";
 
-
         /*AJS-37 FR24 COM2*/
         // Large dial Presets
         // Small dial Radio Volume
@@ -117,7 +116,6 @@
                     Common.DebugP("Received DCSBIOS stringData : " + e.StringData);
                     return;
                 }
-
                 */
             }
             catch (Exception ex)
@@ -135,12 +133,12 @@
                 UpdateCounter(e.Address, e.Data);
 
                 /*
-                                 * IMPORTANT INFORMATION REGARDING THE _*WaitingForFeedback variables
-                                 * Once a dial has been deemed to be "off" position and needs to be changed
-                                 * a change command is sent to DCS-BIOS.
-                                 * Only after a *change* has been acknowledged will the _*WaitingForFeedback be
-                                 * reset. Reading the dial's position with no change in value will not reset.
-                                 */
+                * IMPORTANT INFORMATION REGARDING THE _*WaitingForFeedback variables
+                * Once a dial has been deemed to be "off" position and needs to be changed
+                * a change command is sent to DCS-BIOS.
+                * Only after a *change* has been acknowledged will the _*WaitingForFeedback be
+                * reset. Reading the dial's position with no change in value will not reset.
+                */
 
                 // TILS Channel Selector
                 if (e.Address == _tilsChannelSelectorDcsbiosOutput.Address)
@@ -199,7 +197,6 @@
         {
             try
             {
-
                 if (IgnoreSwitchButtonOnce() && (knob == RadioPanelPZ69KnobsAJS37.UPPER_FREQ_SWITCH || knob == RadioPanelPZ69KnobsAJS37.LOWER_FREQ_SWITCH))
                 {
                     // Don't do anything on the very first button press as the panel sends ALL
@@ -304,7 +301,6 @@
                                     {
                                         SetUpperRadioMode(CurrentAJS37RadioMode.FR22);
                                     }
-
                                     break;
                                 }
 
@@ -314,7 +310,6 @@
                                     {
                                         SetUpperRadioMode(CurrentAJS37RadioMode.FR24);
                                     }
-
                                     break;
                                 }
 
@@ -324,7 +319,6 @@
                                     {
                                         SetUpperRadioMode(CurrentAJS37RadioMode.TILS);
                                     }
-
                                     break;
                                 }
 
@@ -334,7 +328,6 @@
                                     {
                                         SetLowerRadioMode(CurrentAJS37RadioMode.FR22);
                                     }
-
                                     break;
                                 }
 
@@ -344,7 +337,6 @@
                                     {
                                         SetLowerRadioMode(CurrentAJS37RadioMode.FR24);
                                     }
-
                                     break;
                                 }
 
@@ -354,7 +346,6 @@
                                     {
                                         SetLowerRadioMode(CurrentAJS37RadioMode.TILS);
                                     }
-
                                     break;
                                 }
 
@@ -404,7 +395,6 @@
                                     {
                                         SendFrequencyToDCSBIOS(RadioPanelPZ69KnobsAJS37.UPPER_FREQ_SWITCH);
                                     }
-
                                     break;
                                 }
 
@@ -429,7 +419,6 @@
                                     {
                                         SendFrequencyToDCSBIOS(RadioPanelPZ69KnobsAJS37.LOWER_FREQ_SWITCH);
                                     }
-
                                     break;
                                 }
                         }
@@ -439,7 +428,6 @@
                             PluginManager.DoEvent(DCSFPProfile.SelectedProfile.Description, HIDInstance, PluginGamingPanelEnum.PZ69RadioPanel_PreProg_AJS37, (int)radioPanelKnob.RadioPanelPZ69Knob, radioPanelKnob.IsOn, null);
                         }
                     }
-
                     AdjustFrequency(hashSet);
                 }
             }
@@ -453,7 +441,6 @@
         {
             try
             {
-
                 if (SkipCurrentFrequencyChange())
                 {
                     return;
@@ -487,7 +474,6 @@
                                                 {
                                                     DCSBIOS.Send(TILS_CHANNEL_DIAL_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -520,7 +506,6 @@
                                                 {
                                                     DCSBIOS.Send(TILS_CHANNEL_DIAL_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -553,7 +538,6 @@
                                                 {
                                                     DCSBIOS.Send(MASTER_MODE_SELECTOR_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -586,7 +570,6 @@
                                                 {
                                                     DCSBIOS.Send(MASTER_MODE_SELECTOR_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -610,7 +593,6 @@
 
                                         case CurrentAJS37RadioMode.FR24:
                                             {
-
                                                 break;
                                             }
 
@@ -620,7 +602,6 @@
                                                 {
                                                     DCSBIOS.Send(TILS_CHANNEL_DIAL_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -644,7 +625,6 @@
 
                                         case CurrentAJS37RadioMode.FR24:
                                             {
-
                                                 break;
                                             }
 
@@ -654,7 +634,6 @@
                                                 {
                                                     DCSBIOS.Send(TILS_CHANNEL_DIAL_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -687,7 +666,6 @@
                                                 {
                                                     DCSBIOS.Send(MASTER_MODE_SELECTOR_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -720,7 +698,6 @@
                                                 {
                                                     DCSBIOS.Send(MASTER_MODE_SELECTOR_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -743,8 +720,6 @@
             }
         }
 
-
-
         private void ShowFrequenciesOnPanel()
         {
             try
@@ -753,13 +728,11 @@
                 {
                     if (Interlocked.Read(ref _doUpdatePanelLCD) == 0)
                     {
-
                         return;
                     }
 
                     if (!FirstReportHasBeenRead)
                     {
-
                         return;
                     }
 
@@ -895,7 +868,6 @@
             Interlocked.Decrement(ref _doUpdatePanelLCD);
         }
 
-
         protected override void GamingPanelKnobChanged(bool isFirstReport, IEnumerable<object> hashSet)
         {
             PZ69KnobChanged(isFirstReport, hashSet);
@@ -905,7 +877,6 @@
         {
             try
             {
-
                 // COM1
 
                 // COM2
@@ -1019,7 +990,6 @@
             {
                 logger.Error(ex);
             }
-
             return false;
         }
 
@@ -1046,7 +1016,5 @@
         public override void AddOrUpdateOSCommandBinding(PanelSwitchOnOff panelSwitchOnOff, OSCommand operatingSystemCommand)
         {
         }
-
-
     }
 }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69AV8BNA.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69AV8BNA.cs
@@ -90,7 +90,6 @@
         {
             UpdateCounter(e.Address, e.Data);
 
-
             /*
              * IMPORTANT INFORMATION REGARDING THE _*WaitingForFeedback variables
              * Once a dial has been deemed to be "off" position and needs to be changed
@@ -142,7 +141,6 @@
 
         private void SendFrequencyToDCSBIOS(RadioPanelKnobAV8BNA knob)
         {
-
             if (IgnoreSwitchButtonOnce() && (knob.RadioPanelPZ69Knob == RadioPanelPZ69KnobsAV8BNA.UPPER_FREQ_SWITCH || knob.RadioPanelPZ69Knob == RadioPanelPZ69KnobsAV8BNA.LOWER_FREQ_SWITCH))
             {
                 // Don't do anything on the very first button press as the panel sends ALL
@@ -182,7 +180,6 @@
 
                 case RadioPanelPZ69KnobsAV8BNA.LOWER_FREQ_SWITCH:
                     {
-
                         switch (_currentLowerRadioMode)
                         {
                             case CurrentAV8BNARadioMode.COMM1:
@@ -230,13 +227,11 @@
                             {
                                 frequencyAsString = _comm1Frequency;
                             }
-
                             SetPZ69DisplayBytesDefault(ref bytes, double.Parse(frequencyAsString, NumberFormatInfoFullDisplay), PZ69LCDPosition.UPPER_ACTIVE_LEFT);
                             SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.UPPER_STBY_RIGHT);
-
+                            break;
                         }
 
-                        break;
                     case CurrentAV8BNARadioMode.COMM2:
                         {
                             var frequencyAsString = string.Empty;
@@ -247,10 +242,9 @@
 
                             SetPZ69DisplayBytesDefault(ref bytes, double.Parse(frequencyAsString, NumberFormatInfoFullDisplay), PZ69LCDPosition.UPPER_ACTIVE_LEFT);
                             SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.UPPER_STBY_RIGHT);
-
+                            break;
                         }
 
-                        break;
                     case CurrentAV8BNARadioMode.NOUSE:
                         {
                             SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
@@ -267,13 +261,11 @@
                             {
                                 frequencyAsString = _comm1Frequency;
                             }
-
                             SetPZ69DisplayBytesDefault(ref bytes, double.Parse(frequencyAsString, NumberFormatInfoFullDisplay), PZ69LCDPosition.LOWER_ACTIVE_LEFT);
                             SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.LOWER_STBY_RIGHT);
-
+                            break;
                         }
 
-                        break;
                     case CurrentAV8BNARadioMode.COMM2:
                         {
                             var frequencyAsString = string.Empty;
@@ -281,13 +273,11 @@
                             {
                                 frequencyAsString = _comm2Frequency;
                             }
-
                             SetPZ69DisplayBytesDefault(ref bytes, double.Parse(frequencyAsString, NumberFormatInfoFullDisplay), PZ69LCDPosition.LOWER_ACTIVE_LEFT);
                             SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.LOWER_STBY_RIGHT);
-
+                            break;
                         }
 
-                        break;
                     case CurrentAV8BNARadioMode.NOUSE:
                         {
                             SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
@@ -297,7 +287,6 @@
                 }
                 SendLCDData(bytes);
             }
-
             Interlocked.Decrement(ref _doUpdatePanelLCD);
         }
         
@@ -330,7 +319,6 @@
                                             {
                                                 DCSBIOS.Send(COMM1_CHANNEL_INC);
                                             }
-
                                             break;
                                         }
 
@@ -345,7 +333,6 @@
                                             {
                                                 DCSBIOS.Send(COMM2_CHANNEL_INC);
                                             }
-
                                             break;
                                         }
                                 }
@@ -367,7 +354,6 @@
                                             {
                                                 DCSBIOS.Send(COMM1_CHANNEL_DEC);
                                             }
-
                                             break;
                                         }
 
@@ -382,7 +368,6 @@
                                             {
                                                 DCSBIOS.Send(COMM2_CHANNEL_DEC);
                                             }
-
                                             break;
                                         }
                                 }
@@ -442,7 +427,6 @@
                                             {
                                                 DCSBIOS.Send(COMM1_CHANNEL_INC);
                                             }
-
                                             break;
                                         }
 
@@ -457,7 +441,6 @@
                                             {
                                                 DCSBIOS.Send(COMM2_CHANNEL_INC);
                                             }
-
                                             break;
                                         }
                                 }
@@ -479,7 +462,6 @@
                                             {
                                                 DCSBIOS.Send(COMM1_CHANNEL_DEC);
                                             }
-
                                             break;
                                         }
 
@@ -494,7 +476,6 @@
                                             {
                                                 DCSBIOS.Send(COMM2_CHANNEL_DEC);
                                             }
-
                                             break;
                                         }
                                 }
@@ -505,7 +486,6 @@
                             {
                                 switch (_currentLowerRadioMode)
                                 {
-
                                     case CurrentAV8BNARadioMode.COMM1:
                                         {
                                             DCSBIOS.Send(COMM1_VOL_INC);
@@ -570,7 +550,6 @@
                                 {
                                     _currentUpperRadioMode = CurrentAV8BNARadioMode.COMM1;
                                 }
-
                                 break;
                             }
 
@@ -580,7 +559,6 @@
                                 {
                                     _currentUpperRadioMode = CurrentAV8BNARadioMode.COMM2;
                                 }
-
                                 break;
                             }
 
@@ -589,14 +567,13 @@
                         case RadioPanelPZ69KnobsAV8BNA.UPPER_ADF:
                         case RadioPanelPZ69KnobsAV8BNA.UPPER_DME:
                         case RadioPanelPZ69KnobsAV8BNA.UPPER_XPDR:
-                        {
-                            if (radioPanelKnob.IsOn)
                             {
-                                _currentUpperRadioMode = CurrentAV8BNARadioMode.NOUSE;
+                                if (radioPanelKnob.IsOn)
+                                {
+                                    _currentUpperRadioMode = CurrentAV8BNARadioMode.NOUSE;
+                                }
+                                break;
                             }
-
-                            break;
-                        }
 
                         case RadioPanelPZ69KnobsAV8BNA.LOWER_COMM1:
                             {
@@ -604,7 +581,6 @@
                                 {
                                     _currentLowerRadioMode = CurrentAV8BNARadioMode.COMM1;
                                 }
-
                                 break;
                             }
 
@@ -614,7 +590,6 @@
                                 {
                                     _currentLowerRadioMode = CurrentAV8BNARadioMode.COMM2;
                                 }
-
                                 break;
                             }
 
@@ -623,14 +598,13 @@
                         case RadioPanelPZ69KnobsAV8BNA.LOWER_ADF:
                         case RadioPanelPZ69KnobsAV8BNA.LOWER_DME:
                         case RadioPanelPZ69KnobsAV8BNA.LOWER_XPDR:
-                        {
-                            if (radioPanelKnob.IsOn)
                             {
-                                _currentLowerRadioMode = CurrentAV8BNARadioMode.NOUSE;
+                                if (radioPanelKnob.IsOn)
+                                {
+                                    _currentLowerRadioMode = CurrentAV8BNARadioMode.NOUSE;
+                                }
+                                break;
                             }
-
-                            break;
-                        }
 
                         case RadioPanelPZ69KnobsAV8BNA.UPPER_LARGE_FREQ_WHEEL_INC:
                             {
@@ -690,7 +664,6 @@
                         PluginManager.DoEvent(DCSFPProfile.SelectedProfile.Description, HIDInstance, PluginGamingPanelEnum.PZ69RadioPanel_PreProg_AV8BNA, (int)radioPanelKnob.RadioPanelPZ69Knob, radioPanelKnob.IsOn, null);
                     }
                 }
-
                 AdjustFrequency(hashSet);
             }
         }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69AV8BNA.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69AV8BNA.cs
@@ -36,7 +36,7 @@
         private const string COMM1_VOL_DEC = "UFC_COM1_VOL -4000\n";
         private const string COMM1_PULL_PRESS = "UFC_COM1_PULL INC\n";
         private const string COMM1_PULL_RELEASE = "UFC_COM1_PULL DEC\n";
-        private readonly object _lockCOMM1DialsObject = new object();
+        private readonly object _lockCOMM1DialsObject = new();
         private DCSBIOSOutput _comm1DcsbiosOutputFreq;
         private string _comm1Frequency = "225.000";
         private readonly ClickSpeedDetector _comm1ChannelClickSpeedDetector = new ClickSpeedDetector(8);
@@ -50,12 +50,12 @@
         private const string COMM2_VOL_DEC = "UFC_COM2_VOL -4000\n";
         private const string COMM2_PULL_PRESS = "UFC_COM2_PULL INC\n";
         private const string COMM2_PULL_RELEASE = "UFC_COM2_PULL DEC\n";
-        private readonly object _lockCOMM2DialsObject = new object();
+        private readonly object _lockCOMM2DialsObject = new();
         private DCSBIOSOutput _comm2DcsbiosOutputFreq;
         private string _comm2Frequency = "225.000";
         private readonly ClickSpeedDetector _comm2ChannelClickSpeedDetector = new ClickSpeedDetector(8);
 
-        private readonly object _lockShowFrequenciesOnPanelObject = new object();
+        private readonly object _lockShowFrequenciesOnPanelObject = new();
 
         private long _doUpdatePanelLCD;
 

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
@@ -225,7 +225,6 @@
             {
                 return null;
             }
-
             return new List<string>();
         }
 
@@ -247,7 +246,6 @@
                         {
                             return true;
                         }
-
                         _frequencySensitivitySkipper = 0;
                         break;
                     }
@@ -260,12 +258,10 @@
                         {
                             return true;
                         }
-
                         _frequencySensitivitySkipper = 0;
                         break;
                     }
             }
-
             return false;
         }
         
@@ -273,7 +269,6 @@
         {
             e.ProfileHandlerCaller.RegisterPanelBinding(this, ExportSettings());
         }
-        
 
         protected void Reset(ref long syncVariable)
         {
@@ -301,7 +296,6 @@
             {
                 return false; // good!
             }
-
             return true; // wait more
         }
 

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
@@ -24,7 +24,7 @@
         private readonly NumberFormatInfo _numberFormatInfoFullDisplay;
         private int _frequencyKnobSensitivity;
         private volatile int _frequencySensitivitySkipper;
-        protected readonly object LockLCDUpdateObject = new object();
+        protected readonly object LockLCDUpdateObject = new();
         protected bool DataHasBeenReceivedFromDCSBIOS;
 
         /// <summary>
@@ -35,7 +35,7 @@
         public long ResetSyncTimeout { get; set; } = 35000000;
 
         private long _syncOKDelayTimeout = 50000000; // 5s
-        private readonly PZ69DisplayBytes _pZ69DisplayBytes = new PZ69DisplayBytes();
+        private readonly PZ69DisplayBytes _pZ69DisplayBytes = new();
 
         protected RadioPanelPZ69Base(HIDSkeleton hidSkeleton) : base(GamingPanelEnum.PZ69RadioPanel, hidSkeleton)
         {

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Bf109.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Bf109.cs
@@ -66,13 +66,13 @@
         // Small dial Fine tuning
         private readonly ClickSpeedDetector _fineTuneIncreaseChangeMonitor = new ClickSpeedDetector(20);
         private readonly ClickSpeedDetector _fineTuneDecreaseChangeMonitor = new ClickSpeedDetector(20);
-        private readonly object _lockFug16ZyPresetDialObject1 = new object();
+        private readonly object _lockFug16ZyPresetDialObject1 = new();
         private DCSBIOSOutput _fug16ZyPresetDcsbiosOutputPresetDial;
         private volatile uint _fug16ZyPresetCockpitDialPos = 1;
         private const string FUG16_ZY_PRESET_COMMAND_INC = "RADIO_MODE INC\n";
         private const string FUG16_ZY_PRESET_COMMAND_DEC = "RADIO_MODE DEC\n";
         private int _fug16ZyPresetDialSkipper;
-        private readonly object _lockFug16ZyFineTuneDialObject1 = new object();
+        private readonly object _lockFug16ZyFineTuneDialObject1 = new();
         private DCSBIOSOutput _fug16ZyFineTuneDcsbiosOutputDial;
         private volatile uint _fug16ZyFineTuneCockpitDialPos = 1;
         private const string FUG16_ZY_FINE_TUNE_COMMAND_INC = "FUG16_TUNING +300\n";
@@ -84,7 +84,7 @@
         // Large dial 0-1 [step of 1]
         // Small dial Volume control
         // ACT/STBY IFF Test Button
-        private readonly object _lockFUG25AIFFDialObject1 = new object();
+        private readonly object _lockFUG25AIFFDialObject1 = new();
         private DCSBIOSOutput _fug25aIFFDcsbiosOutputDial;
         private volatile uint _fug25aIFFCockpitDialPos = 1;
         private const string FUG25AIFFCommandInc = "FUG25_MODE INC\n";
@@ -99,13 +99,13 @@
         // Large dial N/A
         // Small dial N/A
         // ACT/STBY Homing Switch
-        private readonly object _lockHomingDialObject1 = new object();
+        private readonly object _lockHomingDialObject1 = new();
         private DCSBIOSOutput _homingDcsbiosOutputPresetDial;
         private volatile uint _homingCockpitDialPos = 1;
         private const string HOMING_COMMAND_INC = "FT_ZF_SWITCH INC\n";
         private const string HOMING_COMMAND_DEC = "FT_ZF_SWITCH DEC\n";
 
-        private readonly object _lockShowFrequenciesOnPanelObject = new object();
+        private readonly object _lockShowFrequenciesOnPanelObject = new();
         private long _doUpdatePanelLCD;
 
         public RadioPanelPZ69Bf109(HIDSkeleton hidSkeleton) : base(hidSkeleton)

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Bf109.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Bf109.cs
@@ -151,12 +151,12 @@
                 UpdateCounter(e.Address, e.Data);
 
                 /*
-                                 * IMPORTANT INFORMATION REGARDING THE _*WaitingForFeedback variables
-                                 * Once a dial has been deemed to be "off" position and needs to be changed
-                                 * a change command is sent to DCS-BIOS.
-                                 * Only after a *change* has been acknowledged will the _*WaitingForFeedback be
-                                 * reset. Reading the dial's position with no change in value will not reset.
-                                 */
+                * IMPORTANT INFORMATION REGARDING THE _*WaitingForFeedback variables
+                * Once a dial has been deemed to be "off" position and needs to be changed
+                * a change command is sent to DCS-BIOS.
+                * Only after a *change* has been acknowledged will the _*WaitingForFeedback be
+                * reset. Reading the dial's position with no change in value will not reset.
+                */
 
                 // FuG 16ZY Preset Channel Dial
                 if (e.Address == _fug16ZyPresetDcsbiosOutputPresetDial.Address)
@@ -224,7 +224,6 @@
             }
         }
 
-
         public void PZ69KnobChanged(bool isFirstReport, IEnumerable<object> hashSet)
         {
             if (isFirstReport)
@@ -249,7 +248,6 @@
                                     {
                                         SetUpperRadioMode(CurrentBf109RadioMode.FUG16ZY);
                                     }
-
                                     break;
                                 }
 
@@ -259,7 +257,6 @@
                                     {
                                         SetUpperRadioMode(CurrentBf109RadioMode.IFF);
                                     }
-
                                     break;
                                 }
 
@@ -269,7 +266,6 @@
                                     {
                                         SetUpperRadioMode(CurrentBf109RadioMode.HOMING);
                                     }
-
                                     break;
                                 }
 
@@ -282,7 +278,6 @@
                                     {
                                         SetUpperRadioMode(CurrentBf109RadioMode.NOUSE);
                                     }
-
                                     break;
                                 }
 
@@ -292,7 +287,6 @@
                                     {
                                         SetLowerRadioMode(CurrentBf109RadioMode.FUG16ZY);
                                     }
-
                                     break;
                                 }
 
@@ -302,7 +296,6 @@
                                     {
                                         SetLowerRadioMode(CurrentBf109RadioMode.IFF);
                                     }
-
                                     break;
                                 }
 
@@ -312,7 +305,6 @@
                                     {
                                         SetLowerRadioMode(CurrentBf109RadioMode.HOMING);
                                     }
-
                                     break;
                                 }
 
@@ -325,7 +317,6 @@
                                     {
                                         SetLowerRadioMode(CurrentBf109RadioMode.NOUSE);
                                     }
-
                                     break;
                                 }
 
@@ -359,7 +350,6 @@
                                             }
                                         }
                                     }
-
                                     break;
                                 }
 
@@ -380,7 +370,6 @@
                                             }
                                         }
                                     }
-
                                     break;
                                 }
                         }
@@ -404,7 +393,6 @@
         {
             try
             {
-
                 if (SkipCurrentFrequencyChange())
                 {
                     return;
@@ -428,7 +416,6 @@
                                                 {
                                                     DCSBIOS.Send(FUG16_ZY_PRESET_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -438,7 +425,6 @@
                                                 {
                                                     DCSBIOS.Send(FUG25AIFFCommandInc);
                                                 }
-
                                                 break;
                                             }
 
@@ -466,7 +452,6 @@
                                                 {
                                                     DCSBIOS.Send(FUG16_ZY_PRESET_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -476,7 +461,6 @@
                                                 {
                                                     DCSBIOS.Send(FUG25AIFFCommandDec);
                                                 }
-
                                                 break;
                                             }
 
@@ -507,7 +491,6 @@
                                                     // Change faster
                                                     changeFaster = true;
                                                 }
-
                                                 DCSBIOS.Send(changeFaster ? FUG16_ZY_FINE_TUNE_COMMAND_INC_MORE : FUG16_ZY_FINE_TUNE_COMMAND_INC);
                                                 break;
                                             }
@@ -545,7 +528,6 @@
                                                     // Change faster
                                                     changeFaster = true;
                                                 }
-
                                                 DCSBIOS.Send(changeFaster ? FUG16_ZY_FINE_TUNE_COMMAND_DEC_MORE : FUG16_ZY_FINE_TUNE_COMMAND_DEC);
                                                 break;
                                             }
@@ -580,7 +562,6 @@
                                                 {
                                                     DCSBIOS.Send(FUG16_ZY_PRESET_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -590,7 +571,6 @@
                                                 {
                                                     DCSBIOS.Send(FUG25AIFFCommandInc);
                                                 }
-
                                                 break;
                                             }
 
@@ -618,7 +598,6 @@
                                                 {
                                                     DCSBIOS.Send(FUG16_ZY_PRESET_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -628,7 +607,6 @@
                                                 {
                                                     DCSBIOS.Send(FUG25AIFFCommandDec);
                                                 }
-
                                                 break;
                                             }
 
@@ -659,7 +637,6 @@
                                                     // Change faster
                                                     changeFaster = true;
                                                 }
-
                                                 DCSBIOS.Send(changeFaster ? FUG16_ZY_FINE_TUNE_COMMAND_INC_MORE : FUG16_ZY_FINE_TUNE_COMMAND_INC);
                                                 break;
                                             }
@@ -697,7 +674,6 @@
                                                     // Change faster
                                                     changeFaster = true;
                                                 }
-
                                                 DCSBIOS.Send(changeFaster ? FUG16_ZY_FINE_TUNE_COMMAND_DEC_MORE : FUG16_ZY_FINE_TUNE_COMMAND_DEC);
                                                 break;
                                             }
@@ -740,13 +716,11 @@
                 {
                     if (Interlocked.Read(ref _doUpdatePanelLCD) == 0)
                     {
-
                         return;
                     }
 
                     if (!FirstReportHasBeenRead)
                     {
-
                         return;
                     }
 
@@ -770,7 +744,6 @@
 
                                     fineTunePositionAsString = (_fug16ZyFineTuneCockpitDialPos / 10).ToString();
                                 }
-
                                 SetPZ69DisplayBytesUnsignedInteger(ref bytes, Convert.ToUInt32(modeDialPostionAsString), PZ69LCDPosition.UPPER_ACTIVE_LEFT);
                                 SetPZ69DisplayBytesUnsignedInteger(ref bytes, Convert.ToUInt32(fineTunePositionAsString), PZ69LCDPosition.UPPER_STBY_RIGHT);
                                 break;
@@ -785,7 +758,6 @@
                                 {
                                     positionAsString = (_fug25aIFFCockpitDialPos + 1).ToString().PadLeft(2, ' ');
                                 }
-
                                 SetPZ69DisplayBytesUnsignedInteger(ref bytes, Convert.ToUInt32(positionAsString), PZ69LCDPosition.UPPER_STBY_RIGHT);
                                 SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
                                 break;
@@ -800,7 +772,6 @@
                                 {
                                     positionAsString = (_homingCockpitDialPos + 1).ToString().PadLeft(2, ' ');
                                 }
-
                                 SetPZ69DisplayBytesUnsignedInteger(ref bytes, Convert.ToUInt32(positionAsString), PZ69LCDPosition.UPPER_STBY_RIGHT);
                                 SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
                                 break;
@@ -830,7 +801,6 @@
 
                                     fineTunePositionAsString = (_fug16ZyFineTuneCockpitDialPos / 10).ToString();
                                 }
-
                                 SetPZ69DisplayBytesUnsignedInteger(ref bytes, Convert.ToUInt32(modeDialPostionAsString), PZ69LCDPosition.LOWER_ACTIVE_LEFT);
                                 SetPZ69DisplayBytesUnsignedInteger(ref bytes, Convert.ToUInt32(fineTunePositionAsString), PZ69LCDPosition.LOWER_STBY_RIGHT);
                                 break;
@@ -845,7 +815,6 @@
                                 {
                                     positionAsString = (_fug25aIFFCockpitDialPos + 1).ToString().PadLeft(2, ' ');
                                 }
-
                                 SetPZ69DisplayBytesUnsignedInteger(ref bytes, Convert.ToUInt32(positionAsString), PZ69LCDPosition.LOWER_STBY_RIGHT);
                                 SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
                                 break;
@@ -860,7 +829,6 @@
                                 {
                                     positionAsString = (_homingCockpitDialPos + 1).ToString().PadLeft(2, ' ');
                                 }
-
                                 SetPZ69DisplayBytesUnsignedInteger(ref bytes, Convert.ToUInt32(positionAsString), PZ69LCDPosition.LOWER_STBY_RIGHT);
                                 SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
                                 break;
@@ -969,7 +937,6 @@
                         _fug16ZyPresetDialSkipper = 0;
                         return false;
                     }
-
                     _fug16ZyPresetDialSkipper++;
                     return true;
                 }
@@ -993,7 +960,6 @@
                         _fug25aIFFDialSkipper = 0;
                         return false;
                     }
-
                     _fug25aIFFDialSkipper++;
                     return true;
                 }
@@ -1029,7 +995,5 @@
         public override void AddOrUpdateOSCommandBinding(PanelSwitchOnOff panelSwitchOnOff, OSCommand operatingSystemCommand)
         {
         }
-
-
     }
 }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Emulator.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Emulator.cs
@@ -21,15 +21,15 @@ namespace NonVisuals.Radios
 
     public class RadioPanelPZ69Emulator : RadioPanelPZ69Base
     {
-        private readonly HashSet<RadioPanelPZ69DisplayValue> _displayValues = new HashSet<RadioPanelPZ69DisplayValue>();
-        private readonly HashSet<BIPLinkPZ69> _bipLinks = new HashSet<BIPLinkPZ69>();
-        private readonly object _dcsBiosDataReceivedLock = new object();
+        private readonly HashSet<RadioPanelPZ69DisplayValue> _displayValues = new();
+        private readonly HashSet<BIPLinkPZ69> _bipLinks = new();
+        private readonly object _dcsBiosDataReceivedLock = new();
 
-        private readonly List<RadioPanelPZ69KnobsEmulator> _panelPZ69DialModesUpper = new List<RadioPanelPZ69KnobsEmulator> { RadioPanelPZ69KnobsEmulator.UpperCOM1, RadioPanelPZ69KnobsEmulator.UpperCOM2, RadioPanelPZ69KnobsEmulator.UpperNAV1, RadioPanelPZ69KnobsEmulator.UpperNAV2, RadioPanelPZ69KnobsEmulator.UpperADF, RadioPanelPZ69KnobsEmulator.UpperDME, RadioPanelPZ69KnobsEmulator.UpperXPDR };
-        private readonly List<RadioPanelPZ69KnobsEmulator> _panelPZ69DialModesLower = new List<RadioPanelPZ69KnobsEmulator> { RadioPanelPZ69KnobsEmulator.LowerCOM1, RadioPanelPZ69KnobsEmulator.LowerCOM2, RadioPanelPZ69KnobsEmulator.LowerNAV1, RadioPanelPZ69KnobsEmulator.LowerNAV2, RadioPanelPZ69KnobsEmulator.LowerADF, RadioPanelPZ69KnobsEmulator.LowerDME, RadioPanelPZ69KnobsEmulator.LowerXPDR };
+        private readonly List<RadioPanelPZ69KnobsEmulator> _panelPZ69DialModesUpper = new() { RadioPanelPZ69KnobsEmulator.UpperCOM1, RadioPanelPZ69KnobsEmulator.UpperCOM2, RadioPanelPZ69KnobsEmulator.UpperNAV1, RadioPanelPZ69KnobsEmulator.UpperNAV2, RadioPanelPZ69KnobsEmulator.UpperADF, RadioPanelPZ69KnobsEmulator.UpperDME, RadioPanelPZ69KnobsEmulator.UpperXPDR };
+        private readonly List<RadioPanelPZ69KnobsEmulator> _panelPZ69DialModesLower = new() { RadioPanelPZ69KnobsEmulator.LowerCOM1, RadioPanelPZ69KnobsEmulator.LowerCOM2, RadioPanelPZ69KnobsEmulator.LowerNAV1, RadioPanelPZ69KnobsEmulator.LowerNAV2, RadioPanelPZ69KnobsEmulator.LowerADF, RadioPanelPZ69KnobsEmulator.LowerDME, RadioPanelPZ69KnobsEmulator.LowerXPDR };
 
-        private HashSet<KeyBindingPZ69> _keyBindings = new HashSet<KeyBindingPZ69>();
-        private List<OSCommandBindingPZ69Emulator> _operatingSystemCommandBindings = new List<OSCommandBindingPZ69Emulator>();
+        private HashSet<KeyBindingPZ69> _keyBindings = new();
+        private List<OSCommandBindingPZ69Emulator> _operatingSystemCommandBindings = new();
 
 
         private double _upperActive = -1;

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Emulator.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Emulator.cs
@@ -31,7 +31,6 @@ namespace NonVisuals.Radios
         private HashSet<KeyBindingPZ69> _keyBindings = new();
         private List<OSCommandBindingPZ69Emulator> _operatingSystemCommandBindings = new();
 
-
         private double _upperActive = -1;
         private double _upperStandby = -1;
         private double _lowerActive = -1;
@@ -78,13 +77,12 @@ namespace NonVisuals.Radios
 
             BindingHash = genericPanelBinding.BindingHash;
 
-            var settings = genericPanelBinding.Settings;
+            List<string> settings = genericPanelBinding.Settings;
 
-            foreach (var setting in settings)
+            foreach (string setting in settings)
             {
                 if (!setting.StartsWith("#") && setting.Length > 2)
                 {
-
                     if (setting.StartsWith("RadioPanelKey{"))
                     {
                         var keyBinding = new KeyBindingPZ69();
@@ -123,7 +121,7 @@ namespace NonVisuals.Radios
                 return null;
             }
 
-            var result = new List<string>();
+            List<string> result = new();
 
             foreach (var keyBinding in _keyBindings)
             {
@@ -143,7 +141,7 @@ namespace NonVisuals.Radios
 
             foreach (var displayValue in _displayValues)
             {
-                var tmp = displayValue.ExportSettings();
+                string tmp = displayValue.ExportSettings();
                 if (!string.IsNullOrEmpty(tmp))
                 {
                     result.Add(tmp);
@@ -152,7 +150,7 @@ namespace NonVisuals.Radios
 
             foreach (var bipLink in _bipLinks)
             {
-                var tmp = bipLink.ExportSettings();
+                string tmp = bipLink.ExportSettings();
                 if (!string.IsNullOrEmpty(tmp))
                 {
                     result.Add(tmp);
@@ -202,12 +200,11 @@ namespace NonVisuals.Radios
 
         public HashSet<RadioPanelPZ69DisplayValue> DisplayValueHashSet => _displayValues;
 
-
         private void PZ69KnobChanged(bool isFirstReport, IEnumerable<object> hashSet)
         {
             if (ForwardPanelEvent)
             {
-                foreach (var radioPanelKeyObject in hashSet)
+                foreach (object radioPanelKeyObject in hashSet)
                 {
                     // Looks which switches has been switched and sees whether any key emulation has been tied to them.
                     var radioPanelKey = (RadioPanelPZ69KnobEmulator)radioPanelKeyObject;
@@ -227,8 +224,8 @@ namespace NonVisuals.Radios
                         }
                     }
 
-                    var keyBindingFound = false;
-                    foreach (var keyBinding in _keyBindings)
+                    bool keyBindingFound = false;
+                    foreach (KeyBindingPZ69 keyBinding in _keyBindings)
                     {
                         if (keyBinding.OSKeyPress != null && keyBinding.RadioPanelPZ69Key == radioPanelKey.RadioPanelPZ69Knob && keyBinding.WhenTurnedOn == radioPanelKey.IsOn)
                         {
@@ -248,7 +245,6 @@ namespace NonVisuals.Radios
                                     radioPanelKey.IsOn, 
                                     keyBinding.OSKeyPress.KeyPressSequence);
                             }
-
                             break;
                         }
                     }
@@ -266,7 +262,7 @@ namespace NonVisuals.Radios
                             null);
                     }
 
-                    foreach (var operatingSystemCommand in _operatingSystemCommandBindings)
+                    foreach (OSCommandBindingPZ69Emulator operatingSystemCommand in _operatingSystemCommandBindings)
                     {
                         if (operatingSystemCommand.OSCommandObject != null && operatingSystemCommand.RadioPanelPZ69Key == radioPanelKey.RadioPanelPZ69Knob && operatingSystemCommand.WhenTurnedOn == radioPanelKey.IsOn)
                         {
@@ -275,7 +271,7 @@ namespace NonVisuals.Radios
                         }
                     }
 
-                    foreach (var bipLinkPZ69 in _bipLinks)
+                    foreach (BIPLinkPZ69 bipLinkPZ69 in _bipLinks)
                     {
                         if (bipLinkPZ69.BIPLights.Count > 0 && bipLinkPZ69.RadioPanelPZ69Knob == radioPanelKey.RadioPanelPZ69Knob && bipLinkPZ69.WhenTurnedOn == radioPanelKey.IsOn)
                         {
@@ -283,11 +279,10 @@ namespace NonVisuals.Radios
                             break;
                         }
                     }
-
                 }
             }
 
-            foreach (var radioPanelKeyObject in hashSet)
+            foreach (object radioPanelKeyObject in hashSet)
             {
                 // Looks which switches has been switched and sees whether any key emulation has been tied to them.
                 var radioPanelKey = (RadioPanelPZ69KnobEmulator)radioPanelKeyObject;
@@ -305,7 +300,7 @@ namespace NonVisuals.Radios
                         _lowerStandby = -1;
                     }
 
-                    foreach (var displayValue in _displayValues)
+                    foreach (RadioPanelPZ69DisplayValue displayValue in _displayValues)
                     {
                         if (displayValue.RadioPanelPZ69Knob == radioPanelKey.RadioPanelPZ69Knob)
                         {
@@ -329,7 +324,6 @@ namespace NonVisuals.Radios
                             }
                         }
                     }
-
                     ShowFrequenciesOnPanel();
                 }
             }
@@ -378,18 +372,16 @@ namespace NonVisuals.Radios
             SendLCDData(bytes);
         }
 
-
         public string GetKeyPressForLoggingPurposes(RadioPanelPZ69KnobEmulator radioPanelKey)
         {
-            var result = string.Empty;
-            foreach (var keyBinding in _keyBindings)
+            string result = string.Empty;
+            foreach (KeyBindingPZ69 keyBinding in _keyBindings)
             {
                 if (keyBinding.OSKeyPress != null && keyBinding.RadioPanelPZ69Key == radioPanelKey.RadioPanelPZ69Knob && keyBinding.WhenTurnedOn == radioPanelKey.IsOn)
                 {
                     result = keyBinding.OSKeyPress.GetNonFunctioningVirtualKeyCodesAsString();
                 }
             }
-
             return result;
         }
 
@@ -401,15 +393,15 @@ namespace NonVisuals.Radios
                 return;
             }
 
-            var value = double.Parse(valueAsString, NumberFormatInfoFullDisplay);
+            double value = double.Parse(valueAsString, NumberFormatInfoFullDisplay);
             if (value < 0)
             {
                 ClearDisplayValue(radioPanelPZ69Knob, radioPanelDisplay);
                 return;
             }
 
-            var found = false;
-            foreach (var displayValue in _displayValues)
+            bool found = false;
+            foreach (RadioPanelPZ69DisplayValue displayValue in _displayValues)
             {
                 if (displayValue.RadioPanelPZ69Knob == radioPanelPZ69Knob && displayValue.RadioPanelDisplay == radioPanelDisplay)
                 {
@@ -420,7 +412,7 @@ namespace NonVisuals.Radios
 
             if (!found)
             {
-                var displayValue = new RadioPanelPZ69DisplayValue
+                RadioPanelPZ69DisplayValue displayValue = new() 
                 {
                     RadioPanelPZ69Knob = radioPanelPZ69Knob,
                     RadioPanelDisplay = radioPanelDisplay,
@@ -442,8 +434,8 @@ namespace NonVisuals.Radios
                 return;
             }
 
-            var found = false;
-            foreach (var keyBinding in _keyBindings)
+            bool found = false;
+            foreach (KeyBindingPZ69 keyBinding in _keyBindings)
             {
                 if (keyBinding.RadioPanelPZ69Key == pz69SwitchOnOff.Switch && keyBinding.WhenTurnedOn == pz69SwitchOnOff.ButtonState)
                 {
@@ -455,14 +447,13 @@ namespace NonVisuals.Radios
                     {
                         keyBinding.OSKeyPress = new KeyPress(keyPress, keyPressLength);
                     }
-
                     found = true;
                 }
             }
 
             if (!found && !string.IsNullOrEmpty(keyPress))
             {
-                var keyBinding = new KeyBindingPZ69
+                KeyBindingPZ69 keyBinding = new() 
                 {
                     RadioPanelPZ69Key = pz69SwitchOnOff.Switch,
                     OSKeyPress = new KeyPress(keyPress, keyPressLength),
@@ -485,8 +476,8 @@ namespace NonVisuals.Radios
                 return;
             }
 
-            var found = false;
-            foreach (var keyBinding in _keyBindings)
+            bool found = false;
+            foreach (KeyBindingPZ69 keyBinding in _keyBindings)
             {
                 if (keyBinding.RadioPanelPZ69Key == pz69SwitchOnOff.Switch && keyBinding.WhenTurnedOn == pz69SwitchOnOff.ButtonState)
                 {
@@ -506,7 +497,7 @@ namespace NonVisuals.Radios
 
             if (!found && keySequence.Count > 0)
             {
-                var keyBinding = new KeyBindingPZ69
+                KeyBindingPZ69 keyBinding = new() 
                 {
                     RadioPanelPZ69Key = pz69SwitchOnOff.Switch,
                     OSKeyPress = new KeyPress(description, keySequence),
@@ -536,9 +527,8 @@ namespace NonVisuals.Radios
                 return;
             }
 
-            var found = false;
-
-            foreach (var tmpBipLink in _bipLinks)
+            bool found = false;
+            foreach (BIPLinkPZ69 tmpBipLink in _bipLinks)
             {
                 if (tmpBipLink.RadioPanelPZ69Knob == pz69SwitchOnOff.Switch && tmpBipLink.WhenTurnedOn == pz69SwitchOnOff.ButtonState)
                 {
@@ -564,8 +554,7 @@ namespace NonVisuals.Radios
         {
             var pz69SwitchOnOff = (PZ69SwitchOnOff)panelSwitchOnOff;
 
-            var found = false;
-
+            bool found = false;
             foreach (var operatingSystemCommandBinding in _operatingSystemCommandBindings)
             {
                 if (operatingSystemCommandBinding.RadioPanelPZ69Key == pz69SwitchOnOff.Switch && operatingSystemCommandBinding.WhenTurnedOn == pz69SwitchOnOff.ButtonState)
@@ -578,7 +567,7 @@ namespace NonVisuals.Radios
 
             if (!found)
             {
-                var operatingSystemCommandBindingPZ69 = new OSCommandBindingPZ69Emulator
+                OSCommandBindingPZ69Emulator operatingSystemCommandBindingPZ69 = new() 
                 {
                     RadioPanelPZ69Key = pz69SwitchOnOff.Switch,
                     OSCommandObject = operatingSystemCommand,
@@ -592,7 +581,7 @@ namespace NonVisuals.Radios
 
         public void ClearAllBindings(PZ69SwitchOnOff radioPanelPZ69KnobOnOff)
         {
-            foreach (var keyBinding in _keyBindings)
+            foreach (KeyBindingPZ69 keyBinding in _keyBindings)
             {
                 if (keyBinding.RadioPanelPZ69Key == radioPanelPZ69KnobOnOff.Switch && keyBinding.WhenTurnedOn == radioPanelPZ69KnobOnOff.ButtonState)
                 {
@@ -613,16 +602,15 @@ namespace NonVisuals.Radios
         {
             var controlListPZ69 = (ControlList) controlList;
             var pz69SwitchOnOff = (PZ69SwitchOnOff) panelSwitchOnOff;
-            var found = false;
+            bool found = false;
             if (controlListPZ69 == ControlList.ALL || controlListPZ69 == ControlList.KEYS)
             {
-                foreach (var keyBindingPZ55 in _keyBindings)
+                foreach (KeyBindingPZ69 keyBindingPZ55 in _keyBindings)
                 {
                     if (keyBindingPZ55.RadioPanelPZ69Key == pz69SwitchOnOff.Switch && keyBindingPZ55.WhenTurnedOn == pz69SwitchOnOff.ButtonState)
                     {
                         keyBindingPZ55.OSKeyPress = null;
                     }
-
                     found = true;
                     break;
                 }
@@ -630,13 +618,12 @@ namespace NonVisuals.Radios
 
             if (controlListPZ69 == ControlList.ALL || controlListPZ69 == ControlList.BIPS)
             {
-                foreach (var bipLink in _bipLinks)
+                foreach (BIPLinkPZ69 bipLink in _bipLinks)
                 {
                     if (bipLink.RadioPanelPZ69Knob == pz69SwitchOnOff.Switch && bipLink.WhenTurnedOn == pz69SwitchOnOff.ButtonState)
                     {
                         bipLink.BIPLights.Clear();
                     }
-
                     found = true;
                     break;
                 }
@@ -670,14 +657,13 @@ namespace NonVisuals.Radios
 
         public void Clear(RadioPanelPZ69KnobsEmulator radioPanelPZ69Knob)
         {
-            foreach (var keyBinding in _keyBindings)
+            foreach (KeyBindingPZ69 keyBinding in _keyBindings)
             {
                 if (keyBinding.RadioPanelPZ69Key == radioPanelPZ69Knob)
                 {
                     keyBinding.OSKeyPress = null;
                 }
             }
-
             SetIsDirty();
         }
 
@@ -688,7 +674,7 @@ namespace NonVisuals.Radios
 
         public override DcsOutputAndColorBinding CreateDcsOutputAndColorBinding(SaitekPanelLEDPosition saitekPanelLEDPosition, PanelLEDColor panelLEDColor, DCSBIOSOutput dcsBiosOutput)
         {
-            var dcsOutputAndColorBinding = new DcsOutputAndColorBindingPZ55
+            DcsOutputAndColorBindingPZ55 dcsOutputAndColorBinding = new() 
             {
                 DCSBiosOutputLED = dcsBiosOutput,
                 LEDColor = panelLEDColor,
@@ -701,8 +687,5 @@ namespace NonVisuals.Radios
         {
             SaitekPanelKnobs = RadioPanelPZ69KnobEmulator.GetRadioPanelKnobs();
         }
-
     }
-    
-
 }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69F14B.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69F14B.cs
@@ -52,10 +52,10 @@
         private uint _uhfSavedCockpitDial2Frequency;
         private uint _uhfSavedCockpitDial3Frequency;
         private uint _uhfSavedCockpitDial4Frequency;
-        private readonly object _lockUhfDialBigFreqObject = new object();
-        private readonly object _lockUhfDial3FreqObject = new object();
-        private readonly object _lockUhfDial4FreqObject = new object();
-        private readonly object _lockUhfPresetObject = new object();
+        private readonly object _lockUhfDialBigFreqObject = new();
+        private readonly object _lockUhfDial3FreqObject = new();
+        private readonly object _lockUhfDial4FreqObject = new();
+        private readonly object _lockUhfPresetObject = new();
         private DCSBIOSOutput _uhfDcsbiosOutputBigFrequencyNumber;
         private DCSBIOSOutput _uhfDcsbiosOutputDial3FrequencyNumber;
         private DCSBIOSOutput _uhfDcsbiosOutputDial4FrequencyNumber;
@@ -120,10 +120,10 @@
         private uint _vuhfSavedCockpitDial2Frequency;
         private uint _vuhfSavedCockpitDial3Frequency;
         private uint _vuhfSavedCockpitDial4Frequency;
-        private readonly object _lockVuhfBigFreqObject = new object();
-        private readonly object _lockVuhfDial3FreqObject = new object();
-        private readonly object _lockVuhfDial4FreqObject = new object();
-        private readonly object _lockVuhfPresetObject = new object();
+        private readonly object _lockVuhfBigFreqObject = new();
+        private readonly object _lockVuhfDial3FreqObject = new();
+        private readonly object _lockVuhfDial4FreqObject = new();
+        private readonly object _lockVuhfPresetObject = new();
         private DCSBIOSOutput _vuhfDcsbiosOutputBigFrequencyNumber;
         private DCSBIOSOutput _vuhfDcsbiosOutputDial3FrequencyNumber;
         private DCSBIOSOutput _vuhfDcsbiosOutputDial4FrequencyNumber;
@@ -176,9 +176,9 @@
         private int _pilotTacanSavedCockpitTensFrequency = 6;
         private int _pilotTacanSavedCockpitOnesFrequency = 5;
         private int _pilotTacanSavedCockpitXY;
-        private readonly object _lockPilotTacanTensDialObject = new object();
-        private readonly object _lockPilotTacanOnesObject = new object();
-        private readonly object _lockPilotTacanXYDialObject = new object();
+        private readonly object _lockPilotTacanTensDialObject = new();
+        private readonly object _lockPilotTacanOnesObject = new();
+        private readonly object _lockPilotTacanXYDialObject = new();
         private DCSBIOSOutput _pilotTacanDcsbiosOutputTensDial;
         private DCSBIOSOutput _pilotTacanDcsbiosOutputOnesDial;
         private DCSBIOSOutput _pilotTacanDcsbiosOutputXYDial;
@@ -204,9 +204,9 @@
         private int _rioTacanSavedCockpitTensFrequency = 6;
         private int _rioTacanSavedCockpitOnesFrequency = 5;
         private int _rioTacanSavedCockpitXY;
-        private readonly object _lockRioTacanTensDialObject = new object();
-        private readonly object _lockRioTacanOnesObject = new object();
-        private readonly object _lockRioTacanXYDialObject = new object();
+        private readonly object _lockRioTacanTensDialObject = new();
+        private readonly object _lockRioTacanOnesObject = new();
+        private readonly object _lockRioTacanXYDialObject = new();
         private DCSBIOSOutput _rioTacanDcsbiosOutputTensDial;
         private DCSBIOSOutput _rioTacanDcsbiosOutputOnesDial;
         private DCSBIOSOutput _rioTacanDcsbiosOutputXYDial;
@@ -230,9 +230,9 @@
         private int _rioLink4TensAndOnesFrequencyStandby;
         private int _rioLink4SavedCockpitHundredsFrequency;
         private int _rioLink4SavedCockpitTensAndOnesFrequency;
-        private readonly object _lockRioLink4HundredsDial = new object();
-        private readonly object _lockRioLink4TensDial = new object();
-        private readonly object _lockRioLink4OnesDial = new object();
+        private readonly object _lockRioLink4HundredsDial = new();
+        private readonly object _lockRioLink4TensDial = new();
+        private readonly object _lockRioLink4OnesDial = new();
         private DCSBIOSOutput _rioLink4DcsbiosOutputHundredsDial;
         private DCSBIOSOutput _rioLink4DcsbiosOutputTensDial;
         private DCSBIOSOutput _rioLink4DcsbiosOutputOnesDial;
@@ -254,7 +254,7 @@
         private readonly ClickSpeedDetector _rioLink4TensAndOnesClickSpeedDetector = new ClickSpeedDetector(20);
         private byte _skipRioLink4TensAndOnesFreqChange;
 
-        private readonly object _lockShowFrequenciesOnPanelObject = new object();
+        private readonly object _lockShowFrequenciesOnPanelObject = new();
 
         private long _doUpdatePanelLCD;
 

--- a/Source/NonVisuals/Radios/RadioPanelPZ69F14B.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69F14B.cs
@@ -294,7 +294,6 @@
         {
             UpdateCounter(e.Address, e.Data);
 
-
             /*
              * IMPORTANT INFORMATION REGARDING THE _*WaitingForFeedback variables
              * Once a dial has been deemed to be "off" position and needs to be changed
@@ -665,7 +664,6 @@
                                         SendUHFToDCSBIOS();
                                         ShowFrequenciesOnPanel();
                                     }
-
                                     break;
                                 }
 
@@ -676,7 +674,6 @@
                                         SendVUHFToDCSBIOS();
                                         ShowFrequenciesOnPanel();
                                     }
-
                                     break;
                                 }
 
@@ -721,7 +718,6 @@
                                         SendUHFToDCSBIOS();
                                         ShowFrequenciesOnPanel();
                                     }
-
                                     break;
                                 }
 
@@ -732,7 +728,6 @@
                                         SendVUHFToDCSBIOS();
                                         ShowFrequenciesOnPanel();
                                     }
-
                                     break;
                                 }
 
@@ -758,7 +753,6 @@
                     }
             }
         }
-
 
         private void SendUHFToDCSBIOS()
         {
@@ -822,7 +816,6 @@
                     var dial3SendCount = 0;
                     var dial4SendCount = 0;
 
-
                     do
                     {
                         if (IsTimedOut(ref dial1Timeout))
@@ -857,7 +850,6 @@
                                     dial1SendCount++;
                                     Interlocked.Exchange(ref _uhfDial1WaitingForFeedback, 1);
                                 }
-
                                 Reset(ref dial1Timeout);
                             }
                         }
@@ -878,7 +870,6 @@
                                     dial2SendCount++;
                                     Interlocked.Exchange(ref _uhfDial2WaitingForFeedback, 1);
                                 }
-
                                 Reset(ref dial2Timeout);
                             }
                         }
@@ -900,7 +891,6 @@
                                     Interlocked.Exchange(ref _uhfDial3WaitingForFeedback, 1);
                                 }
                             }
-
                             Reset(ref dial3Timeout);
                         }
                         else
@@ -920,7 +910,6 @@
                                     dial4SendCount++;
                                     Interlocked.Exchange(ref _uhfDial4WaitingForFeedback, 1);
                                 }
-
                                 Reset(ref dial4Timeout);
                             }
                         }
@@ -957,7 +946,6 @@
             {
                 Interlocked.Exchange(ref _uhfThreadNowSynching, 0);
             }
-
             Interlocked.Increment(ref _doUpdatePanelLCD);
         }
         
@@ -1023,7 +1011,6 @@
                     var dial3SendCount = 0;
                     var dial4SendCount = 0;
 
-
                     do
                     {
                         if (IsTimedOut(ref dial1Timeout))
@@ -1058,7 +1045,6 @@
                                     dial1SendCount++;
                                     Interlocked.Exchange(ref _vuhfDial1WaitingForFeedback, 1);
                                 }
-
                                 Reset(ref dial1Timeout);
                             }
                         }
@@ -1079,7 +1065,6 @@
                                     dial2SendCount++;
                                     Interlocked.Exchange(ref _vuhfDial2WaitingForFeedback, 1);
                                 }
-
                                 Reset(ref dial2Timeout);
                             }
                         }
@@ -1101,7 +1086,6 @@
                                     Interlocked.Exchange(ref _vuhfDial3WaitingForFeedback, 1);
                                 }
                             }
-
                             Reset(ref dial3Timeout);
                         }
                         else
@@ -1121,7 +1105,6 @@
                                     dial4SendCount++;
                                     Interlocked.Exchange(ref _vuhfDial4WaitingForFeedback, 1);
                                 }
-
                                 Reset(ref dial4Timeout);
                             }
                         }
@@ -1139,9 +1122,7 @@
                             dial4SendCount = 0;
                             Thread.Sleep(5000);
                         }
-
                         Thread.Sleep(SynchSleepTime); // Should be enough to get an update cycle from DCS-BIOS
-
                     }
                     while ((IsTooShort(dial1OkTime) || IsTooShort(dial2OkTime) || IsTooShort(dial3OkTime) || IsTooShort(dial4OkTime)) && !_shutdownVUHFThread);
                     SwapCockpitStandbyFrequencyVuhf();
@@ -1158,10 +1139,8 @@
             {
                 Interlocked.Exchange(ref _vuhfThreadNowSynching, 0);
             }
-
             Interlocked.Increment(ref _doUpdatePanelLCD);
         }
-
 
         private void SendLink4ToDCSBIOS()
         {
@@ -1201,10 +1180,8 @@
                     var dial2SendCount = 0;
                     var dial3SendCount = 0;
 
-
                     do
                     {
-
                         if (IsTimedOut(ref dial1Timeout))
                         {
                            ResetWaitingForFeedBack(ref _rioLinkHundredsWaitingForFeedback); // Lets do an ugly reset
@@ -1232,7 +1209,6 @@
                                     dial1SendCount++;
                                     Interlocked.Exchange(ref _rioLinkHundredsWaitingForFeedback, 1);
                                 }
-
                                 Reset(ref dial1Timeout);
                             }
                         }
@@ -1253,7 +1229,6 @@
                                     dial1SendCount++;
                                     Interlocked.Exchange(ref _rioLinkTensWaitingForFeedback, 1);
                                 }
-
                                 Reset(ref dial1Timeout);
                             }
                         }
@@ -1274,7 +1249,6 @@
                                     dial1SendCount++;
                                     Interlocked.Exchange(ref _rioLinkOnesWaitingForFeedback, 1);
                                 }
-
                                 Reset(ref dial1Timeout);
                             }
                         }
@@ -1291,10 +1265,7 @@
                             dial3SendCount = 0;
                             Thread.Sleep(5000);
                         }
-
                         Thread.Sleep(SynchSleepTime); // Should be enough to get an update cycle from DCS-BIOS
-
-
                     }
                     while ((IsTooShort(dial1OkTime) || IsTooShort(dial2OkTime) || IsTooShort(dial3OkTime)) && !_shutdownRIOLink4Thread);
                     SwapCockpitStandbyFrequencyDataLink4();
@@ -1311,11 +1282,8 @@
             {
                 Interlocked.Exchange(ref _rioLink4ThreadNowSynching, 0);
             }
-
             Interlocked.Increment(ref _doUpdatePanelLCD);
         }
-
-
 
         private void SendPilotTacanToDCSBIOS()
         {
@@ -1368,10 +1336,8 @@
                     var dial2SendCount = 0;
                     var dial3SendCount = 0;
 
-
                     do
                     {
-
                         if (IsTimedOut(ref dial1Timeout))
                         {
                             ResetWaitingForFeedBack(ref _pilotTacanTensWaitingForFeedback); // Lets do an ugly reset
@@ -1389,7 +1355,6 @@
 
                         if (Interlocked.Read(ref _pilotTacanTensWaitingForFeedback) == 0)
                         {
-
                             lock (_lockPilotTacanTensDialObject)
                             {
                                 if (_pilotTacanCockpitTensDialPos != desiredPositionDial1)
@@ -1400,7 +1365,6 @@
                                     dial1SendCount++;
                                     Interlocked.Exchange(ref _pilotTacanTensWaitingForFeedback, 1);
                                 }
-
                                 Reset(ref dial1Timeout);
                             }
                         }
@@ -1423,7 +1387,6 @@
                                     dial2SendCount++;
                                     Interlocked.Exchange(ref _pilotTacanOnesWaitingForFeedback, 1);
                                 }
-
                                 Reset(ref dial2Timeout);
                             }
                         }
@@ -1434,7 +1397,6 @@
 
                         if (Interlocked.Read(ref _pilotTacanXYWaitingForFeedback) == 0)
                         {
-
                             lock (_lockPilotTacanXYDialObject)
                             {
                                 if (_pilotTacanCockpitXYDialPos != desiredPositionDial3)
@@ -1447,7 +1409,6 @@
                                     Interlocked.Exchange(ref _pilotTacanXYWaitingForFeedback, 1);
                                 }
                             }
-
                             Reset(ref dial3Timeout);
                         }
                         else
@@ -1463,10 +1424,7 @@
                             dial3SendCount = 0;
                             Thread.Sleep(5000);
                         }
-
                         Thread.Sleep(SynchSleepTime); // Should be enough to get an update cycle from DCS-BIOS
-
-
                     }
                     while ((IsTooShort(dial1OkTime) || IsTooShort(dial2OkTime) || IsTooShort(dial3OkTime)) && !_shutdownPilotTACANThread);
                     SwapPilotCockpitStandbyFrequencyTacan();
@@ -1486,7 +1444,6 @@
 
             Interlocked.Increment(ref _doUpdatePanelLCD);
         }
-
 
         private void SendRioTacanToDCSBIOS()
         {
@@ -1524,10 +1481,8 @@
                     var dial2SendCount = 0;
                     var dial3SendCount = 0;
 
-
                     do
                     {
-
                         if (IsTimedOut(ref dial1Timeout))
                         {
                             ResetWaitingForFeedBack(ref _rioTacanTensWaitingForFeedback); // Lets do an ugly reset
@@ -1556,7 +1511,6 @@
                                     dial1SendCount++;
                                     Interlocked.Exchange(ref _rioTacanTensWaitingForFeedback, 1);
                                 }
-
                                 Reset(ref dial1Timeout);
                             }
                         }
@@ -1579,7 +1533,6 @@
                                     dial2SendCount++;
                                     Interlocked.Exchange(ref _rioTacanOnesWaitingForFeedback, 1);
                                 }
-
                                 Reset(ref dial2Timeout);
                             }
                         }
@@ -1590,7 +1543,6 @@
 
                         if (Interlocked.Read(ref _rioTacanXYWaitingForFeedback) == 0)
                         {
-
                             lock (_lockRioTacanXYDialObject)
                             {
                                 if (_rioTacanCockpitXYDialPos != desiredPositionDial3)
@@ -1603,7 +1555,6 @@
                                     Interlocked.Exchange(ref _rioTacanXYWaitingForFeedback, 1);
                                 }
                             }
-
                             Reset(ref dial3Timeout);
                         }
                         else
@@ -1619,10 +1570,7 @@
                             dial3SendCount = 0;
                             Thread.Sleep(5000);
                         }
-
                         Thread.Sleep(SynchSleepTime); // Should be enough to get an update cycle from DCS-BIOS
-
-
                     }
                     while ((IsTooShort(dial1OkTime) || IsTooShort(dial2OkTime) || IsTooShort(dial3OkTime)) && !_shutdownRIOTACANThread);
                     SwapRioCockpitStandbyFrequencyTacan();
@@ -1639,7 +1587,6 @@
             {
                 Interlocked.Exchange(ref _rioTacanThreadNowSynching, 0);
             }
-
             Interlocked.Increment(ref _doUpdatePanelLCD);
         }
 
@@ -1689,7 +1636,6 @@
                                     SetPZ69DisplayBytesDefault(ref bytes, _uhfBigFrequencyStandby + (((double)_uhfSmallFrequencyStandby) / 1000), PZ69LCDPosition.UPPER_STBY_RIGHT);
                                 }
                             }
-
                             break;
                         }
 
@@ -1719,7 +1665,6 @@
                                     SetPZ69DisplayBytesDefault(ref bytes, _vuhfBigFrequencyStandby + (((double)_vuhfSmallFrequencyStandby) / 1000), PZ69LCDPosition.UPPER_STBY_RIGHT);
                                 }
                             }
-
                             break;
                         }
 
@@ -1748,7 +1693,6 @@
                             {
                                 frequencyAsString += _pilotTacanCockpitXYDialPos;
                             }
-
                             SetPZ69DisplayBytes(ref bytes, double.Parse(frequencyAsString, NumberFormatInfoFullDisplay), 1, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
                             SetPZ69DisplayBytes(ref bytes, double.Parse(_pilotTacanTensFrequencyStandby + _pilotTacanOnesFrequencyStandby.ToString() + "." + _pilotTacanXYStandby, NumberFormatInfoFullDisplay), 1, PZ69LCDPosition.UPPER_STBY_RIGHT);
                             break;
@@ -1770,7 +1714,6 @@
                             {
                                 frequencyAsString += _rioTacanCockpitXYDialPos;
                             }
-
                             SetPZ69DisplayBytes(ref bytes, double.Parse(frequencyAsString, NumberFormatInfoFullDisplay), 1, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
                             SetPZ69DisplayBytes(ref bytes, double.Parse(_rioTacanTensFrequencyStandby + _rioTacanOnesFrequencyStandby.ToString() + "." + _rioTacanXYStandby, NumberFormatInfoFullDisplay), 1, PZ69LCDPosition.UPPER_STBY_RIGHT);
                             break;
@@ -1805,11 +1748,9 @@
                                         }
                                     }
                                 }
-
                                 SetPZ69DisplayBytesDefault(ref bytes, frequencyAsString.PadLeft(5,' '), PZ69LCDPosition.UPPER_ACTIVE_LEFT);
                                 SetPZ69DisplayBytesDefault(ref bytes, _rioLink4HundredsFrequencyStandby + _rioLink4TensAndOnesFrequencyStandby.ToString().PadLeft(2, '0'), PZ69LCDPosition.UPPER_STBY_RIGHT);
                             }
-
                             break;
                         }
 
@@ -1848,7 +1789,6 @@
                                     SetPZ69DisplayBytesDefault(ref bytes, _uhfBigFrequencyStandby + (((double)_uhfSmallFrequencyStandby) / 1000), PZ69LCDPosition.LOWER_STBY_RIGHT);
                                 }
                             }
-
                             break;
                         }
 
@@ -1878,7 +1818,6 @@
                                     SetPZ69DisplayBytesDefault(ref bytes, _vuhfBigFrequencyStandby + (((double)_vuhfSmallFrequencyStandby) / 1000), PZ69LCDPosition.LOWER_STBY_RIGHT);
                                 }
                             }
-
                             break;
                         }
 
@@ -1898,7 +1837,6 @@
                             {
                                 frequencyAsString += _pilotTacanCockpitXYDialPos;
                             }
-
                             SetPZ69DisplayBytes(ref bytes, double.Parse(frequencyAsString, NumberFormatInfoFullDisplay), 1, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
                             SetPZ69DisplayBytes(ref bytes, double.Parse(_pilotTacanTensFrequencyStandby + _pilotTacanOnesFrequencyStandby.ToString() + "." + _pilotTacanXYStandby, NumberFormatInfoFullDisplay), 1, PZ69LCDPosition.LOWER_STBY_RIGHT);
                             break;
@@ -1920,7 +1858,6 @@
                             {
                                 frequencyAsString += _rioTacanCockpitXYDialPos;
                             }
-
                             SetPZ69DisplayBytes(ref bytes, double.Parse(frequencyAsString, NumberFormatInfoFullDisplay), 1, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
                             SetPZ69DisplayBytes(ref bytes, double.Parse(_rioTacanTensFrequencyStandby + _rioTacanOnesFrequencyStandby.ToString() + "." + _rioTacanXYStandby, NumberFormatInfoFullDisplay), 1, PZ69LCDPosition.LOWER_STBY_RIGHT);
                             break;
@@ -1955,11 +1892,9 @@
                                         }
                                     }
                                 }
-
                                 SetPZ69DisplayBytesDefault(ref bytes, frequencyAsString.PadLeft(5, ' '), PZ69LCDPosition.LOWER_ACTIVE_LEFT);
                                 SetPZ69DisplayBytesDefault(ref bytes, _rioLink4HundredsFrequencyStandby + _rioLink4TensAndOnesFrequencyStandby.ToString().PadLeft(2, '0'), PZ69LCDPosition.LOWER_STBY_RIGHT);
                             }
-
                             break;
                         }
 
@@ -1972,7 +1907,6 @@
                 }
                 SendLCDData(bytes);
             }
-
             Interlocked.Decrement(ref _doUpdatePanelLCD);
         }
 
@@ -1994,7 +1928,6 @@
                     }
                 }
             }
-
             return frequencyAsString;
         }
 
@@ -2016,7 +1949,6 @@
                     }
                 }
             }
-
             return frequencyAsString;
         }
 
@@ -2066,7 +1998,6 @@
                                                     _uhfBigFrequencyStandby++;
                                                 }
                                             }
-
                                             break;
                                         }
 
@@ -2094,7 +2025,6 @@
                                                     AdjustVUHFBigFrequency(true);
                                                 }
                                             }
-
                                             break;
                                         }
 
@@ -2148,7 +2078,6 @@
 
                                                 _rioLink4HundredsFrequencyStandby++;
                                             }
-
                                             break;
                                         }
                                 }
@@ -2184,7 +2113,6 @@
                                                     _uhfBigFrequencyStandby--;
                                                 }
                                             }
-
                                             break;
                                         }
 
@@ -2209,7 +2137,6 @@
                                                     AdjustVUHFBigFrequency(false);
                                                 }
                                             }
-
                                             break;
                                         }
 
@@ -2263,7 +2190,6 @@
 
                                                 _rioLink4HundredsFrequencyStandby--;
                                             }
-
                                             break;
                                         }
                                 }
@@ -2288,7 +2214,6 @@
                                             {
                                                 UHFSmallFrequencyStandbyAdjust(true);
                                             }
-
                                             break;
                                         }
 
@@ -2306,7 +2231,6 @@
                                             {
                                                 VUHFSmallFrequencyStandbyAdjust(true);
                                             }
-
                                             break;
                                         }
 
@@ -2372,7 +2296,6 @@
                                             {
                                                 UHFSmallFrequencyStandbyAdjust(false);
                                             }
-
                                             break;
                                         }
 
@@ -2390,7 +2313,6 @@
                                             {
                                                 VUHFSmallFrequencyStandbyAdjust(false);
                                             }
-
                                             break;
                                         }
 
@@ -2470,7 +2392,6 @@
                                                     _uhfBigFrequencyStandby += 1;
                                                 }
                                             }
-
                                             break;
                                         }
 
@@ -2498,7 +2419,6 @@
                                                     AdjustVUHFBigFrequency(true);
                                                 }
                                             }
-
                                             break;
                                         }
 
@@ -2552,7 +2472,6 @@
 
                                                 _rioLink4HundredsFrequencyStandby++;
                                             }
-
                                             break;
                                         }
                                 }
@@ -2588,7 +2507,6 @@
                                                     _uhfBigFrequencyStandby -= 1;
                                                 }
                                             }
-
                                             break;
                                         }
 
@@ -2614,7 +2532,6 @@
                                                     AdjustVUHFBigFrequency(false);
                                                 }
                                             }
-
                                             break;
                                         }
 
@@ -2668,7 +2585,6 @@
 
                                                 _rioLink4HundredsFrequencyStandby--;
                                             }
-
                                             break;
                                         }
                                 }
@@ -2693,7 +2609,6 @@
                                             {
                                                 UHFSmallFrequencyStandbyAdjust(true);
                                             }
-
                                             break;
                                         }
 
@@ -2711,7 +2626,6 @@
                                             {
                                                 VUHFSmallFrequencyStandbyAdjust(true);
                                             }
-
                                             break;
                                         }
 
@@ -2777,7 +2691,6 @@
                                             {
                                                 UHFSmallFrequencyStandbyAdjust(false);
                                             }
-
                                             break;
                                         }
 
@@ -2795,7 +2708,6 @@
                                             {
                                                 VUHFSmallFrequencyStandbyAdjust(false);
                                             }
-
                                             break;
                                         }
 
@@ -2845,11 +2757,9 @@
                     }
                 }
             }
-
             Interlocked.Increment(ref _doUpdatePanelLCD);
             ShowFrequenciesOnPanel();
         }
-
 
         private void Link4TensAndOnesFrequencyStandbyAdjust(bool increase)
         {
@@ -3008,7 +2918,6 @@
                 _uhfBigFrequencyStandby = 225;
             }
 
-
             // TACAN
             // 00X/Y - 129X/Y
             if (_pilotTacanTensFrequencyStandby < 0)
@@ -3064,7 +2973,6 @@
                                 {
                                     _currentUpperRadioMode = CurrentF14RadioMode.UHF;
                                 }
-
                                 break;
                             }
 
@@ -3074,7 +2982,6 @@
                                 {
                                     _currentUpperRadioMode = CurrentF14RadioMode.VUHF;
                                 }
-
                                 break;
                             }
 
@@ -3084,7 +2991,6 @@
                                 {
                                     _currentUpperRadioMode = CurrentF14RadioMode.PLT_TACAN;
                                 }
-
                                 break;
                             }
 
@@ -3094,7 +3000,6 @@
                                 {
                                     _currentUpperRadioMode = CurrentF14RadioMode.RIO_TACAN;
                                 }
-
                                 break;
                             }
 
@@ -3104,7 +3009,6 @@
                                 {
                                     _currentUpperRadioMode = CurrentF14RadioMode.LINK4;
                                 }
-
                                 break;
                             }
 
@@ -3115,7 +3019,6 @@
                                 {
                                     _currentUpperRadioMode = CurrentF14RadioMode.NOUSE;
                                 }
-
                                 break;
                             }
 
@@ -3125,7 +3028,6 @@
                                 {
                                     _currentLowerRadioMode = CurrentF14RadioMode.UHF;
                                 }
-
                                 break;
                             }
 
@@ -3135,7 +3037,6 @@
                                 {
                                     _currentLowerRadioMode = CurrentF14RadioMode.VUHF;
                                 }
-
                                 break;
                             }
 
@@ -3145,7 +3046,6 @@
                                 {
                                     _currentLowerRadioMode = CurrentF14RadioMode.PLT_TACAN;
                                 }
-
                                 break;
                             }
 
@@ -3155,7 +3055,6 @@
                                 {
                                     _currentLowerRadioMode = CurrentF14RadioMode.RIO_TACAN;
                                 }
-
                                 break;
                             }
 
@@ -3165,7 +3064,6 @@
                                 {
                                     _currentLowerRadioMode = CurrentF14RadioMode.LINK4;
                                 }
-
                                 break;
                             }
 
@@ -3176,7 +3074,6 @@
                                 {
                                     _currentLowerRadioMode = CurrentF14RadioMode.NOUSE;
                                 }
-
                                 break;
                             }
 
@@ -3234,7 +3131,6 @@
 
                                     _upperButtonPressedAndDialRotated = false;
                                 }
-
                                 break;
                             }
 
@@ -3252,18 +3148,15 @@
 
                                     _lowerButtonPressedAndDialRotated = false;
                                 }
-
                                 break;
                             }
                     }
-
                     
                     if (PluginManager.PlugSupportActivated && PluginManager.HasPlugin())
                     {
                         PluginManager.DoEvent(DCSFPProfile.SelectedProfile.Description, HIDInstance, PluginGamingPanelEnum.PZ69RadioPanel_PreProg_F14B, (int)radioPanelKnob.RadioPanelPZ69Knob, radioPanelKnob.IsOn, null);
                     }
                 }
-
                 AdjustFrequency(hashSet);
             }
         }
@@ -3322,7 +3215,7 @@
 
         public override DcsOutputAndColorBinding CreateDcsOutputAndColorBinding(SaitekPanelLEDPosition saitekPanelLEDPosition, PanelLEDColor panelLEDColor, DCSBIOSOutput dcsBiosOutput)
         {
-            var dcsOutputAndColorBinding = new DcsOutputAndColorBindingPZ55
+            DcsOutputAndColorBindingPZ55 dcsOutputAndColorBinding = new() 
             {
                 DCSBiosOutputLED = dcsBiosOutput,
                 LEDColor = panelLEDColor,
@@ -3372,7 +3265,6 @@
                 }
             }
         }
-
 
         private void SaveCockpitFrequencyVuhf()
         {
@@ -3588,10 +3480,8 @@
                     break;
                 }
             }
-
             return counterUp > counterDown ? dec : inc;
         }
     }
-
 }
 

--- a/Source/NonVisuals/Radios/RadioPanelPZ69F5E.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69F5E.cs
@@ -45,11 +45,11 @@
         private double _uhfSmallFrequencyStandby;
         private double _uhfSavedCockpitBigFrequency;
         private double _uhfSavedCockpitSmallFrequency;
-        private readonly object _lockUhfDialsObject1 = new object();
-        private readonly object _lockUhfDialsObject2 = new object();
-        private readonly object _lockUhfDialsObject3 = new object();
-        private readonly object _lockUhfDialsObject4 = new object();
-        private readonly object _lockUhfDialsObject5 = new object();
+        private readonly object _lockUhfDialsObject1 = new();
+        private readonly object _lockUhfDialsObject2 = new();
+        private readonly object _lockUhfDialsObject3 = new();
+        private readonly object _lockUhfDialsObject4 = new();
+        private readonly object _lockUhfDialsObject5 = new();
         private DCSBIOSOutput _uhfDcsbiosOutputFreqDial1;
         private DCSBIOSOutput _uhfDcsbiosOutputFreqDial2;
         private DCSBIOSOutput _uhfDcsbiosOutputFreqDial3;
@@ -101,9 +101,9 @@
         private int _tacanSavedCockpitBigFrequency = 6;
         private int _tacanSavedCockpitSmallFrequency = 5;
         private int _tacanSavedCockpitXY;
-        private readonly object _lockTacanDialsObject1 = new object();
-        private readonly object _lockTacanDialsObject2 = new object();
-        private readonly object _lockTacanDialsObject3 = new object();
+        private readonly object _lockTacanDialsObject1 = new();
+        private readonly object _lockTacanDialsObject2 = new();
+        private readonly object _lockTacanDialsObject3 = new();
         private DCSBIOSOutput _tacanDcsbiosOutputFreqChannel;
         private volatile uint _tacanCockpitFreq1DialPos = 1;
         private volatile uint _tacanCockpitFreq2DialPos = 1;
@@ -117,7 +117,7 @@
         private long _tacanDial2WaitingForFeedback;
         private long _tacanDial3WaitingForFeedback;
 
-        private readonly object _lockShowFrequenciesOnPanelObject = new object();
+        private readonly object _lockShowFrequenciesOnPanelObject = new();
 
         private long _doUpdatePanelLCD;
 

--- a/Source/NonVisuals/Radios/RadioPanelPZ69F5E.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69F5E.cs
@@ -265,7 +265,6 @@
                 }
             }
 
-
             // TACAN is set via String listener
 
             // Set once
@@ -390,7 +389,6 @@
                                     {
                                         SendUhfToDCSBIOS();
                                     }
-
                                     break;
                                 }
 
@@ -400,7 +398,6 @@
                                     break;
                                 }
                         }
-
                         break;
                     }
 
@@ -414,7 +411,6 @@
                                     {
                                         SendUhfToDCSBIOS();
                                     }
-
                                     break;
                                 }
 
@@ -424,7 +420,6 @@
                                     break;
                                 }
                         }
-
                         break;
                     }
             }
@@ -472,39 +467,14 @@
             freqDial4 = int.Parse(frequencyAsString.Substring(4, 1));
 
             var tmp = int.Parse(frequencyAsString.Substring(5, 1));
-            switch (tmp)
+            freqDial5 = tmp switch
             {
-                case 0:
-                    {
-                        freqDial5 = 0;
-                        break;
-                    }
-
-                case 2:
-                    {
-                        freqDial5 = 1;
-                        break;
-                    }
-
-                case 5:
-                    {
-                        freqDial5 = 2;
-                        break;
-                    }
-
-                case 7:
-                    {
-                        freqDial5 = 3;
-                        break;
-                    }
-
-                default:
-                    {
-                        // Safeguard in case it is in a invalid position
-                        freqDial5 = 0;
-                        break;
-                    }
-            }
+                0 => 0,
+                2 => 1,
+                5 => 2,
+                7 => 3,
+                _ => 0  // Safeguard in case it is in a invalid position
+            };
 
             _shutdownUHFThread = true;
             Thread.Sleep(Constants.ThreadShutDownWaitTime);
@@ -807,7 +777,6 @@
                     var dial1SendCount = 0;
                     var dial2SendCount = 0;
                     var dial3SendCount = 0;
-
 
                     do
                     {
@@ -1122,7 +1091,6 @@
                                     SetPZ69DisplayBytesDefault(ref bytes, _uhfBigFrequencyStandby + _uhfSmallFrequencyStandby, PZ69LCDPosition.LOWER_STBY_RIGHT);
                                 }
                             }
-
                             break;
                         }
 
@@ -1719,7 +1687,6 @@
         {
             // Crude fix if any freqs are outside the valid boundaries
 
-
             // UHF
             // 225.000 - 399.975 MHz
             if (_uhfBigFrequencyStandby < 100)
@@ -1787,7 +1754,6 @@
                                 {
                                     _currentUpperRadioMode = CurrentF5ERadioMode.UHF;
                                 }
-
                                 break;
                             }
 
@@ -1797,7 +1763,6 @@
                                 {
                                     _currentUpperRadioMode = CurrentF5ERadioMode.TACAN;
                                 }
-
                                 break;
                             }
 
@@ -1811,7 +1776,6 @@
                                 {
                                     _currentUpperRadioMode = CurrentF5ERadioMode.NO_USE;
                                 }
-
                                 break;
                             }
 
@@ -1821,7 +1785,6 @@
                                 {
                                     _currentLowerRadioMode = CurrentF5ERadioMode.UHF;
                                 }
-
                                 break;
                             }
 
@@ -1831,7 +1794,6 @@
                                 {
                                     _currentLowerRadioMode = CurrentF5ERadioMode.TACAN;
                                 }
-
                                 break;
                             }
 
@@ -1845,7 +1807,6 @@
                                 {
                                     _currentLowerRadioMode = CurrentF5ERadioMode.NO_USE;
                                 }
-
                                 break;
                             }
 
@@ -1903,7 +1864,6 @@
 
                                     _upperButtonPressedAndDialRotated = false;
                                 }
-
                                 break;
                             }
 
@@ -1921,7 +1881,6 @@
 
                                     _lowerButtonPressedAndDialRotated = false;
                                 }
-
                                 break;
                             }
                     }
@@ -1964,12 +1923,11 @@
             }
         }
 
-
         public override void ClearSettings(bool setIsDirty = false) { }
 
         public override DcsOutputAndColorBinding CreateDcsOutputAndColorBinding(SaitekPanelLEDPosition saitekPanelLEDPosition, PanelLEDColor panelLEDColor, DCSBIOSOutput dcsBiosOutput)
         {
-            var dcsOutputAndColorBinding = new DcsOutputAndColorBindingPZ55
+            DcsOutputAndColorBindingPZ55 dcsOutputAndColorBinding = new()
             {
                 DCSBiosOutputLED = dcsBiosOutput,
                 LEDColor = panelLEDColor,
@@ -2011,32 +1969,13 @@
             {
                 case 1:
                     {
-                        switch (position)
+                        return position switch
                         {
-                            case 1:
-                                {
-                                    return "1";
-                                }
-
-                            case 2:
-                                {
-                                    return "2";
-                                }
-
-                            case 3:
-                                {
-                                    return "3";
-                                }
-
-                            case 4:
-                                {
-                                    return "4";
-
-                                    // throw new NotImplementedException("check how A should be treated.");
-                                    // return "0";//should be "A"
-                                }
-                        }
-                        break;
+                            1 => "1",
+                            2 => "2",
+                            3 => "3",
+                            4 => "4"
+                        };                        
                     }
 
                 case 2:
@@ -2048,33 +1987,16 @@
 
                 case 5:
                     {
-                        switch (position)
+                        // "00" "25" "50" "75", only "00" and "50" used.
+                        // Pos     0    1    2    3
+                        return position switch
                         {
-                            // "00" "25" "50" "75", only "00" and "50" used.
-                            // Pos     0    1    2    3
-                            case 0:
-                                {
-                                    return "0";
-                                }
-
-                            case 1:
-                                {
-                                    return "2";
-                                }
-
-                            case 2:
-                                {
-                                    return "5";
-                                }
-
-                            case 3:
-                                {
-                                    return "7";
-                                }
-                        }
+                            0 => "0",
+                            1 => "2",
+                            2 => "5",
+                            3 => "7"
+                        };
                     }
-
-                    break;
             }
             return string.Empty;
         }
@@ -2220,5 +2142,4 @@
         {
         }
     }
-
 }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69F86F.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69F86F.cs
@@ -33,13 +33,13 @@
         /*F-86F UHF ARC-27 PRESETS COM1*/
         // Large dial 1-18 [step of 1]
         // Small dial Power/Mode control
-        private readonly object _lockARC27PresetDialObject1 = new object();
+        private readonly object _lockARC27PresetDialObject1 = new();
         private DCSBIOSOutput _arc27PresetDcsbiosOutputPresetDial;
         private volatile uint _arc27PresetCockpitDialPos = 1;
         private const string ARC27_PRESET_COMMAND_INC = "ARC27_CHAN_SEL INC\n";
         private const string ARC27_PRESET_COMMAND_DEC = "ARC27_CHAN_SEL DEC\n";
         private int _arc27PresetDialSkipper;
-        private readonly object _lockARC27ModeDialObject1 = new object();
+        private readonly object _lockARC27ModeDialObject1 = new();
         private DCSBIOSOutput _arc27ModeDcsbiosOutputDial;
         private volatile uint _arc27ModeCockpitDialPos = 1;
         private const string ARC27_MODE_COMMAND_INC = "ARC27_PWR_SEL INC\n";
@@ -56,8 +56,8 @@
         // Small dial -> bands
         private readonly ClickSpeedDetector _bigFreqIncreaseChangeMonitor = new ClickSpeedDetector(20);
         private readonly ClickSpeedDetector _bigFreqDecreaseChangeMonitor = new ClickSpeedDetector(20);
-        private readonly object _lockARN6FrequencyObject = new object();
-        private readonly object _lockARN6BandObject = new object();
+        private readonly object _lockARN6FrequencyObject = new();
+        private readonly object _lockARN6BandObject = new();
         private volatile uint _arn6CockpitFrequency = 108;
         private volatile uint _arn6CockpitBand;
         private DCSBIOSOutput _arn6ManualDcsbiosOutputCockpitFrequency;
@@ -73,7 +73,7 @@
         /*F-86F ARN-6 MODES NAV2*/
         // Large dial MODES
         // Small dial volume control
-        private readonly object _lockARN6ModeObject = new object();
+        private readonly object _lockARN6ModeObject = new();
         private DCSBIOSOutput _arn6ModeDcsbiosOutputPresetDial;
         private volatile uint _arn6ModeCockpitDialPos = 1;
         private const string ARN6_MODE_COMMAND_INC = "ARN6_FUNC_SEL INC\n";
@@ -87,14 +87,14 @@
         // Small - No Use
         // ACT-STBY, Toggles IFF Dial Stop Button, button must be depressed to go into Emergency Mode.
         private volatile uint _apx6ModeCockpitDialPos = 1;
-        private readonly object _lockAPX6ModeObject = new object();
+        private readonly object _lockAPX6ModeObject = new();
         private int _apx6ModeDialSkipper;
         private DCSBIOSOutput _apx6ModeDcsbiosOutputCockpit;
         private const string APX6_MODE_DIAL_COMMAND_INC = "APX6_MASTER INC\n";
         private const string APX6_MODE_DIAL_COMMAND_DEC = "APX6_MASTER DEC\n";
         private const string APX_6DIAL_STOP_TOGGLE_COMMAND = "APX_6_IFF_DIAL_STOP TOGGLE\n";
 
-        private readonly object _lockShowFrequenciesOnPanelObject = new object();
+        private readonly object _lockShowFrequenciesOnPanelObject = new();
         private long _doUpdatePanelLCD;
 
         public RadioPanelPZ69F86F(HIDSkeleton hidSkeleton) : base(hidSkeleton)

--- a/Source/NonVisuals/Radios/RadioPanelPZ69F86F.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69F86F.cs
@@ -249,12 +249,10 @@
             }
         }
 
-
         private void SendFrequencyToDCSBIOS(RadioPanelPZ69KnobsF86F knob)
         {
             try
             {
-
                 if (IgnoreSwitchButtonOnce() && (knob == RadioPanelPZ69KnobsF86F.UPPER_FREQ_SWITCH || knob == RadioPanelPZ69KnobsF86F.LOWER_FREQ_SWITCH))
                 {
                     // Don't do anything on the very first button press as the panel sends ALL
@@ -344,7 +342,6 @@
             }
         }
 
-
         public void PZ69KnobChanged(bool isFirstReport, IEnumerable<object> hashSet)
         {
             if (isFirstReport)
@@ -369,7 +366,6 @@
                                     {
                                         SetUpperRadioMode(CurrentF86FRadioMode.ARC27_PRESET);
                                     }
-
                                     break;
                                 }
 
@@ -379,7 +375,6 @@
                                     {
                                         SetUpperRadioMode(CurrentF86FRadioMode.ARC27_VOL);
                                     }
-
                                     break;
                                 }
 
@@ -389,7 +384,6 @@
                                     {
                                         SetUpperRadioMode(CurrentF86FRadioMode.ARN6);
                                     }
-
                                     break;
                                 }
 
@@ -399,7 +393,6 @@
                                     {
                                         SetUpperRadioMode(CurrentF86FRadioMode.ARN6_MODES);
                                     }
-
                                     break;
                                 }
 
@@ -409,7 +402,6 @@
                                     {
                                         SetUpperRadioMode(CurrentF86FRadioMode.ADF_APX6);
                                     }
-
                                     break;
                                 }
 
@@ -420,7 +412,6 @@
                                     {
                                         SetUpperRadioMode(CurrentF86FRadioMode.NOUSE);
                                     }
-
                                     break;
                                 }
 
@@ -430,7 +421,6 @@
                                     {
                                         SetLowerRadioMode(CurrentF86FRadioMode.ARC27_PRESET);
                                     }
-
                                     break;
                                 }
 
@@ -440,7 +430,6 @@
                                     {
                                         SetLowerRadioMode(CurrentF86FRadioMode.ARC27_VOL);
                                     }
-
                                     break;
                                 }
 
@@ -450,7 +439,6 @@
                                     {
                                         SetLowerRadioMode(CurrentF86FRadioMode.ARN6);
                                     }
-
                                     break;
                                 }
 
@@ -460,7 +448,6 @@
                                     {
                                         SetLowerRadioMode(CurrentF86FRadioMode.ARN6_MODES);
                                     }
-
                                     break;
                                 }
 
@@ -470,7 +457,6 @@
                                     {
                                         SetLowerRadioMode(CurrentF86FRadioMode.ADF_APX6);
                                     }
-
                                     break;
                                 }
 
@@ -481,7 +467,6 @@
                                     {
                                         SetLowerRadioMode(CurrentF86FRadioMode.NOUSE);
                                     }
-
                                     break;
                                 }
 
@@ -507,7 +492,6 @@
                                             SendFrequencyToDCSBIOS(RadioPanelPZ69KnobsF86F.UPPER_FREQ_SWITCH);
                                         }
                                     }
-
                                     break;
                                 }
 
@@ -520,7 +504,6 @@
                                             SendFrequencyToDCSBIOS(RadioPanelPZ69KnobsF86F.LOWER_FREQ_SWITCH);
                                         }
                                     }
-
                                     break;
                                 }
                         }
@@ -566,7 +549,6 @@
                                                 {
                                                     DCSBIOS.Send(ARC27_PRESET_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -583,7 +565,6 @@
                                                 {
                                                     DCSBIOS.Send(ARN6_MODE_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -593,7 +574,6 @@
                                                 {
                                                     DCSBIOS.Send(APX6_MODE_DIAL_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -615,7 +595,6 @@
                                                 {
                                                     DCSBIOS.Send(ARC27_PRESET_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -632,7 +611,6 @@
                                                 {
                                                     DCSBIOS.Send(ARN6_MODE_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -642,7 +620,6 @@
                                                 {
                                                     DCSBIOS.Send(APX6_MODE_DIAL_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -664,7 +641,6 @@
                                                 {
                                                     DCSBIOS.Send(ARC27_MODE_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -680,7 +656,6 @@
                                                 {
                                                     DCSBIOS.Send(ARN6_BAND_DIAL_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -690,7 +665,6 @@
                                                 {
                                                     DCSBIOS.Send(ARN6_VOLUME_KNOB_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -713,7 +687,6 @@
                                                 {
                                                     DCSBIOS.Send(ARC27_MODE_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -729,7 +702,6 @@
                                                 {
                                                     DCSBIOS.Send(ARN6_BAND_DIAL_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -739,7 +711,6 @@
                                                 {
                                                     DCSBIOS.Send(ARN6_VOLUME_KNOB_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -762,7 +733,6 @@
                                                 {
                                                     DCSBIOS.Send(ARC27_PRESET_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -779,7 +749,6 @@
                                                 {
                                                     DCSBIOS.Send(ARN6_MODE_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -789,7 +758,6 @@
                                                 {
                                                     DCSBIOS.Send(APX6_MODE_DIAL_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -811,7 +779,6 @@
                                                 {
                                                     DCSBIOS.Send(ARC27_PRESET_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -828,7 +795,6 @@
                                                 {
                                                     DCSBIOS.Send(ARN6_MODE_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -838,7 +804,6 @@
                                                 {
                                                     DCSBIOS.Send(APX6_MODE_DIAL_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -860,7 +825,6 @@
                                                 {
                                                     DCSBIOS.Send(ARC27_MODE_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -876,7 +840,6 @@
                                                 {
                                                     DCSBIOS.Send(ARN6_BAND_DIAL_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -886,7 +849,6 @@
                                                 {
                                                     DCSBIOS.Send(ARN6_VOLUME_KNOB_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -909,7 +871,6 @@
                                                 {
                                                     DCSBIOS.Send(ARC27_MODE_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -925,7 +886,6 @@
                                                 {
                                                     DCSBIOS.Send(ARN6_BAND_DIAL_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -935,7 +895,6 @@
                                                 {
                                                     DCSBIOS.Send(ARN6_VOLUME_KNOB_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -967,13 +926,11 @@
                 {
                     if (Interlocked.Read(ref _doUpdatePanelLCD) == 0)
                     {
-
                         return;
                     }
 
                     if (!FirstReportHasBeenRead)
                     {
-
                         return;
                     }
 
@@ -1038,32 +995,13 @@
                                 uint mode = 0;
                                 lock (_lockARN6ModeObject)
                                 {
-                                    switch (_arn6ModeCockpitDialPos)
+                                    mode = _arn6ModeCockpitDialPos switch
                                     {
-                                        case 2:
-                                            {
-                                                mode = 1;
-                                                break;
-                                            }
-
-                                        case 3:
-                                            {
-                                                mode = 2;
-                                                break;
-                                            }
-
-                                        case 0:
-                                            {
-                                                mode = 3;
-                                                break;
-                                            }
-
-                                        case 1:
-                                            {
-                                                mode = 4;
-                                                break;
-                                            }
-                                    }
+                                        2 => 1,
+                                        3 => 2,
+                                        0 => 3,
+                                        1 => 4
+                                    };
                                 }
 
                                 SetPZ69DisplayBytesUnsignedInteger(ref bytes, mode, PZ69LCDPosition.UPPER_STBY_RIGHT);
@@ -1152,32 +1090,13 @@
                                 uint mode = 0;
                                 lock (_lockARN6ModeObject)
                                 {
-                                    switch (_arn6ModeCockpitDialPos)
+                                    mode = _arn6ModeCockpitDialPos switch
                                     {
-                                        case 2:
-                                            {
-                                                mode = 1;
-                                                break;
-                                            }
-
-                                        case 3:
-                                            {
-                                                mode = 2;
-                                                break;
-                                            }
-
-                                        case 0:
-                                            {
-                                                mode = 3;
-                                                break;
-                                            }
-
-                                        case 1:
-                                            {
-                                                mode = 4;
-                                                break;
-                                            }
-                                    }
+                                        2 => 1,
+                                        3 => 2,
+                                        0 => 3,
+                                        1 => 4
+                                    };
                                 }
 
                                 SetPZ69DisplayBytesUnsignedInteger(ref bytes, mode, PZ69LCDPosition.LOWER_STBY_RIGHT);
@@ -1218,7 +1137,6 @@
 
             Interlocked.Decrement(ref _doUpdatePanelLCD);
         }
-
 
         protected override void GamingPanelKnobChanged(bool isFirstReport, IEnumerable<object> hashSet)
         {
@@ -1290,9 +1208,6 @@
             try
             {
                 _currentLowerRadioMode = currentF86FRadioMode;
-
-                // If NOUSE then send next round of data to the panel in order to clear the LCD.
-                // _sendNextRoundToPanel = true;catch (Exception ex)
             }
             catch (Exception ex)
             {
@@ -1300,28 +1215,22 @@
             }
         }
 
-
         private bool SkipARC27PresetDialChange()
         {
             try
             {
-                if (_currentUpperRadioMode == CurrentF86FRadioMode.ARC27_PRESET || _currentLowerRadioMode == CurrentF86FRadioMode.ARC27_PRESET)
+                if (_arc27PresetDialSkipper > 2)
                 {
-                    if (_arc27PresetDialSkipper > 2)
-                    {
-                        _arc27PresetDialSkipper = 0;
-                        return false;
-                    }
-
-                    _arc27PresetDialSkipper++;
-                    return true;
+                    _arc27PresetDialSkipper = 0;
+                    return false;
                 }
+                _arc27PresetDialSkipper++;
+                return true;
             }
             catch (Exception ex)
             {
                 logger.Error(ex);
             }
-
             return false;
         }
 
@@ -1329,23 +1238,18 @@
         {
             try
             {
-                if (_currentUpperRadioMode == CurrentF86FRadioMode.ARC27_PRESET || _currentLowerRadioMode == CurrentF86FRadioMode.ARC27_PRESET)
+                if (_arc27ModeDialSkipper > 2)
                 {
-                    if (_arc27ModeDialSkipper > 2)
-                    {
-                        _arc27ModeDialSkipper = 0;
-                        return false;
-                    }
-
-                    _arc27ModeDialSkipper++;
-                    return true;
+                    _arc27ModeDialSkipper = 0;
+                    return false;
                 }
+                _arc27ModeDialSkipper++;
+                return true;
             }
             catch (Exception ex)
             {
                 logger.Error(ex);
             }
-
             return false;
         }
 
@@ -1353,23 +1257,18 @@
         {
             try
             {
-                if (_currentUpperRadioMode == CurrentF86FRadioMode.ARN6 || _currentLowerRadioMode == CurrentF86FRadioMode.ARN6)
+                if (_arn6BandDialSkipper > 2)
                 {
-                    if (_arn6BandDialSkipper > 2)
-                    {
-                        _arn6BandDialSkipper = 0;
-                        return false;
-                    }
-
-                    _arn6BandDialSkipper++;
-                    return true;
+                    _arn6BandDialSkipper = 0;
+                    return false;
                 }
+                _arn6BandDialSkipper++;
+                return true;
             }
             catch (Exception ex)
             {
                 logger.Error(ex);
             }
-
             return false;
         }
 
@@ -1377,23 +1276,18 @@
         {
             try
             {
-                if (_currentUpperRadioMode == CurrentF86FRadioMode.ARN6_MODES || _currentLowerRadioMode == CurrentF86FRadioMode.ARN6_MODES)
+                if (_arn6ModeDialSkipper > 2)
                 {
-                    if (_arn6ModeDialSkipper > 2)
-                    {
-                        _arn6ModeDialSkipper = 0;
-                        return false;
-                    }
-
-                    _arn6ModeDialSkipper++;
-                    return true;
+                    _arn6ModeDialSkipper = 0;
+                    return false;
                 }
+                _arn6ModeDialSkipper++;
+                return true;
             }
             catch (Exception ex)
             {
                 logger.Error(ex);
             }
-
             return false;
         }
 
@@ -1401,23 +1295,18 @@
         {
             try
             {
-                if (_currentUpperRadioMode == CurrentF86FRadioMode.ADF_APX6 || _currentLowerRadioMode == CurrentF86FRadioMode.ADF_APX6)
+                if (_apx6ModeDialSkipper > 2)
                 {
-                    if (_apx6ModeDialSkipper > 2)
-                    {
-                        _apx6ModeDialSkipper = 0;
-                        return false;
-                    }
-
-                    _apx6ModeDialSkipper++;
-                    return true;
+                    _apx6ModeDialSkipper = 0;
+                    return false;
                 }
+                _apx6ModeDialSkipper++;
+                return true;
             }
             catch (Exception ex)
             {
                 logger.Error(ex);
             }
-
             return false;
         }
 
@@ -1444,6 +1333,5 @@
         public override void AddOrUpdateOSCommandBinding(PanelSwitchOnOff panelSwitchOnOff, OSCommand operatingSystemCommand)
         {
         }
-
     }
 }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69FA18C.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69FA18C.cs
@@ -31,92 +31,55 @@ namespace NonVisuals.Radios
         }
 
         private CurrentFA18CRadioMode _currentUpperRadioMode = CurrentFA18CRadioMode.COMM1;
-
         private CurrentFA18CRadioMode _currentLowerRadioMode = CurrentFA18CRadioMode.COMM2;
-
         private bool _upperButtonPressed;
-
         private bool _lowerButtonPressed;
-
         private bool _upperButtonPressedAndDialRotated;
-
         private bool _lowerButtonPressedAndDialRotated;
 
         /*FA-18C COMM1 radio*/
         private const string COMM1_CHANNEL_INC = "UFC_COMM1_CHANNEL_SELECT INC\n";
-
         private const string COMM1_CHANNEL_DEC = "UFC_COMM1_CHANNEL_SELECT DEC\n";
-
         private const string COMM1_VOL_INC = "UFC_COMM1_VOL +4000\n";
-
         private const string COMM1_VOL_DEC = "UFC_COMM1_VOL -4000\n";
-
         private const string COMM1_PULL_PRESS = "UFC_COMM1_PULL INC\n";
-
         private const string COMM1_PULL_RELEASE = "UFC_COMM1_PULL DEC\n";
-        
-        private readonly object _lockCOMM1DialsObject = new object();
-
+        private readonly object _lockCOMM1DialsObject = new();
         private DCSBIOSOutput _comm1DcsbiosOutputFreq; // comm1 frequency from DCSbios
-
         private DCSBIOSOutput _comm1DcsbiosOutputChannel; // comm1 channel 1 to 24 from CDSbios
-
         private volatile uint _comm1CockpitFreq = 12400;
-
         private volatile uint _comm1CockpitChannel = 1; // channel number 1 to 24
-        
         private long _comm1DialWaitingForFeedback;
-        
+       
         /*FA-18C COMM2 radio*/
         private const string COMM2_CHANNEL_INC = "UFC_COMM2_CHANNEL_SELECT INC\n";
-
         private const string COMM2_CHANNEL_DEC = "UFC_COMM2_CHANNEL_SELECT DEC\n";
-
         private const string COMM2_VOL_INC = "UFC_COMM2_VOL +4000\n";
-
         private const string COMM2_VOL_DEC = "UFC_COMM2_VOL -4000\n";
-
         private const string COMM2_PULL_PRESS = "UFC_COMM2_PULL INC\n";
-
         private const string COMM2_PULL_RELEASE = "UFC_COMM2_PULL DEC\n";
-
         private double _comm2BigFrequencyStandby = 255;
-        
-        private readonly object _lockComm2DialObject = new object();
-
+        private readonly object _lockComm2DialObject = new();
         private DCSBIOSOutput _comm2DcsbiosOutputFreq; // comm2 frequency from DCSbios
-
         private DCSBIOSOutput _comm2DcsbiosOutputChannel; // comm2 channel 1 to 24
 
         // private DCSBIOSOutput _comm2DcsbiosOutputPull;  // comm2 pull button
         // private DCSBIOSOutput _comm2DcsbiosOutputVol;   // comm2 volume
         private volatile uint _comm2CockpitFreq = 12400;
-
         private volatile uint _comm2CockpitChannel = 1; // channel number 1 to 24
-        
         private long _comm2DialWaitingForFeedback;
 
         /*FA-18C ILS*/
         private uint _ilsChannelStandby = 10;
-
         private uint _ilsSavedCockpitChannel = 1;
-
-        private readonly object _lockIlsDialsObject = new object();
-
+        private readonly object _lockIlsDialsObject = new();
         private DCSBIOSOutput _ilsDcsbiosOutputChannel;
-
         private volatile uint _ilsCockpitChannel = 1;
-
         private const string ILS_CHANNEL_COMMAND = "COM_ILS_CHANNEL_SW ";
-
         private Thread _ilsSyncThread;
-
         private long _ilsThreadNowSynching;
-
         private long _ilsDialWaitingForFeedback;
-
-        private readonly object _lockShowFrequenciesOnPanelObject = new object();
-
+        private readonly object _lockShowFrequenciesOnPanelObject = new();
         private long _doUpdatePanelLCD;
 
         public RadioPanelPZ69FA18C(HIDSkeleton hidSkeleton)

--- a/Source/NonVisuals/Radios/RadioPanelPZ69FA18C.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69FA18C.cs
@@ -85,7 +85,7 @@ namespace NonVisuals.Radios
         public RadioPanelPZ69FA18C(HIDSkeleton hidSkeleton)
             : base(hidSkeleton)
         {
-             CreateRadioKnobs();
+            CreateRadioKnobs();
             Startup();
             BIOSEventHandler.AttachDataListener(this);
         }
@@ -262,7 +262,6 @@ namespace NonVisuals.Radios
                                     break;
                                 }
                         }
-
                         break;
                     }
 
@@ -296,7 +295,6 @@ namespace NonVisuals.Radios
                                     break;
                                 }
                         }
-
                         break;
                     }
             }
@@ -329,8 +327,7 @@ namespace NonVisuals.Radios
 
                     long dialTimeout = DateTime.Now.Ticks;
                     long dialOkTime = 0;
-
-                    var dialSendCount = 0;
+                    int dialSendCount = 0;
 
                     do
                     {
@@ -399,6 +396,20 @@ namespace NonVisuals.Radios
             Interlocked.Increment(ref _doUpdatePanelLCD);
         }
 
+        private string GetCOM1FrequencyAsString()
+        {
+            uint integerCOMM1 = _comm1CockpitFreq / 100;
+            uint decimalCOMM1 = _comm1CockpitFreq - (integerCOMM1 * 100);
+            return $"{integerCOMM1}.{decimalCOMM1}";
+        }
+
+        private string GetCOM2FrequencyAsString()
+        {
+            uint integerCOMM2 = _comm2CockpitFreq / 100;
+            uint decimalCOMM2 = _comm2CockpitFreq - (integerCOMM2 * 100);
+            return $"{integerCOMM2}.{decimalCOMM2}";
+        }
+
         private void ShowFrequenciesOnPanel()
         {
             lock (_lockShowFrequenciesOnPanelObject)
@@ -425,12 +436,7 @@ namespace NonVisuals.Radios
                     case CurrentFA18CRadioMode.COMM1:
                         {
                             // show comm1 frequencies in upper panel
-
-                            uint integerCOMM1 = _comm1CockpitFreq / 100;
-                            uint decimalCOMM1 = _comm1CockpitFreq - (integerCOMM1 * 100);
-                            var frequencyAsString = string.Empty + integerCOMM1;
-                            frequencyAsString += ".";
-                            frequencyAsString += decimalCOMM1;
+                            string frequencyAsString = GetCOM1FrequencyAsString();
 
                             if (_upperButtonPressed)
                             {
@@ -449,11 +455,7 @@ namespace NonVisuals.Radios
                     case CurrentFA18CRadioMode.COMM2:
                         {
                             // show comm2 frequencies in upper panel
-                            uint integerCOMM2 = _comm2CockpitFreq / 100;
-                            uint decimalCOMM2 = _comm2CockpitFreq - (integerCOMM2 * 100);
-                            var frequencyAsString = string.Empty + integerCOMM2;
-                            frequencyAsString += ".";
-                            frequencyAsString += decimalCOMM2;
+                            string frequencyAsString = GetCOM2FrequencyAsString();
 
                             if (_upperButtonPressed)
                             {
@@ -525,12 +527,7 @@ namespace NonVisuals.Radios
                     case CurrentFA18CRadioMode.COMM1:
                         {
                             // show comm1 frequencies in lower panel
-
-                            uint integerCOMM1 = _comm1CockpitFreq / 100;
-                            uint decimalCOMM1 = _comm1CockpitFreq - (integerCOMM1 * 100);
-                            var frequencyAsString = string.Empty + integerCOMM1;
-                            frequencyAsString += ".";
-                            frequencyAsString += decimalCOMM1;
+                            string frequencyAsString = GetCOM1FrequencyAsString();
 
                             if (_lowerButtonPressed)
                             {
@@ -549,11 +546,7 @@ namespace NonVisuals.Radios
                     case CurrentFA18CRadioMode.COMM2:
                         {
                             // show comm2 frequencies in lower panel
-                            uint integerCOMM2 = _comm2CockpitFreq / 100;
-                            uint decimalCOMM2 = _comm2CockpitFreq - (integerCOMM2 * 100);
-                            var frequencyAsString = string.Empty + integerCOMM2;
-                            frequencyAsString += ".";
-                            frequencyAsString += decimalCOMM2;
+                            string frequencyAsString = GetCOM2FrequencyAsString();
 
                             if (_lowerButtonPressed)
                             {
@@ -660,7 +653,6 @@ namespace NonVisuals.Radios
                                             break;
                                         }
                                 }
-
                                 break;
                             }
 
@@ -703,7 +695,6 @@ namespace NonVisuals.Radios
                                             break;
                                         }
                                 }
-
                                 break;
                             }
 
@@ -738,7 +729,6 @@ namespace NonVisuals.Radios
                                             break;
                                         }
                                 }
-
                                 break;
                             }
 
@@ -773,7 +763,6 @@ namespace NonVisuals.Radios
                                             break;
                                         }
                                 }
-
                                 break;
                             }
 
@@ -816,7 +805,6 @@ namespace NonVisuals.Radios
                                             break;
                                         }
                                 }
-
                                 break;
                             }
 
@@ -859,7 +847,6 @@ namespace NonVisuals.Radios
                                             break;
                                         }
                                 }
-
                                 break;
                             }
 
@@ -894,7 +881,6 @@ namespace NonVisuals.Radios
                                             break;
                                         }
                                 }
-
                                 break;
                             }
 
@@ -929,7 +915,6 @@ namespace NonVisuals.Radios
                                             break;
                                         }
                                 }
-
                                 break;
                             }
                     }
@@ -996,7 +981,6 @@ namespace NonVisuals.Radios
                                 {
                                     _currentUpperRadioMode = CurrentFA18CRadioMode.COMM1;
                                 }
-
                                 break;
                             }
 
@@ -1006,7 +990,6 @@ namespace NonVisuals.Radios
                                 {
                                     _currentUpperRadioMode = CurrentFA18CRadioMode.COMM2;
                                 }
-
                                 break;
                             }
 
@@ -1016,7 +999,6 @@ namespace NonVisuals.Radios
                                 {
                                     _currentUpperRadioMode = CurrentFA18CRadioMode.VHFFM;
                                 }
-
                                 break;
                             }
 
@@ -1026,7 +1008,6 @@ namespace NonVisuals.Radios
                                 {
                                     _currentUpperRadioMode = CurrentFA18CRadioMode.ILS;
                                 }
-
                                 break;
                             }
 
@@ -1036,7 +1017,6 @@ namespace NonVisuals.Radios
                                 {
                                     _currentUpperRadioMode = CurrentFA18CRadioMode.TACAN;
                                 }
-
                                 break;
                             }
 
@@ -1056,7 +1036,6 @@ namespace NonVisuals.Radios
                                 {
                                     _currentLowerRadioMode = CurrentFA18CRadioMode.COMM1;
                                 }
-
                                 break;
                             }
 
@@ -1066,7 +1045,6 @@ namespace NonVisuals.Radios
                                 {
                                     _currentLowerRadioMode = CurrentFA18CRadioMode.COMM2;
                                 }
-
                                 break;
                             }
 
@@ -1076,7 +1054,6 @@ namespace NonVisuals.Radios
                                 {
                                     _currentLowerRadioMode = CurrentFA18CRadioMode.VHFFM;
                                 }
-
                                 break;
                             }
 
@@ -1086,7 +1063,6 @@ namespace NonVisuals.Radios
                                 {
                                     _currentLowerRadioMode = CurrentFA18CRadioMode.ILS;
                                 }
-
                                 break;
                             }
 
@@ -1096,7 +1072,6 @@ namespace NonVisuals.Radios
                                 {
                                     _currentLowerRadioMode = CurrentFA18CRadioMode.TACAN;
                                 }
-
                                 break;
                             }
 
@@ -1175,7 +1150,6 @@ namespace NonVisuals.Radios
 
                                     _upperButtonPressedAndDialRotated = false;
                                 }
-
                                 break;
                             }
 
@@ -1204,7 +1178,6 @@ namespace NonVisuals.Radios
 
                                     _lowerButtonPressedAndDialRotated = false;
                                 }
-
                                 break;
                             }
                     }
@@ -1220,7 +1193,6 @@ namespace NonVisuals.Radios
                             null);
                     }
                 }
-
                 AdjustFrequency(hashSet);
             }
         }
@@ -1265,7 +1237,7 @@ namespace NonVisuals.Radios
 
         public override DcsOutputAndColorBinding CreateDcsOutputAndColorBinding(SaitekPanelLEDPosition saitekPanelLEDPosition, PanelLEDColor panelLEDColor, DCSBIOSOutput dcsBiosOutput)
         {
-            var dcsOutputAndColorBinding = new DcsOutputAndColorBindingPZ55
+            DcsOutputAndColorBindingPZ55 dcsOutputAndColorBinding = new()
             {
                 DCSBiosOutputLED = dcsBiosOutput,
                 LEDColor = panelLEDColor,

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Fw190.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Fw190.cs
@@ -64,13 +64,13 @@
         /*FuG 16ZY COM1*/
         // Large dial 0-3 [step of 1]
         // Small dial Fine tuning
-        private readonly object _lockFug16ZyPresetDialObject1 = new object();
+        private readonly object _lockFug16ZyPresetDialObject1 = new();
         private DCSBIOSOutput _fug16ZyPresetDcsbiosOutputPresetDial;
         private volatile uint _fug16ZyPresetCockpitDialPos = 1;
         private const string FUG16_ZY_PRESET_COMMAND_INC = "RADIO_MODE INC\n";
         private const string FUG16_ZY_PRESET_COMMAND_DEC = "RADIO_MODE DEC\n";
         private int _fug16ZyPresetDialSkipper;
-        private readonly object _lockFug16ZyFineTuneDialObject1 = new object();
+        private readonly object _lockFug16ZyFineTuneDialObject1 = new();
         private DCSBIOSOutput _fug16ZyFineTuneDcsbiosOutputDial;
         private volatile uint _fug16ZyFineTuneCockpitDialPos = 1;
         private const string FUG16_ZY_FINE_TUNE_COMMAND_INC = "FUG16_TUNING INC\n";
@@ -80,7 +80,7 @@
         // Large dial 0-1 [step of 1]
         // Small dial Volume control
         // ACT/STBY IFF Test Button
-        private readonly object _lockFUG25AIFFDialObject1 = new object();
+        private readonly object _lockFUG25AIFFDialObject1 = new();
         private DCSBIOSOutput _fug25AIFFDcsbiosOutputDial;
         private volatile uint _fug25AIFFCockpitDialPos = 1;
         private const string FUG25_AIFF_COMMAND_INC = "FUG25_MODE INC\n";
@@ -95,13 +95,13 @@
         // Large dial N/A
         // Small dial N/A
         // ACT/STBY Homing Switch
-        private readonly object _lockHomingDialObject1 = new object();
+        private readonly object _lockHomingDialObject1 = new();
         private DCSBIOSOutput _homingDcsbiosOutputPresetDial;
         private volatile uint _homingCockpitDialPos = 1;
         private const string HOMING_COMMAND_INC = "FT_ZF_SWITCH INC\n";
         private const string HOMING_COMMAND_DEC = "FT_ZF_SWITCH DEC\n";
 
-        private readonly object _lockShowFrequenciesOnPanelObject = new object();
+        private readonly object _lockShowFrequenciesOnPanelObject = new();
         private long _doUpdatePanelLCD;
 
         public RadioPanelPZ69Fw190(HIDSkeleton hidSkeleton) : base(hidSkeleton)

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Fw190.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Fw190.cs
@@ -147,12 +147,12 @@
                 UpdateCounter(e.Address, e.Data);
 
                 /*
-                                 * IMPORTANT INFORMATION REGARDING THE _*WaitingForFeedback variables
-                                 * Once a dial has been deemed to be "off" position and needs to be changed
-                                 * a change command is sent to DCS-BIOS.
-                                 * Only after a *change* has been acknowledged will the _*WaitingForFeedback be
-                                 * reset. Reading the dial's position with no change in value will not reset.
-                                 */
+                * IMPORTANT INFORMATION REGARDING THE _*WaitingForFeedback variables
+                * Once a dial has been deemed to be "off" position and needs to be changed
+                * a change command is sent to DCS-BIOS.
+                * Only after a *change* has been acknowledged will the _*WaitingForFeedback be
+                * reset. Reading the dial's position with no change in value will not reset.
+                */
 
                 // FuG 16ZY Preset Channel Dial
                 if (e.Address == _fug16ZyPresetDcsbiosOutputPresetDial.Address)
@@ -220,7 +220,6 @@
             }
         }
 
-
         public void PZ69KnobChanged(bool isFirstReport, IEnumerable<object> hashSet)
         {
             if (isFirstReport)
@@ -245,7 +244,6 @@
                                     {
                                         SetUpperRadioMode(CurrentFw190RadioMode.FUG16ZY);
                                     }
-
                                     break;
                                 }
 
@@ -255,7 +253,6 @@
                                     {
                                         SetUpperRadioMode(CurrentFw190RadioMode.IFF);
                                     }
-
                                     break;
                                 }
 
@@ -265,7 +262,6 @@
                                     {
                                         SetUpperRadioMode(CurrentFw190RadioMode.HOMING);
                                     }
-
                                     break;
                                 }
 
@@ -278,7 +274,6 @@
                                     {
                                         SetUpperRadioMode(CurrentFw190RadioMode.NOUSE);
                                     }
-
                                     break;
                                 }
 
@@ -288,7 +283,6 @@
                                     {
                                         SetLowerRadioMode(CurrentFw190RadioMode.FUG16ZY);
                                     }
-
                                     break;
                                 }
 
@@ -298,7 +292,6 @@
                                     {
                                         SetLowerRadioMode(CurrentFw190RadioMode.IFF);
                                     }
-
                                     break;
                                 }
 
@@ -308,7 +301,6 @@
                                     {
                                         SetLowerRadioMode(CurrentFw190RadioMode.HOMING);
                                     }
-
                                     break;
                                 }
 
@@ -321,7 +313,6 @@
                                     {
                                         SetLowerRadioMode(CurrentFw190RadioMode.NOUSE);
                                     }
-
                                     break;
                                 }
 
@@ -355,7 +346,6 @@
                                             }
                                         }
                                     }
-
                                     break;
                                 }
 
@@ -376,7 +366,6 @@
                                             }
                                         }
                                     }
-
                                     break;
                                 }
                         }
@@ -400,7 +389,6 @@
         {
             try
             {
-
                 if (SkipCurrentFrequencyChange())
                 {
                     return;
@@ -424,7 +412,6 @@
                                                 {
                                                     DCSBIOS.Send(FUG16_ZY_PRESET_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -434,7 +421,6 @@
                                                 {
                                                     DCSBIOS.Send(FUG25_AIFF_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -462,7 +448,6 @@
                                                 {
                                                     DCSBIOS.Send(FUG16_ZY_PRESET_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -472,7 +457,6 @@
                                                 {
                                                     DCSBIOS.Send(FUG25_AIFF_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -560,7 +544,6 @@
                                                 {
                                                     DCSBIOS.Send(FUG16_ZY_PRESET_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -570,7 +553,6 @@
                                                 {
                                                     DCSBIOS.Send(FUG25_AIFF_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -598,7 +580,6 @@
                                                 {
                                                     DCSBIOS.Send(FUG16_ZY_PRESET_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -608,7 +589,6 @@
                                                 {
                                                     DCSBIOS.Send(FUG25_AIFF_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -687,7 +667,6 @@
                         }
                     }
                 }
-
                 ShowFrequenciesOnPanel();
             }
             catch (Exception ex)
@@ -704,13 +683,11 @@
                 {
                     if (Interlocked.Read(ref _doUpdatePanelLCD) == 0)
                     {
-
                         return;
                     }
 
                     if (!FirstReportHasBeenRead)
                     {
-
                         return;
                     }
 
@@ -844,14 +821,12 @@
             {
                 logger.Error(ex);
             }
-
             Interlocked.Decrement(ref _doUpdatePanelLCD);
         }
 
 
         protected override void GamingPanelKnobChanged(bool isFirstReport, IEnumerable<object> hashSet)
         {
-
             PZ69KnobChanged(isFirstReport, hashSet);
         }
 
@@ -883,7 +858,7 @@
 
         public override DcsOutputAndColorBinding CreateDcsOutputAndColorBinding(SaitekPanelLEDPosition saitekPanelLEDPosition, PanelLEDColor panelLEDColor, DCSBIOSOutput dcsBiosOutput)
         {
-            var dcsOutputAndColorBinding = new DcsOutputAndColorBindingPZ55
+            DcsOutputAndColorBindingPZ55 dcsOutputAndColorBinding = new()
             {
                 DCSBiosOutputLED = dcsBiosOutput,
                 LEDColor = panelLEDColor,
@@ -935,7 +910,6 @@
                         _fug16ZyPresetDialSkipper = 0;
                         return false;
                     }
-
                     _fug16ZyPresetDialSkipper++;
                     return true;
                 }
@@ -944,7 +918,6 @@
             {
                 logger.Error(ex);
             }
-
             return false;
         }
 
@@ -959,7 +932,6 @@
                         _fug25AIFFDialSkipper = 0;
                         return false;
                     }
-
                     _fug25AIFFDialSkipper++;
                     return true;
                 }
@@ -968,7 +940,6 @@
             {
                 logger.Error(ex);
             }
-
             return false;
         }
         
@@ -983,6 +954,5 @@
         public override void AddOrUpdateBIPLinkBinding(PanelSwitchOnOff panelSwitchOnOff, BIPLink bipLink) { }
 
         public override void AddOrUpdateOSCommandBinding(PanelSwitchOnOff panelSwitchOnOff, OSCommand operatingSystemCommand) { }
-
     }
 }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Generic.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Generic.cs
@@ -94,17 +94,14 @@ namespace NonVisuals.Radios
         public override void ImportSettings(GenericPanelBinding genericPanelBinding)
         {
             ClearSettings();
-
             BindingHash = genericPanelBinding.BindingHash;
-
             _settingsAreBeingImported = true;
 
             var settings = genericPanelBinding.Settings;
-            foreach (var setting in settings)
+            foreach (string setting in settings)
             {
                 if (!setting.StartsWith("#") && setting.Length > 2)
                 {
-
                     if (setting.StartsWith("RadioPanelKeyDialPos{"))
                     {
                         var keyBinding = new KeyBindingPZ69DialPosition();
@@ -156,9 +153,9 @@ namespace NonVisuals.Radios
                 return null;
             }
 
-            var result = new List<string>();
+            List<string> result = new();
 
-            foreach (var keyBinding in _keyBindings)
+            foreach (KeyBindingPZ69DialPosition keyBinding in _keyBindings)
             {
                 if (keyBinding.OSKeyPress != null)
                 {
@@ -166,7 +163,7 @@ namespace NonVisuals.Radios
                 }
             }
 
-            foreach (var operatingSystemCommand in _operatingSystemCommandBindings)
+            foreach (OSCommandBindingPZ69FullEmulator operatingSystemCommand in _operatingSystemCommandBindings)
             {
                 if (!operatingSystemCommand.OSCommandObject.IsEmpty)
                 {
@@ -174,7 +171,7 @@ namespace NonVisuals.Radios
                 }
             }
 
-            foreach (var displayValue in _displayValues)
+            foreach (RadioPanelPZ69DisplayValue displayValue in _displayValues)
             {
                 var tmp = displayValue.ExportSettings();
                 if (!string.IsNullOrEmpty(tmp))
@@ -183,7 +180,7 @@ namespace NonVisuals.Radios
                 }
             }
 
-            foreach (var bipLink in _bipLinks)
+            foreach (BIPLinkPZ69 bipLink in _bipLinks)
             {
                 var tmp = bipLink.ExportSettings();
                 if (!string.IsNullOrEmpty(tmp))
@@ -192,7 +189,7 @@ namespace NonVisuals.Radios
                 }
             }
 
-            foreach (var dcsBiosLcdBindings in _dcsBiosLcdBindings)
+            foreach (DCSBIOSOutputBindingPZ69 dcsBiosLcdBindings in _dcsBiosLcdBindings)
             {
                 var tmp = dcsBiosLcdBindings.ExportSettings();
                 if (!string.IsNullOrEmpty(tmp))
@@ -201,7 +198,7 @@ namespace NonVisuals.Radios
                 }
             }
 
-            foreach (var dcsBiosBindings in _dcsBiosBindings)
+            foreach (DCSBIOSActionBindingPZ69 dcsBiosBindings in _dcsBiosBindings)
             {
                 var tmp = dcsBiosBindings.ExportSettings();
                 if (!string.IsNullOrEmpty(tmp))
@@ -230,7 +227,7 @@ namespace NonVisuals.Radios
                 lock (_lcdDataVariablesLockObject)
                 {
                     UpdateCounter(e.Address, e.Data);
-                    foreach (var dcsbiosBindingLCD in _dcsBiosLcdBindings)
+                    foreach (DCSBIOSOutputBindingPZ69 dcsbiosBindingLCD in _dcsBiosLcdBindings)
                     {
                         if (!dcsbiosBindingLCD.HasBinding)
                         {
@@ -309,12 +306,11 @@ namespace NonVisuals.Radios
 
         public HashSet<RadioPanelPZ69DisplayValue> DisplayValueHashSet => _displayValues;
 
-
         private void PZ69KnobChanged(bool isFirstReport, IEnumerable<object> hashSet)
         {
             if (ForwardPanelEvent)
             {
-                foreach (var radioPanelKeyObject in hashSet)
+                foreach (object radioPanelKeyObject in hashSet)
                 {
                     // Looks which switches has been switched and sees whether any key emulation has been tied to them.
                     var radioPanelKey = (RadioPanelPZ69KnobEmulator)radioPanelKeyObject;
@@ -394,8 +390,8 @@ namespace NonVisuals.Radios
                         }
                     }
 
-                    var keyBindingFound = false;
-                    foreach (var keyBinding in _keyBindings)
+                    bool keyBindingFound = false;
+                    foreach (KeyBindingPZ69DialPosition keyBinding in _keyBindings)
                     {
                         if (keyBinding.DialPosition == _pz69UpperDialPosition || keyBinding.DialPosition == _pz69LowerDialPosition)
                         {
@@ -437,7 +433,7 @@ namespace NonVisuals.Radios
                         }
                     }
 
-                    foreach (var operatingSystemCommand in _operatingSystemCommandBindings)
+                    foreach (OSCommandBindingPZ69FullEmulator operatingSystemCommand in _operatingSystemCommandBindings)
                     {
                         if (operatingSystemCommand.DialPosition == _pz69UpperDialPosition || operatingSystemCommand.DialPosition == _pz69LowerDialPosition)
                         {
@@ -449,7 +445,7 @@ namespace NonVisuals.Radios
                         }
                     }
 
-                    foreach (var bipLinkPZ69 in _bipLinks)
+                    foreach (BIPLinkPZ69 bipLinkPZ69 in _bipLinks)
                     {
                         if (bipLinkPZ69.BIPLights.Count > 0 && bipLinkPZ69.RadioPanelPZ69Knob == radioPanelKey.RadioPanelPZ69Knob && bipLinkPZ69.WhenTurnedOn == radioPanelKey.IsOn)
                         {
@@ -458,7 +454,7 @@ namespace NonVisuals.Radios
                         }
                     }
 
-                    foreach (var dcsBiosBinding in _dcsBiosBindings)
+                    foreach (DCSBIOSActionBindingPZ69 dcsBiosBinding in _dcsBiosBindings)
                     {
                         if (dcsBiosBinding.DialPosition == _pz69UpperDialPosition || dcsBiosBinding.DialPosition == _pz69LowerDialPosition)
                         {
@@ -472,7 +468,7 @@ namespace NonVisuals.Radios
                 }
             }
 
-            foreach (var radioPanelKeyObject in hashSet)
+            foreach (object radioPanelKeyObject in hashSet)
             {
                 // Looks which switches has been switched and sees whether any key emulation has been tied to them.
                 var radioPanelKey = (RadioPanelPZ69KnobEmulator)radioPanelKeyObject;
@@ -490,7 +486,7 @@ namespace NonVisuals.Radios
                         _lowerStandby = -1;
                     }
 
-                    foreach (var displayValue in _displayValues)
+                    foreach (RadioPanelPZ69DisplayValue displayValue in _displayValues)
                     {
                         if (displayValue.RadioPanelPZ69Knob == radioPanelKey.RadioPanelPZ69Knob)
                         {
@@ -541,17 +537,17 @@ namespace NonVisuals.Radios
                  * Here we have a situation where the value to be displayed can be either just a dumb value
                  * or something from DCS-BIOS.
                  */
-                var upperActiveString = _upperActive < 0 ? "" : _upperActive.ToString(CultureInfo.InvariantCulture);
-                var upperStandbyString = _upperStandby < 0 ? "" : _upperStandby.ToString(CultureInfo.InvariantCulture);
-                var lowerActiveString = _lowerActive < 0 ? "" : _lowerActive.ToString(CultureInfo.InvariantCulture);
-                var lowerStandbyString = _lowerStandby < 0 ? "" : _lowerStandby.ToString(CultureInfo.InvariantCulture);
+                string upperActiveString = _upperActive < 0 ? "" : _upperActive.ToString(CultureInfo.InvariantCulture);
+                string upperStandbyString = _upperStandby < 0 ? "" : _upperStandby.ToString(CultureInfo.InvariantCulture);
+                string lowerActiveString = _lowerActive < 0 ? "" : _lowerActive.ToString(CultureInfo.InvariantCulture);
+                string lowerStandbyString = _lowerStandby < 0 ? "" : _lowerStandby.ToString(CultureInfo.InvariantCulture);
 
-                var upperActiveFound = false;
-                var upperStandbyFound = false;
-                var lowerActiveFound = false;
-                var lowerStandbyFound = false;
+                bool upperActiveFound = false;
+                bool upperStandbyFound = false;
+                bool lowerActiveFound = false;
+                bool lowerStandbyFound = false;
                 // Find upper left => lower right data from the DCS-BIOS LCD holders
-                foreach (var dcsbiosBindingLCDPZ69 in LCDBindings)
+                foreach (DCSBIOSOutputBindingPZ69 dcsbiosBindingLCDPZ69 in LCDBindings)
                 {
                     if (dcsbiosBindingLCDPZ69.DialPosition == _pz69UpperDialPosition)
                     {
@@ -645,8 +641,8 @@ namespace NonVisuals.Radios
 
         public string GetKeyPressForLoggingPurposes(RadioPanelPZ69KnobEmulator radioPanelKey)
         {
-            var result = string.Empty;
-            foreach (var keyBinding in _keyBindings)
+            string result = string.Empty;
+            foreach (KeyBindingPZ69DialPosition keyBinding in _keyBindings)
             {
                 if (keyBinding.OSKeyPress != null && keyBinding.RadioPanelPZ69Key == radioPanelKey.RadioPanelPZ69Knob && keyBinding.WhenTurnedOn == radioPanelKey.IsOn)
                 {
@@ -665,15 +661,15 @@ namespace NonVisuals.Radios
                 return;
             }
 
-            var value = double.Parse(valueAsString, NumberFormatInfoFullDisplay);
+            double value = double.Parse(valueAsString, NumberFormatInfoFullDisplay);
             if (value < 0)
             {
                 ClearDisplayValue(radioPanelPZ69Knob, radioPanelDisplay);
                 return;
             }
 
-            var found = false;
-            foreach (var displayValue in _displayValues)
+            bool found = false;
+            foreach (RadioPanelPZ69DisplayValue displayValue in _displayValues)
             {
                 if (displayValue.RadioPanelPZ69Knob == radioPanelPZ69Knob && displayValue.RadioPanelDisplay == radioPanelDisplay)
                 {
@@ -684,7 +680,7 @@ namespace NonVisuals.Radios
 
             if (!found)
             {
-                var displayValue = new RadioPanelPZ69DisplayValue
+                RadioPanelPZ69DisplayValue displayValue = new()
                 {
                     RadioPanelPZ69Knob = radioPanelPZ69Knob,
                     RadioPanelDisplay = radioPanelDisplay,
@@ -702,13 +698,13 @@ namespace NonVisuals.Radios
             var pz69DialPosition = GetDial(radioPanelPZ69KeyOnOff.Switch);
             if (string.IsNullOrEmpty(keyPress))
             {
-                var tmp = new PZ69SwitchOnOff(radioPanelPZ69KeyOnOff.Switch, radioPanelPZ69KeyOnOff.ButtonState);
+                PZ69SwitchOnOff tmp = new(radioPanelPZ69KeyOnOff.Switch, radioPanelPZ69KeyOnOff.ButtonState);
                 ClearAllBindings(pz69DialPosition, tmp);
                 return;
             }
 
-            var found = false;
-            foreach (var keyBinding in _keyBindings)
+            bool found = false;
+            foreach (KeyBindingPZ69DialPosition keyBinding in _keyBindings)
             {
                 if (keyBinding.RadioPanelPZ69Key == radioPanelPZ69KeyOnOff.Switch && keyBinding.WhenTurnedOn == radioPanelPZ69KeyOnOff.ButtonState && keyBinding.DialPosition == pz69DialPosition)
                 {
@@ -720,14 +716,13 @@ namespace NonVisuals.Radios
                     {
                         keyBinding.OSKeyPress = new KeyPress(keyPress, keyPressLength);
                     }
-
                     found = true;
                 }
             }
 
             if (!found && !string.IsNullOrEmpty(keyPress))
             {
-                var keyBinding = new KeyBindingPZ69DialPosition
+                KeyBindingPZ69DialPosition keyBinding = new()
                 {
                     RadioPanelPZ69Key = radioPanelPZ69KeyOnOff.Switch,
                     DialPosition = pz69DialPosition,
@@ -743,11 +738,9 @@ namespace NonVisuals.Radios
 
         public override void AddOrUpdateOSCommandBinding(PanelSwitchOnOff panelSwitchOnOff, OSCommand operatingSystemCommand)
         {
-            var radioPanelPZ69KeyOnOff = (PZ69SwitchOnOff)panelSwitchOnOff;
-
-            var found = false;
-
-            var pz69DialPosition = GetDial(radioPanelPZ69KeyOnOff.Switch);
+            PZ69SwitchOnOff radioPanelPZ69KeyOnOff = (PZ69SwitchOnOff)panelSwitchOnOff;
+            bool found = false;
+            PZ69DialPosition pz69DialPosition = GetDial(radioPanelPZ69KeyOnOff.Switch);
             foreach (var operatingSystemCommandBinding in _operatingSystemCommandBindings)
             {
                 if (operatingSystemCommandBinding.DialPosition == pz69DialPosition && operatingSystemCommandBinding.RadioPanelPZ69Key == radioPanelPZ69KeyOnOff.Switch && operatingSystemCommandBinding.WhenTurnedOn == radioPanelPZ69KeyOnOff.ButtonState)
@@ -760,7 +753,7 @@ namespace NonVisuals.Radios
 
             if (!found)
             {
-                var operatingSystemCommandBindingPZ69Full = new OSCommandBindingPZ69FullEmulator
+                OSCommandBindingPZ69FullEmulator operatingSystemCommandBindingPZ69Full = new() 
                 {
                     DialPosition = pz69DialPosition,
                     RadioPanelPZ69Key = radioPanelPZ69KeyOnOff.Switch,
@@ -769,21 +762,19 @@ namespace NonVisuals.Radios
                 };
                 _operatingSystemCommandBindings.Add(operatingSystemCommandBindingPZ69Full);
             }
-
             SetIsDirty();
         }
 
 
         public void ClearAllBindings(PZ69DialPosition pz69DialPosition, PZ69SwitchOnOff radioPanelPZ69KnobOnOff)
         {
-            foreach (var keyBinding in _keyBindings)
+            foreach (KeyBindingPZ69DialPosition keyBinding in _keyBindings)
             {
                 if (keyBinding.DialPosition == pz69DialPosition && keyBinding.RadioPanelPZ69Key == radioPanelPZ69KnobOnOff.Switch && keyBinding.WhenTurnedOn == radioPanelPZ69KnobOnOff.ButtonState)
                 {
                     keyBinding.OSKeyPress = null;
                 }
             }
-
             SetIsDirty();
         }
 
@@ -795,7 +786,7 @@ namespace NonVisuals.Radios
 
         public override void AddOrUpdateSequencedKeyBinding(PanelSwitchOnOff panelSwitchOnOff, string description, SortedList<int, IKeyPressInfo> keySequence)
         {
-            var radioPanelPZ69KeyOnOff = (PZ69SwitchOnOff)panelSwitchOnOff;
+            PZ69SwitchOnOff radioPanelPZ69KeyOnOff = (PZ69SwitchOnOff)panelSwitchOnOff;
             var pz69DialPosition = GetDial(radioPanelPZ69KeyOnOff.Switch);
 
             if (keySequence.Count == 0)
@@ -805,8 +796,8 @@ namespace NonVisuals.Radios
                 return;
             }
 
-            var found = false;
-            foreach (var keyBinding in _keyBindings)
+            bool found = false;
+            foreach (KeyBindingPZ69DialPosition keyBinding in _keyBindings)
             {
                 if (keyBinding.RadioPanelPZ69Key == radioPanelPZ69KeyOnOff.Switch && keyBinding.WhenTurnedOn == radioPanelPZ69KeyOnOff.ButtonState && keyBinding.DialPosition == pz69DialPosition)
                 {
@@ -826,7 +817,7 @@ namespace NonVisuals.Radios
 
             if (!found && keySequence.Count > 0)
             {
-                var keyBinding = new KeyBindingPZ69DialPosition
+                KeyBindingPZ69DialPosition keyBinding = new()
                 {
                     RadioPanelPZ69Key = radioPanelPZ69KeyOnOff.Switch,
                     DialPosition = pz69DialPosition,
@@ -842,8 +833,8 @@ namespace NonVisuals.Radios
 
         public override void AddOrUpdateBIPLinkBinding(PanelSwitchOnOff panelSwitchOnOff, BIPLink bipLink)
         {
-            var radioPanelPZ69KeyOnOff = (PZ69SwitchOnOff)panelSwitchOnOff;
-            var bipLinkPZ69 = (BIPLinkPZ69)bipLink;
+            PZ69SwitchOnOff radioPanelPZ69KeyOnOff = (PZ69SwitchOnOff)panelSwitchOnOff;
+            BIPLinkPZ69 bipLinkPZ69 = (BIPLinkPZ69)bipLink;
 
             if (bipLinkPZ69.BIPLights.Count == 0)
             {
@@ -852,9 +843,8 @@ namespace NonVisuals.Radios
                 return;
             }
 
-            var found = false;
-
-            foreach (var tmpBipLink in _bipLinks)
+            bool found = false;
+            foreach (BIPLinkPZ69 tmpBipLink in _bipLinks)
             {
                 if (tmpBipLink.RadioPanelPZ69Knob == radioPanelPZ69KeyOnOff.Switch && tmpBipLink.WhenTurnedOn == radioPanelPZ69KeyOnOff.ButtonState)
                 {
@@ -872,16 +862,14 @@ namespace NonVisuals.Radios
                 bipLinkPZ69.WhenTurnedOn = radioPanelPZ69KeyOnOff.ButtonState;
                 _bipLinks.Add(bipLinkPZ69);
             }
-
             SetIsDirty();
         }
 
         public void AddOrUpdateLCDBinding(DCSBIOSOutput dcsbiosOutput, PZ69LCDPosition pz69LCDPosition, bool limitDecimals, int decimalPlaces)
         {
-
             lock (_lcdDataVariablesLockObject)
             {
-                var found = false;
+                bool found = false;
                 var pz69DialPosition = _pz69UpperDialPosition;
                 if (pz69LCDPosition == PZ69LCDPosition.LOWER_STBY_RIGHT ||
                     pz69LCDPosition == PZ69LCDPosition.LOWER_ACTIVE_LEFT)
@@ -889,7 +877,7 @@ namespace NonVisuals.Radios
                     pz69DialPosition = _pz69LowerDialPosition;
                 }
 
-                foreach (var dcsBiosBindingLCD in _dcsBiosLcdBindings)
+                foreach (DCSBIOSOutputBindingPZ69 dcsBiosBindingLCD in _dcsBiosLcdBindings)
                 {
                     if (dcsBiosBindingLCD.DialPosition == pz69DialPosition &&
                         dcsBiosBindingLCD.PZ69LcdPosition == pz69LCDPosition)
@@ -903,7 +891,7 @@ namespace NonVisuals.Radios
 
                 if (!found)
                 {
-                    var dcsBiosBindingLCD = new DCSBIOSOutputBindingPZ69
+                    DCSBIOSOutputBindingPZ69 dcsBiosBindingLCD = new()
                     {
                         DialPosition = pz69DialPosition,
                         DCSBIOSOutputObject = dcsbiosOutput,
@@ -913,24 +901,22 @@ namespace NonVisuals.Radios
                     _dcsBiosLcdBindings.Add(dcsBiosBindingLCD);
                 }
             }
-
             SetIsDirty();
         }
 
         public void AddOrUpdateLCDBinding(DCSBIOSOutputFormula dcsbiosOutputFormula, PZ69LCDPosition pz69LCDPosition, bool limitDecimals, int decimalPlaces)
         {
-
             lock (_lcdDataVariablesLockObject)
             {
-                var found = false;
-                var pz69DialPosition = _pz69UpperDialPosition;
+                bool found = false;
+                PZ69DialPosition pz69DialPosition = _pz69UpperDialPosition;
                 if (pz69LCDPosition == PZ69LCDPosition.LOWER_STBY_RIGHT ||
                     pz69LCDPosition == PZ69LCDPosition.LOWER_ACTIVE_LEFT)
                 {
                     pz69DialPosition = _pz69LowerDialPosition;
                 }
 
-                foreach (var dcsBiosBindingLCD in _dcsBiosLcdBindings)
+                foreach (DCSBIOSOutputBindingPZ69 dcsBiosBindingLCD in _dcsBiosLcdBindings)
                 {
                     if (dcsBiosBindingLCD.DialPosition == pz69DialPosition &&
                         dcsBiosBindingLCD.PZ69LcdPosition == pz69LCDPosition)
@@ -945,7 +931,7 @@ namespace NonVisuals.Radios
 
                 if (!found)
                 {
-                    var dcsBiosBindingLCD = new DCSBIOSOutputBindingPZ69
+                    DCSBIOSOutputBindingPZ69 dcsBiosBindingLCD = new() 
                     {
                         DialPosition = pz69DialPosition,
                         DCSBIOSOutputFormulaObject = dcsbiosOutputFormula,
@@ -955,23 +941,21 @@ namespace NonVisuals.Radios
                     _dcsBiosLcdBindings.Add(dcsBiosBindingLCD);
                 }
             }
-
             SetIsDirty();
         }
-
 
         public void DeleteDCSBIOSLcdBinding(PZ69LCDPosition pz69LCDPosition)
         {
             lock (_lcdDataVariablesLockObject)
             {
-                var pz69DialPosition = _pz69UpperDialPosition;
+                PZ69DialPosition pz69DialPosition = _pz69UpperDialPosition;
                 if (pz69LCDPosition == PZ69LCDPosition.LOWER_STBY_RIGHT ||
                     pz69LCDPosition == PZ69LCDPosition.LOWER_ACTIVE_LEFT)
                 {
                     pz69DialPosition = _pz69LowerDialPosition;
                 }
                 
-                foreach (var dcsBiosBindingLCD in _dcsBiosLcdBindings)
+                foreach (DCSBIOSOutputBindingPZ69 dcsBiosBindingLCD in _dcsBiosLcdBindings)
                 {
                     if (dcsBiosBindingLCD.DialPosition == pz69DialPosition &&
                         dcsBiosBindingLCD.PZ69LcdPosition == pz69LCDPosition)
@@ -982,13 +966,12 @@ namespace NonVisuals.Radios
                     }
                 }
             }
-            
             SetIsDirty();
         }
 
         public override void AddOrUpdateDCSBIOSBinding(PanelSwitchOnOff panelSwitchOnOff, List<DCSBIOSInput> dcsbiosInputs, string description)
         {
-            var radioPanelPZ69KeyOnOff = (PZ69SwitchOnOff)panelSwitchOnOff;
+            PZ69SwitchOnOff radioPanelPZ69KeyOnOff = (PZ69SwitchOnOff)panelSwitchOnOff;
             if (dcsbiosInputs.Count == 0)
             {
                 RemoveSwitchFromList(ControlList.DCSBIOS, radioPanelPZ69KeyOnOff);
@@ -996,9 +979,9 @@ namespace NonVisuals.Radios
                 return;
             }
 
-            var found = false;
-            var pz69DialPosition = GetDial(radioPanelPZ69KeyOnOff.Switch);
-            foreach (var dcsBiosBinding in _dcsBiosBindings)
+            bool found = false;
+            PZ69DialPosition pz69DialPosition = GetDial(radioPanelPZ69KeyOnOff.Switch);
+            foreach (DCSBIOSActionBindingPZ69 dcsBiosBinding in _dcsBiosBindings)
             {
                 if (dcsBiosBinding.DialPosition == pz69DialPosition && dcsBiosBinding.RadioPanelPZ69Knob == radioPanelPZ69KeyOnOff.Switch && dcsBiosBinding.WhenTurnedOn == radioPanelPZ69KeyOnOff.ButtonState)
                 {
@@ -1011,7 +994,7 @@ namespace NonVisuals.Radios
 
             if (!found)
             {
-                var dcsBiosBinding = new DCSBIOSActionBindingPZ69
+                DCSBIOSActionBindingPZ69 dcsBiosBinding = new()
                 {
                     RadioPanelPZ69Knob = radioPanelPZ69KeyOnOff.Switch,
                     DialPosition = pz69DialPosition,
@@ -1021,16 +1004,15 @@ namespace NonVisuals.Radios
                 };
                 _dcsBiosBindings.Add(dcsBiosBinding);
             }
-
             SetIsDirty();
         }
 
         public void DeleteDCSBIOSBinding(RadioPanelPZ69KnobsEmulator knob, bool whenTurnedOn)
         {
-            var pz69DialPosition = GetDial(knob);
+            PZ69DialPosition pz69DialPosition = GetDial(knob);
 
             // Removes config
-            foreach (var dcsBiosBinding in _dcsBiosBindings)
+            foreach (DCSBIOSActionBindingPZ69 dcsBiosBinding in _dcsBiosBindings)
             {
                 if (dcsBiosBinding.DialPosition == pz69DialPosition && dcsBiosBinding.RadioPanelPZ69Knob == knob && dcsBiosBinding.WhenTurnedOn == whenTurnedOn)
                 {
@@ -1038,26 +1020,24 @@ namespace NonVisuals.Radios
                     break;
                 }
             }
-
             SetIsDirty();
         }
 
         public override void RemoveSwitchFromList(object controlList, PanelSwitchOnOff panelSwitchOnOff)
         {
-            var pz69SwitchOnOff = (PZ69SwitchOnOff)panelSwitchOnOff;
-            var controlListPZ69 = (ControlList)controlList;
+            PZ69SwitchOnOff pz69SwitchOnOff = (PZ69SwitchOnOff)panelSwitchOnOff;
+            ControlList controlListPZ69 = (ControlList)controlList;
 
-            var found = false;
-            var pz69DialPosition = GetDial(pz69SwitchOnOff.Switch);
+            bool found = false;
+            PZ69DialPosition pz69DialPosition = GetDial(pz69SwitchOnOff.Switch);
             if (controlListPZ69 == ControlList.ALL || controlListPZ69 == ControlList.KEYS)
             {
-                foreach (var keyBinding in _keyBindings)
+                foreach (KeyBindingPZ69DialPosition keyBinding in _keyBindings)
                 {
                     if (keyBinding.RadioPanelPZ69Key == pz69SwitchOnOff.Switch && keyBinding.WhenTurnedOn == pz69SwitchOnOff.ButtonState && keyBinding.DialPosition == pz69DialPosition)
                     {
                         keyBinding.OSKeyPress = null;
                     }
-
                     found = true;
                     break;
                 }
@@ -1065,13 +1045,12 @@ namespace NonVisuals.Radios
 
             if (controlListPZ69 == ControlList.ALL || controlListPZ69 == ControlList.DCSBIOS)
             {
-                foreach (var dcsBiosBinding in _dcsBiosBindings)
+                foreach (DCSBIOSActionBindingPZ69 dcsBiosBinding in _dcsBiosBindings)
                 {
                     if (dcsBiosBinding.RadioPanelPZ69Knob == pz69SwitchOnOff.Switch && dcsBiosBinding.WhenTurnedOn == pz69SwitchOnOff.ButtonState && dcsBiosBinding.DialPosition == pz69DialPosition)
                     {
                         dcsBiosBinding.DCSBIOSInputs.Clear();
                     }
-
                     found = true;
                     break;
                 }
@@ -1079,13 +1058,12 @@ namespace NonVisuals.Radios
 
             if (controlListPZ69 == ControlList.ALL || controlListPZ69 == ControlList.BIPS)
             {
-                foreach (var bipLink in _bipLinks)
+                foreach (BIPLinkPZ69 bipLink in _bipLinks)
                 {
                     if (bipLink.RadioPanelPZ69Knob == pz69SwitchOnOff.Switch && bipLink.WhenTurnedOn == pz69SwitchOnOff.ButtonState)
                     {
                         bipLink.BIPLights.Clear();
                     }
-
                     found = true;
                     break;
                 }
@@ -1119,54 +1097,24 @@ namespace NonVisuals.Radios
 
         public bool IsBindingActive(KeyBindingPZ69DialPosition keyBindingPZ69DialPosition)
         {
-            var dial = GetDial(keyBindingPZ69DialPosition.RadioPanelPZ69Key);
-            if (dial == keyBindingPZ69DialPosition.DialPosition)
-            {
-                return true;
-            }
-
-            return false;
+            PZ69DialPosition dial = GetDial(keyBindingPZ69DialPosition.RadioPanelPZ69Key);
+            return dial == keyBindingPZ69DialPosition.DialPosition;
         }
 
         private PZ69DialPosition GetDial(RadioPanelPZ69KnobsEmulator knob)
         {
-            if (knob.ToString().Contains("Upper"))
-            {
-                return _pz69UpperDialPosition;
-            }
-
-            return _pz69LowerDialPosition;
+            return knob.ToString().Contains("Upper") ? _pz69UpperDialPosition : _pz69LowerDialPosition;
         }
-
-        /*
-        private bool IsLowerArea(RadioPanelPZ69KnobsEmulator knob)
-        {
-            if (knob.ToString().Contains("Upper"))
-            {
-                return false;
-            }
-            return true;
-        }
-
-        private bool IsUpperArea(RadioPanelPZ69KnobsEmulator knob)
-        {
-            if (knob.ToString().Contains("Upper"))
-            {
-                return true;
-            }
-            return false;
-        }
-        */
+       
         public void Clear(RadioPanelPZ69KnobsEmulator radioPanelPZ69Knob)
         {
-            foreach (var keyBinding in _keyBindings)
+            foreach (KeyBindingPZ69DialPosition keyBinding in _keyBindings)
             {
                 if (keyBinding.RadioPanelPZ69Key == radioPanelPZ69Knob)
                 {
                     keyBinding.OSKeyPress = null;
                 }
             }
-
             SetIsDirty();
         }
 
@@ -1175,11 +1123,9 @@ namespace NonVisuals.Radios
             PZ69KnobChanged(isFirstReport, hashSet);
         }
 
-
-
         public override DcsOutputAndColorBinding CreateDcsOutputAndColorBinding(SaitekPanelLEDPosition saitekPanelLEDPosition, PanelLEDColor panelLEDColor, DCSBIOSOutput dcsBiosOutput)
         {
-            var dcsOutputAndColorBinding = new DcsOutputAndColorBindingPZ55
+            DcsOutputAndColorBindingPZ55 dcsOutputAndColorBinding = new() 
             {
                 DCSBiosOutputLED = dcsBiosOutput,
                 LEDColor = panelLEDColor,

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Generic.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Generic.cs
@@ -34,16 +34,16 @@ namespace NonVisuals.Radios
          * - BIP Link.
          */
         // private HashSet<DCSBIOSBindingPZ69> _dcsBiosBindings = new HashSet<DCSBIOSBindingPZ69>();
-        private HashSet<KeyBindingPZ69DialPosition> _keyBindings = new HashSet<KeyBindingPZ69DialPosition>();
-        private List<OSCommandBindingPZ69FullEmulator> _operatingSystemCommandBindings = new List<OSCommandBindingPZ69FullEmulator>();
-        private readonly HashSet<RadioPanelPZ69DisplayValue> _displayValues = new HashSet<RadioPanelPZ69DisplayValue>();
-        private HashSet<DCSBIOSOutputBindingPZ69> _dcsBiosLcdBindings = new HashSet<DCSBIOSOutputBindingPZ69>();
-        private HashSet<DCSBIOSActionBindingPZ69> _dcsBiosBindings = new HashSet<DCSBIOSActionBindingPZ69>();
-        private readonly HashSet<BIPLinkPZ69> _bipLinks = new HashSet<BIPLinkPZ69>();
-        private readonly object _lcdDataVariablesLockObject = new object();
+        private HashSet<KeyBindingPZ69DialPosition> _keyBindings = new();
+        private List<OSCommandBindingPZ69FullEmulator> _operatingSystemCommandBindings = new();
+        private readonly HashSet<RadioPanelPZ69DisplayValue> _displayValues = new();
+        private HashSet<DCSBIOSOutputBindingPZ69> _dcsBiosLcdBindings = new();
+        private HashSet<DCSBIOSActionBindingPZ69> _dcsBiosBindings = new();
+        private readonly HashSet<BIPLinkPZ69> _bipLinks = new();
+        private readonly object _lcdDataVariablesLockObject = new();
 
-        private readonly List<RadioPanelPZ69KnobsEmulator> _panelPZ69DialModesUpper = new List<RadioPanelPZ69KnobsEmulator> { RadioPanelPZ69KnobsEmulator.UpperCOM1, RadioPanelPZ69KnobsEmulator.UpperCOM2, RadioPanelPZ69KnobsEmulator.UpperNAV1, RadioPanelPZ69KnobsEmulator.UpperNAV2, RadioPanelPZ69KnobsEmulator.UpperADF, RadioPanelPZ69KnobsEmulator.UpperDME, RadioPanelPZ69KnobsEmulator.UpperXPDR };
-        private readonly List<RadioPanelPZ69KnobsEmulator> _panelPZ69DialModesLower = new List<RadioPanelPZ69KnobsEmulator> { RadioPanelPZ69KnobsEmulator.LowerCOM1, RadioPanelPZ69KnobsEmulator.LowerCOM2, RadioPanelPZ69KnobsEmulator.LowerNAV1, RadioPanelPZ69KnobsEmulator.LowerNAV2, RadioPanelPZ69KnobsEmulator.LowerADF, RadioPanelPZ69KnobsEmulator.LowerDME, RadioPanelPZ69KnobsEmulator.LowerXPDR };
+        private readonly List<RadioPanelPZ69KnobsEmulator> _panelPZ69DialModesUpper = new() { RadioPanelPZ69KnobsEmulator.UpperCOM1, RadioPanelPZ69KnobsEmulator.UpperCOM2, RadioPanelPZ69KnobsEmulator.UpperNAV1, RadioPanelPZ69KnobsEmulator.UpperNAV2, RadioPanelPZ69KnobsEmulator.UpperADF, RadioPanelPZ69KnobsEmulator.UpperDME, RadioPanelPZ69KnobsEmulator.UpperXPDR };
+        private readonly List<RadioPanelPZ69KnobsEmulator> _panelPZ69DialModesLower = new() { RadioPanelPZ69KnobsEmulator.LowerCOM1, RadioPanelPZ69KnobsEmulator.LowerCOM2, RadioPanelPZ69KnobsEmulator.LowerNAV1, RadioPanelPZ69KnobsEmulator.LowerNAV2, RadioPanelPZ69KnobsEmulator.LowerADF, RadioPanelPZ69KnobsEmulator.LowerDME, RadioPanelPZ69KnobsEmulator.LowerXPDR };
         private double _upperActive = -1;
         private double _upperStandby = -1;
         private double _lowerActive = -1;

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Ka50.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Ka50.cs
@@ -181,7 +181,6 @@
             base.Dispose(disposing);
         }
 
-
         public override void DcsBiosDataReceived(object sender, DCSBIOSDataEventArgs e)
         {
             try
@@ -386,7 +385,6 @@
                                         {
                                             SendR800L1ToDCSBIOS();
                                         }
-
                                         break;
                                     }
 
@@ -401,7 +399,6 @@
                                         break;
                                     }
                             }
-
                             break;
                         }
 
@@ -420,7 +417,6 @@
                                         {
                                             SendR800L1ToDCSBIOS();
                                         }
-
                                         break;
                                     }
 
@@ -435,7 +431,6 @@
                                         break;
                                     }
                             }
-
                             break;
                         }
                 }
@@ -479,8 +474,8 @@
                     try
                     {
                         /*
-                                          * Ka-50 R-800L1 VHF 2
-                                          */
+                        * Ka-50 R-800L1 VHF 2
+                        */
                         Interlocked.Exchange(ref _r800L1ThreadNowSynching, 1);
                         long dial1Timeout = DateTime.Now.Ticks;
                         long dial2Timeout = DateTime.Now.Ticks;
@@ -565,7 +560,6 @@
                                         dial1SendCount++;
                                         Interlocked.Exchange(ref _r800L1Dial1WaitingForFeedback, 1);
                                     }
-
                                     Reset(ref dial1Timeout);
                                 }
                             }
@@ -586,7 +580,6 @@
                                         dial2SendCount++;
                                         Interlocked.Exchange(ref _r800L1Dial2WaitingForFeedback, 1);
                                     }
-
                                     Reset(ref dial2Timeout);
                                 }
                             }
@@ -607,7 +600,6 @@
                                         dial3SendCount++;
                                         Interlocked.Exchange(ref _r800L1Dial3WaitingForFeedback, 1);
                                     }
-
                                     Reset(ref dial3Timeout);
                                 }
                             }
@@ -619,22 +611,13 @@
                             var desiredPositionDial4 = 0;
                             if (Interlocked.Read(ref _r800L1Dial4WaitingForFeedback) == 0)
                             {
-                                if (desiredPositionDial4X == 0)
+                                desiredPositionDial4 = desiredPositionDial4X switch
                                 {
-                                    desiredPositionDial4 = 0;
-                                }
-                                else if (desiredPositionDial4X == 2)
-                                {
-                                    desiredPositionDial4 = 0;
-                                }
-                                else if (desiredPositionDial4X == 5)
-                                {
-                                    desiredPositionDial4 = 2;
-                                }
-                                else if (desiredPositionDial4X == 7)
-                                {
-                                    desiredPositionDial4 = 2;
-                                }
+                                    0 => 0,
+                                    2 => 0,
+                                    5 => 2,
+                                    7 => 2 
+                                };
 
                                 // "00" "25" "50" "75", only "00" and "50" used.
                                 // Pos     0    1    2    3
@@ -656,7 +639,6 @@
                                         dial4SendCount++;
                                         Interlocked.Exchange(ref _r800L1Dial4WaitingForFeedback, 1);
                                     }
-
                                     Reset(ref dial4Timeout);
                                 }
                             }
@@ -741,7 +723,6 @@
                                     {
                                         SetUpperRadioMode(CurrentKa50RadioMode.VHF1_R828);
                                     }
-
                                     break;
                                 }
 
@@ -751,7 +732,6 @@
                                     {
                                         SetUpperRadioMode(CurrentKa50RadioMode.VHF2_R800L1);
                                     }
-
                                     break;
                                 }
 
@@ -761,7 +741,6 @@
                                     {
                                         SetUpperRadioMode(CurrentKa50RadioMode.ADF_ARK22);
                                     }
-
                                     break;
                                 }
 
@@ -771,7 +750,6 @@
                                     {
                                         SetLowerRadioMode(CurrentKa50RadioMode.VHF1_R828);
                                     }
-
                                     break;
                                 }
 
@@ -781,7 +759,6 @@
                                     {
                                         SetLowerRadioMode(CurrentKa50RadioMode.VHF2_R800L1);
                                     }
-
                                     break;
                                 }
 
@@ -791,7 +768,6 @@
                                     {
                                         SetLowerRadioMode(CurrentKa50RadioMode.ADF_ARK22);
                                     }
-
                                     break;
                                 }
 
@@ -801,7 +777,6 @@
                                     {
                                         SetUpperRadioMode(CurrentKa50RadioMode.ABRIS);
                                     }
-
                                     break;
                                 }
 
@@ -811,7 +786,6 @@
                                     {
                                         SetUpperRadioMode(CurrentKa50RadioMode.DATALINK);
                                     }
-
                                     break;
                                 }
 
@@ -822,7 +796,6 @@
                                     {
                                         SetUpperRadioMode(CurrentKa50RadioMode.NOUSE);
                                     }
-
                                     break;
                                 }
 
@@ -832,7 +805,6 @@
                                     {
                                         SetLowerRadioMode(CurrentKa50RadioMode.ABRIS);
                                     }
-
                                     break;
                                 }
 
@@ -842,7 +814,6 @@
                                     {
                                         SetLowerRadioMode(CurrentKa50RadioMode.DATALINK);
                                     }
-
                                     break;
                                 }
 
@@ -853,7 +824,6 @@
                                     {
                                         SetLowerRadioMode(CurrentKa50RadioMode.NOUSE);
                                     }
-
                                     break;
                                 }
 
@@ -899,17 +869,6 @@
                                                 DCSBIOS.Send(ADF_MODE_DEC);
                                             }
                                         }
-
-                                        /*if (_adfModeSwitchLastSent.Equals(ADFModeSwitchAntenna))
-                                                                                {
-                                                                                    DCSBIOS.Send(ADFModeSwitchCompass);
-                                                                                    _adfModeSwitchLastSent = ADFModeSwitchCompass;
-                                                                                }
-                                                                                else
-                                                                                {
-                                                                                    DCSBIOS.Send(ADFModeSwitchAntenna);
-                                                                                    _adfModeSwitchLastSent = ADFModeSwitchAntenna;
-                                                                                }*/
                                     }
                                     else if (_currentUpperRadioMode == CurrentKa50RadioMode.DATALINK && radioPanelKnob.IsOn)
                                     {
@@ -919,7 +878,6 @@
                                     {
                                         SendFrequencyToDCSBIOS(radioPanelKnob.IsOn, RadioPanelPZ69KnobsKa50.UPPER_FREQ_SWITCH);
                                     }
-
                                     break;
                                 }
 
@@ -961,7 +919,6 @@
                                     {
                                         SendFrequencyToDCSBIOS(radioPanelKnob.IsOn, RadioPanelPZ69KnobsKa50.LOWER_FREQ_SWITCH);
                                     }
-
                                     break;
                                 }
                         }
@@ -977,7 +934,6 @@
                                 null);
                         }
                     }
-
                     AdjustFrequency(hashSet);
                 }
             }
@@ -1013,7 +969,6 @@
                                                 {
                                                     DCSBIOS.Send(VHF1_PRESET_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -1034,7 +989,6 @@
                                                 {
                                                     _r800L1BigFrequencyStandby++;
                                                 }
-
                                                 break;
                                             }
 
@@ -1051,7 +1005,6 @@
                                                 {
                                                     DCSBIOS.Send(DATALINK_MASTER_MODE_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -1061,7 +1014,6 @@
                                                 {
                                                     DCSBIOS.Send(ADF_PRESET_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -1070,7 +1022,6 @@
                                                 break;
                                             }
                                     }
-
                                     break;
                                 }
 
@@ -1084,7 +1035,6 @@
                                                 {
                                                     DCSBIOS.Send(VHF1_PRESET_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -1105,7 +1055,6 @@
                                                 {
                                                     _r800L1BigFrequencyStandby--;
                                                 }
-
                                                 break;
                                             }
 
@@ -1122,7 +1071,6 @@
                                                 {
                                                     DCSBIOS.Send(DATALINK_MASTER_MODE_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -1132,7 +1080,6 @@
                                                 {
                                                     DCSBIOS.Send(ADF_PRESET_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -1141,7 +1088,6 @@
                                                 break;
                                             }
                                     }
-
                                     break;
                                 }
 
@@ -1163,7 +1109,6 @@
                                                     _r800L1SmallFrequencyStandby = 0;
                                                     break;
                                                 }
-
                                                 _r800L1SmallFrequencyStandby += 5;
                                                 break;
                                             }
@@ -1181,7 +1126,6 @@
                                                 {
                                                     DCSBIOS.Send(DATALINK_SELF_ID_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -1196,7 +1140,6 @@
                                                 break;
                                             }
                                     }
-
                                     break;
                                 }
 
@@ -1218,7 +1161,6 @@
                                                     _r800L1SmallFrequencyStandby = 95;
                                                     break;
                                                 }
-
                                                 _r800L1SmallFrequencyStandby -= 5;
                                                 break;
                                             }
@@ -1236,7 +1178,6 @@
                                                 {
                                                     DCSBIOS.Send(DATALINK_SELF_ID_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -1251,7 +1192,6 @@
                                                 break;
                                             }
                                     }
-
                                     break;
                                 }
 
@@ -1265,7 +1205,6 @@
                                                 {
                                                     DCSBIOS.Send(VHF1_PRESET_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -1300,7 +1239,6 @@
                                                 {
                                                     _r800L1BigFrequencyStandby = _r800L1BigFrequencyStandby - 149 + 220;
                                                 }
-
                                                 break;
                                             }
 
@@ -1317,7 +1255,6 @@
                                                 {
                                                     DCSBIOS.Send(DATALINK_MASTER_MODE_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -1327,7 +1264,6 @@
                                                 {
                                                     DCSBIOS.Send(ADF_PRESET_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -1336,7 +1272,6 @@
                                                 break;
                                             }
                                     }
-
                                     break;
                                 }
 
@@ -1350,7 +1285,6 @@
                                                 {
                                                     DCSBIOS.Send(VHF1_PRESET_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -1385,7 +1319,6 @@
                                                 {
                                                     _r800L1BigFrequencyStandby = 149 - (220 - _r800L1BigFrequencyStandby);
                                                 }
-
                                                 break;
                                             }
 
@@ -1402,7 +1335,6 @@
                                                 {
                                                     DCSBIOS.Send(DATALINK_MASTER_MODE_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -1412,7 +1344,6 @@
                                                 {
                                                     DCSBIOS.Send(ADF_PRESET_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -1421,7 +1352,6 @@
                                                 break;
                                             }
                                     }
-
                                     break;
                                 }
 
@@ -1461,7 +1391,6 @@
                                                 {
                                                     DCSBIOS.Send(DATALINK_SELF_ID_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -1476,7 +1405,6 @@
                                                 break;
                                             }
                                     }
-
                                     break;
                                 }
 
@@ -1498,7 +1426,6 @@
                                                     _r800L1SmallFrequencyStandby = 95;
                                                     break;
                                                 }
-
                                                 _r800L1SmallFrequencyStandby -= 5;
                                                 break;
                                             }
@@ -1516,7 +1443,6 @@
                                                 {
                                                     DCSBIOS.Send(DATALINK_SELF_ID_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -1531,7 +1457,6 @@
                                                 break;
                                             }
                                     }
-
                                     break;
                                 }
                         }
@@ -1592,7 +1517,6 @@
                         _vhf1PresetDialSkipper = 0;
                         return false;
                     }
-
                     _vhf1PresetDialSkipper++;
                     return true;
                 }
@@ -1601,7 +1525,6 @@
             {
                 logger.Error(ex);
             }
-
             return false;
         }
 
@@ -1616,7 +1539,6 @@
                         _adfPresetDialSkipper = 0;
                         return false;
                     }
-
                     _adfPresetDialSkipper++;
                     return true;
                 }
@@ -1625,7 +1547,6 @@
             {
                 logger.Error(ex);
             }
-
             return false;
         }
 
@@ -1640,7 +1561,6 @@
                         _datalinkMasterModeDialSkipper = 0;
                         return false;
                     }
-
                     _datalinkMasterModeDialSkipper++;
                     return true;
                 }
@@ -1649,7 +1569,6 @@
             {
                 logger.Error(ex);
             }
-
             return false;
         }
 
@@ -1664,7 +1583,6 @@
                         _datalinkSelfIdDialSkipper = 0;
                         return false;
                     }
-
                     _datalinkSelfIdDialSkipper++;
                     return true;
                 }
@@ -1673,7 +1591,6 @@
             {
                 logger.Error(ex);
             }
-
             return false;
         }
 
@@ -1797,26 +1714,12 @@
                                 string channelAsString;
                                 lock (_lockADFDialObject1)
                                 {
-                                    switch (_adfCockpitPresetDialPos)
+                                    channelAsString = _adfCockpitPresetDialPos switch
                                     {
-                                        case 0:
-                                            {
-                                                channelAsString = "9".PadLeft(2, ' ');
-                                                break;
-                                            }
-
-                                        case 1:
-                                            {
-                                                channelAsString = "10".PadLeft(2, ' ');
-                                                break;
-                                            }
-
-                                        default:
-                                            {
-                                                channelAsString = (_adfCockpitPresetDialPos - 1).ToString().PadLeft(2, ' ');
-                                                break;
-                                            }
-                                    }
+                                        0 => "9".PadLeft(2, ' '),
+                                        1 => "10".PadLeft(2, ' '),
+                                        _ => (_adfCockpitPresetDialPos - 1).ToString().PadLeft(2, ' ')
+                                    };
                                 }
 
                                 uint adfMode = 0;
@@ -1927,26 +1830,12 @@
                                 string channelAsString;
                                 lock (_lockADFDialObject1)
                                 {
-                                    switch (_adfCockpitPresetDialPos)
+                                    channelAsString = _adfCockpitPresetDialPos switch
                                     {
-                                        case 0:
-                                            {
-                                                channelAsString = "9".PadLeft(2, ' ');
-                                                break;
-                                            }
-
-                                        case 1:
-                                            {
-                                                channelAsString = "10".PadLeft(2, ' ');
-                                                break;
-                                            }
-
-                                        default:
-                                            {
-                                                channelAsString = (_adfCockpitPresetDialPos - 1).ToString().PadLeft(2, ' ');
-                                                break;
-                                            }
-                                    }
+                                        0 => "9".PadLeft(2, ' '),
+                                        1 => "10".PadLeft(2, ' '),
+                                        _ => (_adfCockpitPresetDialPos - 1).ToString().PadLeft(2, ' ')
+                                    };
                                 }
 
                                 uint adfMode = 0;
@@ -2022,7 +1911,7 @@
 
         public override DcsOutputAndColorBinding CreateDcsOutputAndColorBinding(SaitekPanelLEDPosition saitekPanelLEDPosition, PanelLEDColor panelLEDColor, DCSBIOSOutput dcsBiosOutput)
         {
-            var dcsOutputAndColorBinding = new DcsOutputAndColorBindingPZ55
+            DcsOutputAndColorBindingPZ55 dcsOutputAndColorBinding = new()
             {
                 DCSBiosOutputLED = dcsBiosOutput,
                 LEDColor = panelLEDColor,
@@ -2231,7 +2120,6 @@
                                         return inc;
                                     }
                             }
-
                             break;
                         }
 
@@ -2266,7 +2154,6 @@
                                         return inc;
                                     }
                             }
-
                             break;
                         }
 
@@ -2301,7 +2188,6 @@
                                         return inc;
                                     }
                             }
-
                             break;
                         }
 
@@ -2336,7 +2222,6 @@
                                         return inc;
                                     }
                             }
-
                             break;
                         }
 
@@ -2371,7 +2256,6 @@
                                         return inc;
                                     }
                             }
-
                             break;
                         }
 
@@ -2402,7 +2286,6 @@
                                         return dec;
                                     }
                             }
-
                             break;
                         }
 
@@ -2437,7 +2320,6 @@
                                         return dec;
                                     }
                             }
-
                             break;
                         }
 
@@ -2472,7 +2354,6 @@
                                         return dec;
                                     }
                             }
-
                             break;
                         }
 
@@ -2507,7 +2388,6 @@
                                         return dec;
                                     }
                             }
-
                             break;
                         }
 
@@ -2538,7 +2418,6 @@
                                         return null;
                                     }
                             }
-
                             break;
                         }
                 }
@@ -2549,7 +2428,7 @@
             }
 
             throw new Exception(
-                "Should reach this code. private String GetCommandDirectionFor0To9Dials(uint desiredDialPosition, uint actualDialPosition) -> " + desiredDialPosition + "   " + actualDialPosition);
+                $"Should not reach this code. private String GetCommandDirectionFor0To9Dials(uint desiredDialPosition, uint actualDialPosition) -> {desiredDialPosition}   {actualDialPosition}");
         }
 
         private string GetR800L1DialFrequencyForPosition(uint position)
@@ -2558,28 +2437,13 @@
             {
                 // "00"  "25" "50" "75"
                 // 0    1    2    3  
-                switch (position)
+                return position switch
                 {
-                    case 0:
-                        {
-                            return "0";
-                        }
-
-                    case 1:
-                        {
-                            return "5";
-                        }
-
-                    case 2:
-                        {
-                            return "5";
-                        }
-
-                    case 3:
-                        {
-                            return "0";
-                        }
-                }
+                    0 => "0",
+                    1 => "5",
+                    2 => "5",
+                    3 => "0",
+                };             
             }
             catch (Exception ex)
             {

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Ka50.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Ka50.cs
@@ -33,25 +33,16 @@
         /*COM1 Ka-50 VHF 1 R-828*/
         // Large dial 1-10 [step of 1]
         // Small dial volume control
-        private readonly object _lockVhf1DialObject1 = new object();
-
+        private readonly object _lockVhf1DialObject1 = new();
         private DCSBIOSOutput _vhf1DcsbiosOutputPresetDial;
-
         private volatile uint _vhf1CockpitPresetDialPos = 1;
-
         private const string VHF1_PRESET_COMMAND_INC = "R828_CHANNEL INC\n";
-
         private const string VHF1_PRESET_COMMAND_DEC = "R828_CHANNEL DEC\n";
-
         private int _vhf1PresetDialSkipper;
-
         // private DCSBIOSOutput _vhf1DcsbiosOutputVolumeDial;
         private const string VHF1_VOLUME_KNOB_COMMAND_INC = "R828_VOLUME +2500\n";
-
         private const string VHF1_VOLUME_KNOB_COMMAND_DEC = "R828_VOLUME -2500\n";
-
         private const string VHF1_TUNER_BUTTON_PRESS = "R828_TUNER INC\n";
-
         private const string VHF1_TUNER_BUTTON_RELEASE = "R828_TUNER DEC\n";
 
         /*COM2 Ka-50 VHF 2 R-800L1*/
@@ -63,99 +54,59 @@
             //
         };*/
         private readonly ClickSpeedDetector _r800L1BigFreqIncreaseChangeMonitor = new ClickSpeedDetector(20);
-
         private readonly ClickSpeedDetector _r800L1BigFreqDecreaseChangeMonitor = new ClickSpeedDetector(20);
-
         const int CHANGE_VALUE = 10;
 
         // private long _changesWithinLastticksSinceLastChangeLargeDial;
         private readonly int[] _r800L1Freq1DialValues = { 10, 11, 12, 13, 14, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39 };
-
         private uint _r800L1BigFrequencyStandby = 108;
-
         private uint _r800L1SmallFrequencyStandby;
-
         private volatile uint _r800L1SavedCockpitBigFrequency;
-
         private volatile uint _r800L1SavedCockpitSmallFrequency;
-
-        private readonly object _lockR800L1DialsObject1 = new object();
-
-        private readonly object _lockR800L1DialsObject2 = new object();
-
-        private readonly object _lockR800L1DialsObject3 = new object();
-
-        private readonly object _lockR800L1DialsObject4 = new object();
-
+        private readonly object _lockR800L1DialsObject1 = new();
+        private readonly object _lockR800L1DialsObject2 = new();
+        private readonly object _lockR800L1DialsObject3 = new();
+        private readonly object _lockR800L1DialsObject4 = new();
         private DCSBIOSOutput _r800L1DcsbiosOutputFreqDial1;
-
         private DCSBIOSOutput _r800L1DcsbiosOutputFreqDial2;
-
         private DCSBIOSOutput _r800L1DcsbiosOutputFreqDial3;
-
         private DCSBIOSOutput _r800L1DcsbiosOutputFreqDial4;
-
         private volatile uint _r800L1CockpitFreq1DialPos = 1;
-
         private volatile uint _r800L1CockpitFreq2DialPos = 1;
-
         private volatile uint _r800L1CockpitFreq3DialPos = 1;
-
         private volatile uint _r800L1CockpitFreq4DialPos = 1;
-
         private const string R800_L1_FREQ_1DIAL_COMMAND = "R800_FREQ1 ";
-
         private const string R800_L1_FREQ_2DIAL_COMMAND = "R800_FREQ2 ";
-
         private const string R800_L1_FREQ_3DIAL_COMMAND = "R800_FREQ3 ";
-
         private const string R800_L1_FREQ_4DIAL_COMMAND = "R800_FREQ4 ";
-
         private Thread _r800L1SyncThread;
-
         private long _r800L1ThreadNowSynching;
-
         private long _r800L1Dial1WaitingForFeedback;
-
         private long _r800L1Dial2WaitingForFeedback;
-
         private long _r800L1Dial3WaitingForFeedback;
-
         private long _r800L1Dial4WaitingForFeedback;
 
         /*ADF Ka-50 ARK-22 ADF*/
         // Large dial 0-9 [step of 1]
         // Small dial volume control
         // ACT/STBY Switch between ADF Modes Inner Auto Outer
-        private readonly object _lockADFDialObject1 = new object();
-
+        private readonly object _lockADFDialObject1 = new();
         private DCSBIOSOutput _adfDcsbiosOutputPresetDial;
-
         private volatile uint _adfCockpitPresetDialPos = 1;
-
         private const string ADF_PRESET_COMMAND_INC = "ADF_CHANNEL INC\n";
-
         private const string ADF_PRESET_COMMAND_DEC = "ADF_CHANNEL DEC\n";
-
         private int _adfPresetDialSkipper;
-
         private const string ADF_VOLUME_KNOB_COMMAND_INC = "ADF_VOLUME +2500\n";
-
         private const string ADF_VOLUME_KNOB_COMMAND_DEC = "ADF_VOLUME -2500\n";
 
         /*private const string ADFModeSwitchAntenna = "ADF_CMPS_ANT INC\n";
         private const string ADFModeSwitchCompass = "ADF_CMPS_ANT DEC\n";
         private string _adfModeSwitchLastSent = string.Empty;*/
-        private readonly object _lockADFModeDialObject = new object();
-
+        private readonly object _lockADFModeDialObject = new();
         private DCSBIOSOutput _adfModeDcsbiosOutput;
-
         private volatile uint _adfModeCockpitPos = 1;
-
         private const string ADF_MODE_INC = "ADF_NDB_MODE INC\n";
-
         private const string ADF_MODE_DEC = "ADF_NDB_MODE DEC\n";
-
         private bool _adfModeSwitchDirectionUp;
 
         /*NAV1 Ka-50 ABRIS NAV1 (Not radio but programmed as there are so few radio systems on the KA-50*/
@@ -163,71 +114,44 @@
         // Small ABRIS Right Dial
         // ACT/STBY Push Right ABRIS Dial IN/OUT
         private readonly ClickSpeedDetector _abrisLeftDialIncreaseChangeMonitor = new ClickSpeedDetector(10);
-
         private readonly ClickSpeedDetector _abrisLeftDialDecreaseChangeMonitor = new ClickSpeedDetector(10);
 
         private const string ABRIS_LEFT_DIAL_COMMAND_INC_MORE = "ABRIS_BRIGHTNESS +2500\n";
-
         private const string ABRIS_LEFT_DIAL_COMMAND_DEC_MORE = "ABRIS_BRIGHTNESS -2500\n";
-
         private const string ABRIS_LEFT_DIAL_COMMAND_INC = "ABRIS_BRIGHTNESS +1000\n";
-
         private const string ABRIS_LEFT_DIAL_COMMAND_DEC = "ABRIS_BRIGHTNESS -1000\n";
 
         private readonly ClickSpeedDetector _abrisRightDialIncreaseChangeMonitor = new ClickSpeedDetector(10);
-
         private readonly ClickSpeedDetector _abrisRightDialDecreaseChangeMonitor = new ClickSpeedDetector(10);
 
         private const string ABRIS_RIGHT_DIAL_COMMAND_INC_MORE = "ABRIS_CURSOR_ROT +2500\n";
-
         private const string ABRIS_RIGHT_DIAL_COMMAND_DEC_MORE = "ABRIS_CURSOR_ROT -2500\n";
-
         private const string ABRIS_RIGHT_DIAL_COMMAND_INC = "ABRIS_CURSOR_ROT +5000\n";
-
         private const string ABRIS_RIGHT_DIAL_COMMAND_DEC = "ABRIS_CURSOR_ROT -5000\n";
-
         private const string ABRIS_RIGHT_DIAL_PUSH_TOGGLE_ON_COMMAND = "ABRIS_CURSOR_BTN 1\n";
-
         private const string ABRIS_RIGHT_DIAL_PUSH_TOGGLE_OFF_COMMAND = "ABRIS_CURSOR_BTN 0\n";
 
         /*NAV2 Ka-50 Datalink Operation*/
         // Large dial Datalink Master Mode 0-3
         // Small dial Datalink Self ID
         // ACT/STBY Datalink ON/OFF
-        private readonly object _lockDatalinkMasterModeObject = new object();
-
+        private readonly object _lockDatalinkMasterModeObject = new();
         private DCSBIOSOutput _datalinkMasterModeDcsbiosOutput;
-
         private volatile uint _datalinkMasterModeCockpitPos = 1;
-
         private const string DATALINK_MASTER_MODE_COMMAND_INC = "DLNK_MASTER_MODE INC\n";
-
         private const string DATALINK_MASTER_MODE_COMMAND_DEC = "DLNK_MASTER_MODE DEC\n";
-
         private int _datalinkMasterModeDialSkipper;
-
-        private readonly object _lockDatalinkSelfIdObject = new object();
-
+        private readonly object _lockDatalinkSelfIdObject = new();
         private DCSBIOSOutput _datalinkSelfIdDcsbiosOutput;
-
         private volatile uint _datalinkSelfIdCockpitPos = 1;
-
         private const string DATALINK_SELF_ID_COMMAND_INC = "DLNK_SELF_ID INC\n";
-
         private const string DATALINK_SELF_ID_COMMAND_DEC = "DLNK_SELF_ID DEC\n";
-
         private int _datalinkSelfIdDialSkipper;
-
-        private readonly object _lockDatalinkPowerOnOffObject = new object();
-
+        private readonly object _lockDatalinkPowerOnOffObject = new();
         private DCSBIOSOutput _datalinkPowerOnOffDcsbiosOutput;
-
         private volatile uint _datalinkPowerOnOffCockpitPos = 1;
-
         private const string DATALINK_POWER_ON_OFF_COMMAND_TOGGLE = "PVI_POWER TOGGLE\n";
-
-        private readonly object _lockShowFrequenciesOnPanelObject = new object();
-
+        private readonly object _lockShowFrequenciesOnPanelObject = new();
         private long _doUpdatePanelLCD;
 
         public RadioPanelPZ69Ka50(HIDSkeleton hidSkeleton)

--- a/Source/NonVisuals/Radios/RadioPanelPZ69M2000C.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69M2000C.cs
@@ -33,8 +33,8 @@
         /*M-2000C VHF PRESETS COM1*/
         // Large dial PRESETS [step of 1]
         // Small dial Volume
-        private readonly object _lockVUHFPresetFreqObject = new object();
-        private readonly object _lockVUHFPresetDialObject = new object();
+        private readonly object _lockVUHFPresetFreqObject = new();
+        private readonly object _lockVUHFPresetDialObject = new();
         private DCSBIOSOutput _vhfDcsbiosOutputPresetFreqString;
         private DCSBIOSOutput _vhfDcsbiosOutputPresetDial;
         private string _vhfPresetCockpitFrequency = string.Empty;
@@ -49,8 +49,8 @@
         /*M2000C UHF PRESETS COM2*/
         // Large dial PRESETS [step of 1]
         // Small dial Volume
-        private readonly object _lockUHFPresetFreqObject = new object();
-        private readonly object _lockUHFPresetDialObject = new object();
+        private readonly object _lockUHFPresetFreqObject = new();
+        private readonly object _lockUHFPresetDialObject = new();
         private DCSBIOSOutput _uhfDcsbiosOutputPresetFreqString;
         private DCSBIOSOutput _uhfDcsbiosOutputPresetDial;
         private string _uhfPresetCockpitFrequency = string.Empty;
@@ -64,7 +64,7 @@
         // definePotentiometer("UHF_RADIO_VOL_KNOB", 16, 3706, 706, { 0, 1}, "AUDIO PANEL", "I - UHF - Radio Volume Knob")
 
         /*M-2000C TACAN NAV1*/
-        private readonly object _lockTACANDialObject = new object();
+        private readonly object _lockTACANDialObject = new();
         private DCSBIOSOutput _tacanDcsbiosOutputDialTens;
         private DCSBIOSOutput _tacanDcsbiosOutputDialOnes;
         private volatile uint _tacanTensCockpitDialPos = 1;
@@ -84,7 +84,7 @@
         private const string TACANXY_SELECT_COMMAND_DEC = "TAC_X_Y_SEL DEC\n";
 
         /*M-2000C VOR.ILS NAV2*/
-        private readonly object _lockVoRialObject = new object();
+        private readonly object _lockVoRialObject = new();
         private DCSBIOSOutput _vorDcsbiosOutputDialDecimals;
         private DCSBIOSOutput _vorDcsbiosOutputDialOnes;
         private volatile uint _vorDecimalsCockpitDialPos = 1;
@@ -102,7 +102,7 @@
         private const string VOR_POWER_COMMAND_DEC = "VORILS_PWR_DIAL DEC\n";
         private const string VOR_TEST_COMMAND_INC = "VORILS_TEST_DIAL INC\n";
         private const string VOR_TEST_COMMAND_DEC = "VORILS_TEST_DIAL DEC\n";
-        private readonly object _lockShowFrequenciesOnPanelObject = new object();
+        private readonly object _lockShowFrequenciesOnPanelObject = new();
         private long _doUpdatePanelLCD;
 
         private bool _upperFreqSwitchPressedDown;

--- a/Source/NonVisuals/Radios/RadioPanelPZ69M2000C.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69M2000C.cs
@@ -45,7 +45,6 @@
         private const string VHFVolumeCommandInc = "VUHF_RADIO_VOL_KNOB +3200\n";
         private const string VHFVolumeCommandDec = "VUHF_RADIO_VOL_KNOB -3200\n";
 
-
         /*M2000C UHF PRESETS COM2*/
         // Large dial PRESETS [step of 1]
         // Small dial Volume
@@ -182,12 +181,12 @@
                 UpdateCounter(e.Address, e.Data);
 
                 /*
-                                 * IMPORTANT INFORMATION REGARDING THE _*WaitingForFeedback variables
-                                 * Once a dial has been deemed to be "off" position and needs to be changed
-                                 * a change command is sent to DCS-BIOS.
-                                 * Only after a *change* has been acknowledged will the _*WaitingForFeedback be
-                                 * reset. Reading the dial's position with no change in value will not reset.
-                                 */
+                * IMPORTANT INFORMATION REGARDING THE _*WaitingForFeedback variables
+                * Once a dial has been deemed to be "off" position and needs to be changed
+                * a change command is sent to DCS-BIOS.
+                * Only after a *change* has been acknowledged will the _*WaitingForFeedback be
+                * reset. Reading the dial's position with no change in value will not reset.
+                */
 
                 // V/UHF Preset Channel Dial
                 if (e.Address == _vhfDcsbiosOutputPresetDial.Address)
@@ -446,7 +445,6 @@
                                     {
                                         SetUpperRadioMode(CurrentM2000CRadioMode.VUHF);
                                     }
-
                                     break;
                                 }
 
@@ -456,7 +454,6 @@
                                     {
                                         SetUpperRadioMode(CurrentM2000CRadioMode.UHF);
                                     }
-
                                     break;
                                 }
 
@@ -466,7 +463,6 @@
                                     {
                                         SetUpperRadioMode(CurrentM2000CRadioMode.TACAN);
                                     }
-
                                     break;
                                 }
 
@@ -476,7 +472,6 @@
                                     {
                                         SetUpperRadioMode(CurrentM2000CRadioMode.VOR);
                                     }
-
                                     break;
                                 }
 
@@ -488,7 +483,6 @@
                                     {
                                         SetUpperRadioMode(CurrentM2000CRadioMode.NOUSE);
                                     }
-
                                     break;
                                 }
 
@@ -498,7 +492,6 @@
                                     {
                                         SetLowerRadioMode(CurrentM2000CRadioMode.VUHF);
                                     }
-
                                     break;
                                 }
 
@@ -508,7 +501,6 @@
                                     {
                                         SetLowerRadioMode(CurrentM2000CRadioMode.UHF);
                                     }
-
                                     break;
                                 }
 
@@ -518,7 +510,6 @@
                                     {
                                         SetLowerRadioMode(CurrentM2000CRadioMode.TACAN);
                                     }
-
                                     break;
                                 }
 
@@ -528,7 +519,6 @@
                                     {
                                         SetLowerRadioMode(CurrentM2000CRadioMode.VOR);
                                     }
-
                                     break;
                                 }
 
@@ -540,7 +530,6 @@
                                     {
                                         SetLowerRadioMode(CurrentM2000CRadioMode.NOUSE);
                                     }
-
                                     break;
                                 }
 
@@ -611,11 +600,8 @@
                                             {
                                                 if (!SkipVUHFPresetDialChange())
                                                 {
-
                                                     DCSBIOS.Send(VHFPresetCommandInc);
-
                                                 }
-
                                                 break;
                                             }
 
@@ -625,7 +611,6 @@
                                                 {
                                                     DCSBIOS.Send(UHF_PRESET_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -635,7 +620,6 @@
                                                 {
                                                     DCSBIOS.Send(_upperFreqSwitchPressedDown ? TACANXY_SELECT_COMMAND_INC : TACAN_TENS_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -645,7 +629,6 @@
                                                 {
                                                     DCSBIOS.Send(_upperFreqSwitchPressedDown ? VOR_POWER_COMMAND_INC : VOR_DECIMALS_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -665,11 +648,8 @@
                                             {
                                                 if (!SkipVUHFPresetDialChange())
                                                 {
-
                                                     DCSBIOS.Send(VHFPresetCommandDec);
-
                                                 }
-
                                                 break;
                                             }
 
@@ -679,7 +659,6 @@
                                                 {
                                                     DCSBIOS.Send(UHF_PRESET_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -689,7 +668,6 @@
                                                 {
                                                     DCSBIOS.Send(_upperFreqSwitchPressedDown ? TACANXY_SELECT_COMMAND_DEC : TACAN_TENS_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -699,7 +677,6 @@
                                                 {
                                                     DCSBIOS.Send(_upperFreqSwitchPressedDown ? VOR_POWER_COMMAND_DEC : VOR_DECIMALS_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
                                     }
@@ -712,9 +689,7 @@
                                     {
                                         case CurrentM2000CRadioMode.VUHF:
                                             {
-
                                                 DCSBIOS.Send(VHFVolumeCommandInc);
-
                                                 break;
                                             }
 
@@ -730,7 +705,6 @@
                                                 {
                                                     DCSBIOS.Send(_upperFreqSwitchPressedDown ? TACAN_MODE_SELECT_COMMAND_INC : TACAN_ONES_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -740,7 +714,6 @@
                                                 {
                                                     DCSBIOS.Send(_upperFreqSwitchPressedDown ? VOR_TEST_COMMAND_INC : VOR_ONES_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -764,9 +737,7 @@
 
                                         case CurrentM2000CRadioMode.VUHF:
                                             {
-
                                                 DCSBIOS.Send(VHFVolumeCommandDec);
-
                                                 break;
                                             }
 
@@ -776,7 +747,6 @@
                                                 {
                                                     DCSBIOS.Send(_upperFreqSwitchPressedDown ? TACAN_MODE_SELECT_COMMAND_DEC : TACAN_ONES_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -786,7 +756,6 @@
                                                 {
                                                     DCSBIOS.Send(_upperFreqSwitchPressedDown ? VOR_TEST_COMMAND_DEC : VOR_ONES_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -806,11 +775,8 @@
                                             {
                                                 if (!SkipVUHFPresetDialChange())
                                                 {
-
                                                     DCSBIOS.Send(VHFPresetCommandInc);
-
                                                 }
-
                                                 break;
                                             }
 
@@ -820,7 +786,6 @@
                                                 {
                                                     DCSBIOS.Send(UHF_PRESET_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -830,7 +795,6 @@
                                                 {
                                                     DCSBIOS.Send(_lowerFreqSwitchPressedDown ? TACANXY_SELECT_COMMAND_INC : TACAN_TENS_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -840,7 +804,6 @@
                                                 {
                                                     DCSBIOS.Send(_lowerFreqSwitchPressedDown ? VOR_POWER_COMMAND_INC : VOR_DECIMALS_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -860,11 +823,8 @@
                                             {
                                                 if (!SkipVUHFPresetDialChange())
                                                 {
-
                                                     DCSBIOS.Send(VHFPresetCommandDec);
-
                                                 }
-
                                                 break;
                                             }
 
@@ -874,7 +834,6 @@
                                                 {
                                                     DCSBIOS.Send(UHF_PRESET_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -884,7 +843,6 @@
                                                 {
                                                     DCSBIOS.Send(_lowerFreqSwitchPressedDown ? TACANXY_SELECT_COMMAND_DEC : TACAN_TENS_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -894,7 +852,6 @@
                                                 {
                                                     DCSBIOS.Send(_lowerFreqSwitchPressedDown ? VOR_POWER_COMMAND_DEC : VOR_DECIMALS_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -919,7 +876,6 @@
                                         case CurrentM2000CRadioMode.VUHF:
                                             {
                                                 DCSBIOS.Send(VHFVolumeCommandInc);
-
                                                 break;
                                             }
 
@@ -929,7 +885,6 @@
                                                 {
                                                     DCSBIOS.Send(_lowerFreqSwitchPressedDown ? TACAN_MODE_SELECT_COMMAND_INC : TACAN_ONES_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -939,7 +894,6 @@
                                                 {
                                                     DCSBIOS.Send(_lowerFreqSwitchPressedDown ? VOR_TEST_COMMAND_INC : VOR_ONES_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -963,9 +917,7 @@
 
                                         case CurrentM2000CRadioMode.VUHF:
                                             {
-
                                                 DCSBIOS.Send(VHFVolumeCommandDec);
-
                                                 break;
                                             }
 
@@ -975,7 +927,6 @@
                                                 {
                                                     DCSBIOS.Send(_lowerFreqSwitchPressedDown ? TACAN_MODE_SELECT_COMMAND_DEC : TACAN_ONES_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -985,7 +936,6 @@
                                                 {
                                                     DCSBIOS.Send(_lowerFreqSwitchPressedDown ? VOR_TEST_COMMAND_DEC : VOR_ONES_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -1021,7 +971,6 @@
 
                     if (!FirstReportHasBeenRead)
                     {
-
                         return;
                     }
 
@@ -1051,7 +1000,6 @@
                                         SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.UPPER_STBY_RIGHT);
                                     }
                                 }
-
                                 break;
                             }
 
@@ -1076,7 +1024,6 @@
                                         SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.UPPER_STBY_RIGHT);
                                     }
                                 }
-
                                 break;
                             }
 
@@ -1099,7 +1046,7 @@
                             {
                                 var channelAsString = string.Empty;
                                 var settingsAsString = string.Empty;
-                                lock (_lockTACANDialObject)
+                                lock (_lockVoRialObject)
                                 {
                                     var ones = _vorOnesCockpitDialPos + 8;
                                     var decimals = _vorDecimalsCockpitDialPos * 5;
@@ -1142,7 +1089,6 @@
                                         SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.LOWER_STBY_RIGHT);
                                     }
                                 }
-
                                 break;
                             }
 
@@ -1167,7 +1113,6 @@
                                         SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.LOWER_STBY_RIGHT);
                                     }
                                 }
-
                                 break;
                             }
 
@@ -1190,7 +1135,7 @@
                             {
                                 var channelAsString = string.Empty;
                                 var settingsAsString = string.Empty;
-                                lock (_lockTACANDialObject)
+                                lock (_lockVoRialObject)
                                 {
                                     var ones = _vorOnesCockpitDialPos + 8;
                                     var decimals = _vorDecimalsCockpitDialPos * 5;
@@ -1220,7 +1165,6 @@
 
             Interlocked.Decrement(ref _doUpdatePanelLCD);
         }
-
 
         protected override void GamingPanelKnobChanged(bool isFirstReport, IEnumerable<object> hashSet)
         {
@@ -1308,7 +1252,6 @@
             }
         }
 
-
         private bool SkipVUHFPresetDialChange()
         {
             try
@@ -1320,7 +1263,6 @@
                         _vhfPresetDialSkipper = 0;
                         return false;
                     }
-
                     _vhfPresetDialSkipper++;
                     return true;
                 }
@@ -1329,7 +1271,6 @@
             {
                 logger.Error(ex);
             }
-
             return false;
         }
 
@@ -1344,7 +1285,6 @@
                         _uhfPresetDialSkipper = 0;
                         return false;
                     }
-
                     _uhfPresetDialSkipper++;
                     return true;
                 }
@@ -1353,7 +1293,6 @@
             {
                 logger.Error(ex);
             }
-
             return false;
         }
 
@@ -1368,7 +1307,6 @@
                         _tacanDialSkipper = 0;
                         return false;
                     }
-
                     _tacanDialSkipper++;
                     return true;
                 }
@@ -1377,7 +1315,6 @@
             {
                 logger.Error(ex);
             }
-
             return false;
         }
 
@@ -1392,7 +1329,6 @@
                         _vorDialSkipper = 0;
                         return false;
                     }
-
                     _vorDialSkipper++;
                     return true;
                 }
@@ -1401,7 +1337,6 @@
             {
                 logger.Error(ex);
             }
-
             return false;
         }
 
@@ -1428,6 +1363,5 @@
         public override void AddOrUpdateOSCommandBinding(PanelSwitchOnOff panelSwitchOnOff, OSCommand operatingSystemCommand)
         {
         }
-
     }
 }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Mi8.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Mi8.cs
@@ -122,6 +122,7 @@
         private long _yadro1ADial2WaitingForFeedback;
         private long _yadro1ADial3WaitingForFeedback;
         private long _yadro1ADial4WaitingForFeedback;
+        private volatile bool _shutdownYaDRO1AThread;
 
         /*
          * Mi-8 R-828 FM Radio PRESETS NAV2
@@ -683,11 +684,9 @@
                                         {
                                             DCSBIOS.Send(SPU7_ICS_SWITCH_TOGGLE_COMMAND);
                                         }
-
                                         break;
                                     }
                             }
-
                             break;
                         }
 
@@ -729,11 +728,9 @@
                                         {
                                             DCSBIOS.Send(SPU7_ICS_SWITCH_TOGGLE_COMMAND);
                                         }
-
                                         break;
                                     }
                             }
-
                             break;
                         }
                 }
@@ -777,8 +774,8 @@
                     try
                     {
                         /*
-                                          * Mi-8 R-863 COM1
-                                          */
+                        * Mi-8 R-863 COM1
+                        */
                         Interlocked.Exchange(ref _r863ManualThreadNowSynching, 1);
                         long dial1Timeout = DateTime.Now.Ticks;
                         long dial2Timeout = DateTime.Now.Ticks;
@@ -867,15 +864,15 @@
                                               + GetCommandDirectionForR863ManualDial1(desiredPositionDial1X, _r863ManualCockpitFreq1DialPos);// + "DEC\n"; // TODO is this still a problem? 30.7.2018 Went into loop GetCommandDirectionForR863ManualDial1(desiredPositionDial1X, _r863ManualCockpitFreq1DialPos);
 
                                         /*
-                                                                                    25.7.2018
-                                                                                    10	0.22999967634678
-                                                                                    39	0.21999971568584
+                                        25.7.2018
+                                        10	0.22999967634678
+                                        39	0.21999971568584
                                         
-                                                                                    10Mhz  Rotary Knob (Mi-8MT/R863_FREQ1)
-                                                                                    Changing the dial (in cockpit) 39 => 10 does not show in DCS-BIOS in the CTRL-Ref page. But going down from 10 => 39 is OK.
-                                                                                    I have gotten the values above from DCS using the Lua console so I can see that they do actually change but there is something not working in DCS-BIOS
-                                                                                    So only go down with it
-                                                                                 */
+                                        10Mhz  Rotary Knob (Mi-8MT/R863_FREQ1)
+                                        Changing the dial (in cockpit) 39 => 10 does not show in DCS-BIOS in the CTRL-Ref page. But going down from 10 => 39 is OK.
+                                        I have gotten the values above from DCS using the Lua console so I can see that they do actually change but there is something not working in DCS-BIOS
+                                        So only go down with it
+                                        */
                                         DCSBIOS.Send(str);
                                         dial1SendCount++;
                                         Interlocked.Exchange(ref _r863ManualDial1WaitingForFeedback, 1);
@@ -901,7 +898,6 @@
                                         dial2SendCount++;
                                         Interlocked.Exchange(ref _r863ManualDial2WaitingForFeedback, 1);
                                     }
-
                                     Reset(ref dial2Timeout);
                                 }
                             }
@@ -922,7 +918,6 @@
                                         dial3SendCount++;
                                         Interlocked.Exchange(ref _r863ManualDial3WaitingForFeedback, 1);
                                     }
-
                                     Reset(ref dial3Timeout);
                                 }
                             }
@@ -951,7 +946,6 @@
                                         dial4SendCount++;
                                         Interlocked.Exchange(ref _r863ManualDial4WaitingForFeedback, 1);
                                     }
-
                                     Reset(ref dial4Timeout);
                                 }
                             }
@@ -1041,7 +1035,6 @@
             }
         }
 
-        private volatile bool _shutdownYaDRO1AThread;
         private void YaDRO1ASynchThreadMethod()
         {
             try
@@ -1140,7 +1133,6 @@
                                         DCSBIOS.Send(str);
                                         Interlocked.Exchange(ref _yadro1ADial1WaitingForFeedback, 1);
                                     }
-
                                     Reset(ref dial1Timeout);
                                 }
                             }
@@ -1160,7 +1152,6 @@
                                         DCSBIOS.Send(str);
                                         Interlocked.Exchange(ref _yadro1ADial2WaitingForFeedback, 1);
                                     }
-
                                     Reset(ref dial2Timeout);
                                 }
                             }
@@ -1180,7 +1171,6 @@
                                         DCSBIOS.Send(str);
                                         Interlocked.Exchange(ref _yadro1ADial3WaitingForFeedback, 1);
                                     }
-
                                     Reset(ref dial3Timeout);
                                 }
                             }
@@ -1200,7 +1190,6 @@
                                         DCSBIOS.Send(str);
                                         Interlocked.Exchange(ref _yadro1ADial4WaitingForFeedback, 1);
                                     }
-
                                     Reset(ref dial4Timeout);
                                 }
                             }
@@ -1275,7 +1264,6 @@
                                     {
                                         SetUpperRadioMode(CurrentMi8RadioMode.R863_MANUAL);
                                     }
-
                                     break;
                                 }
 
@@ -1285,7 +1273,6 @@
                                     {
                                         SetUpperRadioMode(CurrentMi8RadioMode.R863_PRESET);
                                     }
-
                                     break;
                                 }
 
@@ -1295,7 +1282,6 @@
                                     {
                                         SetUpperRadioMode(CurrentMi8RadioMode.YADRO1A);
                                     }
-
                                     break;
                                 }
 
@@ -1305,7 +1291,6 @@
                                     {
                                         SetUpperRadioMode(CurrentMi8RadioMode.R828_PRESETS);
                                     }
-
                                     break;
                                 }
 
@@ -1315,7 +1300,6 @@
                                     {
                                         SetUpperRadioMode(CurrentMi8RadioMode.ADF_ARK9);
                                     }
-
                                     break;
                                 }
 
@@ -1325,7 +1309,6 @@
                                     {
                                         SetUpperRadioMode(CurrentMi8RadioMode.SPU7);
                                     }
-
                                     break;
                                 }
 
@@ -1335,7 +1318,6 @@
                                     {
                                         SetLowerRadioMode(CurrentMi8RadioMode.R863_MANUAL);
                                     }
-
                                     break;
                                 }
 
@@ -1345,7 +1327,6 @@
                                     {
                                         SetLowerRadioMode(CurrentMi8RadioMode.R863_PRESET);
                                     }
-
                                     break;
                                 }
 
@@ -1355,7 +1336,6 @@
                                     {
                                         SetLowerRadioMode(CurrentMi8RadioMode.YADRO1A);
                                     }
-
                                     break;
                                 }
 
@@ -1365,7 +1345,6 @@
                                     {
                                         SetLowerRadioMode(CurrentMi8RadioMode.R828_PRESETS);
                                     }
-
                                     break;
                                 }
 
@@ -1375,7 +1354,6 @@
                                     {
                                         SetLowerRadioMode(CurrentMi8RadioMode.ADF_ARK9);
                                     }
-
                                     break;
                                 }
 
@@ -1385,7 +1363,6 @@
                                     {
                                         SetLowerRadioMode(CurrentMi8RadioMode.SPU7);
                                     }
-
                                     break;
                                 }
 
@@ -1395,7 +1372,6 @@
                                     {
                                         SetUpperRadioMode(CurrentMi8RadioMode.ARK_UD);
                                     }
-
                                     break;
                                 }
 
@@ -1405,7 +1381,6 @@
                                     {
                                         SetLowerRadioMode(CurrentMi8RadioMode.ARK_UD);
                                     }
-
                                     break;
                                 }
 
@@ -1443,7 +1418,6 @@
                                     {
                                         SendFrequencyToDCSBIOS(radioPanelKnob.IsOn, RadioPanelPZ69KnobsMi8.UPPER_FREQ_SWITCH);
                                     }
-
                                     break;
                                 }
 
@@ -1468,7 +1442,6 @@
                                     {
                                         SendFrequencyToDCSBIOS(radioPanelKnob.IsOn, RadioPanelPZ69KnobsMi8.LOWER_FREQ_SWITCH);
                                     }
-
                                     break;
                                 }
                         }
@@ -1484,7 +1457,6 @@
                                 null);
                         }
                     }
-
                     AdjustFrequency(hashSet);
                 }
             }
@@ -1543,7 +1515,6 @@
                                                 {
                                                     _r863ManualBigFrequencyStandby = 100;
                                                 }
-
                                                 break;
                                             }
 
@@ -1553,7 +1524,6 @@
                                                 {
                                                     DCSBIOS.Send(R863_PRESET_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -1581,7 +1551,6 @@
                                                 {
                                                     _yadro1ABigFrequencyStandby = 20;
                                                 }
-                                                
                                                 break;
                                             }
 
@@ -1591,7 +1560,6 @@
                                                 {
                                                     DCSBIOS.Send(R828_PRESET_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -1601,7 +1569,6 @@
                                                 {
                                                     DCSBIOS.Send(_adfBackupMainCockpitDial1Pos == 1 ? ADF_MAIN100_KHZ_PRESET_COMMAND_INC : ADF_BACKUP100_KHZ_PRESET_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -1611,7 +1578,6 @@
                                                 {
                                                     DCSBIOS.Send(ARKUD_PRESET_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -1621,7 +1587,6 @@
                                                 {
                                                     DCSBIOS.Send(SPU7_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -1630,7 +1595,6 @@
                                                 break;
                                             }
                                     }
-
                                     break;
                                 }
 
@@ -1667,7 +1631,6 @@
                                                 {
                                                     _r863ManualBigFrequencyStandby = 399;
                                                 }
-                                                
                                                 break;
                                             }
 
@@ -1677,7 +1640,6 @@
                                                 {
                                                     DCSBIOS.Send(R863_PRESET_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -1705,7 +1667,6 @@
                                                 {
                                                     _yadro1ABigFrequencyStandby = 179;
                                                 }
-
                                                 break;
                                             }
 
@@ -1715,7 +1676,6 @@
                                                 {
                                                     DCSBIOS.Send(R828_PRESET_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -1725,7 +1685,6 @@
                                                 {
                                                     DCSBIOS.Send(_adfBackupMainCockpitDial1Pos == 1 ? ADF_MAIN100_KHZ_PRESET_COMMAND_DEC : ADF_BACKUP100_KHZ_PRESET_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -1735,7 +1694,6 @@
                                                 {
                                                     DCSBIOS.Send(ARKUD_PRESET_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -1745,7 +1703,6 @@
                                                 {
                                                     DCSBIOS.Send(SPU7_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -1754,7 +1711,6 @@
                                                 break;
                                             }
                                     }
-
                                     break;
                                 }
 
@@ -1806,7 +1762,6 @@
                                                 {
                                                     DCSBIOS.Send(_adfBackupMainCockpitDial1Pos == 1 ? ADF_MAIN10_KHZ_PRESET_COMMAND_INC : ADF_BACKUP10_KHZ_PRESET_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -1816,7 +1771,6 @@
                                                 {
                                                     DCSBIOS.Send(ARKUD_MODE_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -1831,7 +1785,6 @@
                                                 break;
                                             }
                                     }
-
                                     break;
                                 }
 
@@ -1847,7 +1800,6 @@
                                                     _r863ManualSmallFrequencyStandby = 975;
                                                     break;
                                                 }
-
                                                 _r863ManualSmallFrequencyStandby -= 25;
                                                 break;
                                             }
@@ -1866,7 +1818,6 @@
                                                     _yadro1ASmallFrequencyStandby = 99;
                                                     break;
                                                 }
-
                                                 _yadro1ASmallFrequencyStandby--;
                                                 break;
                                             }
@@ -1883,7 +1834,6 @@
                                                 {
                                                     DCSBIOS.Send(_adfBackupMainCockpitDial1Pos == 1 ? ADF_MAIN10_KHZ_PRESET_COMMAND_DEC : ADF_BACKUP10_KHZ_PRESET_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -1893,7 +1843,6 @@
                                                 {
                                                     DCSBIOS.Send(ARKUD_MODE_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -1908,7 +1857,6 @@
                                                 break;
                                             }
                                     }
-
                                     break;
                                 }
 
@@ -1945,7 +1893,6 @@
                                                 {
                                                     _r863ManualBigFrequencyStandby = 100;
                                                 }
-
                                                 break;
                                             }
 
@@ -1955,7 +1902,6 @@
                                                 {
                                                     DCSBIOS.Send(R863_PRESET_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -1983,7 +1929,6 @@
                                                 {
                                                     _yadro1ABigFrequencyStandby = 20;
                                                 }
-
                                                 break;
                                             }
 
@@ -1993,7 +1938,6 @@
                                                 {
                                                     DCSBIOS.Send(R828_PRESET_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -2003,7 +1947,6 @@
                                                 {
                                                     DCSBIOS.Send(_adfBackupMainCockpitDial1Pos == 1 ? ADF_MAIN100_KHZ_PRESET_COMMAND_INC : ADF_BACKUP100_KHZ_PRESET_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -2013,7 +1956,6 @@
                                                 {
                                                     DCSBIOS.Send(ARKUD_PRESET_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -2023,7 +1965,6 @@
                                                 {
                                                     DCSBIOS.Send(SPU7_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -2032,7 +1973,6 @@
                                                 break;
                                             }
                                     }
-
                                     break;
                                 }
 
@@ -2069,7 +2009,6 @@
                                                 {
                                                     _r863ManualBigFrequencyStandby = 399;
                                                 }
-
                                                 break;
                                             }
 
@@ -2079,7 +2018,6 @@
                                                 {
                                                     DCSBIOS.Send(R863_PRESET_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -2107,7 +2045,6 @@
                                                 {
                                                     _yadro1ABigFrequencyStandby = 179;
                                                 }
-
                                                 break;
                                             }
 
@@ -2117,7 +2054,6 @@
                                                 {
                                                     DCSBIOS.Send(R828_PRESET_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -2127,7 +2063,6 @@
                                                 {
                                                     DCSBIOS.Send(_adfBackupMainCockpitDial1Pos == 1 ? ADF_MAIN100_KHZ_PRESET_COMMAND_DEC : ADF_BACKUP100_KHZ_PRESET_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -2137,7 +2072,6 @@
                                                 {
                                                     DCSBIOS.Send(ARKUD_PRESET_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -2147,7 +2081,6 @@
                                                 {
                                                     DCSBIOS.Send(SPU7_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -2156,7 +2089,6 @@
                                                 break;
                                             }
                                     }
-
                                     break;
                                 }
 
@@ -2208,7 +2140,6 @@
                                                 {
                                                     DCSBIOS.Send(_adfBackupMainCockpitDial1Pos == 1 ? ADF_MAIN10_KHZ_PRESET_COMMAND_INC : ADF_BACKUP10_KHZ_PRESET_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -2218,7 +2149,6 @@
                                                 {
                                                     DCSBIOS.Send(ARKUD_MODE_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -2233,7 +2163,6 @@
                                                 break;
                                             }
                                     }
-
                                     break;
                                 }
 
@@ -2249,7 +2178,6 @@
                                                     _r863ManualSmallFrequencyStandby = 975;
                                                     break;
                                                 }
-                                                
                                                 _r863ManualSmallFrequencyStandby -= 25;
                                                 break;
                                             }
@@ -2268,7 +2196,6 @@
                                                     _yadro1ASmallFrequencyStandby = 99;
                                                     break;
                                                 }
-
                                                 _yadro1ASmallFrequencyStandby -= 1;
                                                 break;
                                             }
@@ -2285,7 +2212,6 @@
                                                 {
                                                     DCSBIOS.Send(_adfBackupMainCockpitDial1Pos == 1 ? ADF_MAIN10_KHZ_PRESET_COMMAND_DEC : ADF_BACKUP10_KHZ_PRESET_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -2295,7 +2221,6 @@
                                                 {
                                                     DCSBIOS.Send(ARKUD_MODE_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
 
@@ -2310,13 +2235,11 @@
                                                 break;
                                             }
                                     }
-
                                     break;
                                 }
                         }
                     }
                 }
-
                 ShowFrequenciesOnPanel(true);
             }
             catch (Exception ex)
@@ -2459,7 +2382,6 @@
                                         }
                                     }
                                 }
-
                                 break;
                             }
 
@@ -2658,7 +2580,6 @@
                                         }
                                     }
                                 }
-
                                 break;
                             }
 
@@ -2847,7 +2768,7 @@
 
         public override DcsOutputAndColorBinding CreateDcsOutputAndColorBinding(SaitekPanelLEDPosition saitekPanelLEDPosition, PanelLEDColor panelLEDColor, DCSBIOSOutput dcsBiosOutput)
         {
-            var dcsOutputAndColorBinding = new DcsOutputAndColorBindingPZ55
+            DcsOutputAndColorBindingPZ55 dcsOutputAndColorBinding = new() 
             {
                 DCSBiosOutputLED = dcsBiosOutput,
                 LEDColor = panelLEDColor,
@@ -3045,14 +2966,12 @@
                 {
                     return inc;
                 }
-
                 return dec;
             }
             catch (Exception ex)
             {
                 logger.Error(ex);
             }
-
             return inc;
         }
 
@@ -3075,7 +2994,6 @@
                     {
                         tmpActualDialPositionUp++;
                     }
-
                     upCount++;
                 }
                 while (tmpActualDialPositionUp != desiredDialPosition);
@@ -3092,7 +3010,6 @@
                     {
                         tmpActualDialPositionUp--;
                     }
-
                     downCount++;
                 }
                 while (tmpActualDialPositionUp != desiredDialPosition);
@@ -3101,7 +3018,6 @@
                 {
                     return inc;
                 }
-
                 return dec;
             }
             catch (Exception ex)
@@ -3110,7 +3026,7 @@
             }
 
             throw new Exception(
-                "Should not reach this code. private String GetCommandDirectionFor0To9Dials(uint desiredDialPosition, uint actualDialPosition) -> " + desiredDialPosition + "   " + actualDialPosition);
+                $"Should not reach this code. private String GetCommandDirectionFor0To9Dials(uint desiredDialPosition, uint actualDialPosition) -> {desiredDialPosition}   {actualDialPosition}");
         }
 
         /*
@@ -3173,7 +3089,6 @@
             {
                 logger.Error(ex);
             }
-
             return false;
         }
 
@@ -3197,7 +3112,6 @@
             {
                 logger.Error(ex);
             }
-
             return false;
         }
 
@@ -3221,7 +3135,6 @@
             {
                 logger.Error(ex);
             }
-
             return false;
         }
 
@@ -3245,7 +3158,6 @@
             {
                 logger.Error(ex);
             }
-
             return false;
         }
 
@@ -3269,7 +3181,6 @@
             {
                 logger.Error(ex);
             }
-
             return false;
         }
 
@@ -3293,7 +3204,6 @@
             {
                 logger.Error(ex);
             }
-
             return false;
         }
 
@@ -3317,7 +3227,6 @@
             {
                 logger.Error(ex);
             }
-
             return false;
         }
 

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Mi8.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Mi8.cs
@@ -40,58 +40,34 @@
          * Small dial 0 - 95
          */
         private readonly ClickSpeedDetector _bigFreqIncreaseChangeMonitor = new ClickSpeedDetector(20);
-
         private readonly ClickSpeedDetector _bigFreqDecreaseChangeMonitor = new ClickSpeedDetector(20);
-
         private const int CHANGE_VALUE = 10;
 
         // private int[] _r863ManualFreq1DialValues = { 10, 11, 12, 13, 14, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39 };
         private uint _r863ManualBigFrequencyStandby = 108;
-
         private uint _r863ManualSmallFrequencyStandby;
 
         private volatile uint _r863ManualSavedCockpitBigFrequency;
-
         private volatile uint _r863ManualSavedCockpitSmallFrequency;
-
-        private readonly object _lockR863ManualDialsObject1 = new object();
-
-        private readonly object _lockR863ManualDialsObject2 = new object();
-
-        private readonly object _lockR863ManualDialsObject3 = new object();
-
-        private readonly object _lockR863ManualDialsObject4 = new object();
-
+        private readonly object _lockR863ManualDialsObject1 = new();
+        private readonly object _lockR863ManualDialsObject2 = new();
+        private readonly object _lockR863ManualDialsObject3 = new();
+        private readonly object _lockR863ManualDialsObject4 = new();
         private volatile uint _r863ManualCockpitFreq1DialPos = 1;
-
         private volatile uint _r863ManualCockpitFreq2DialPos = 1;
-
         private volatile uint _r863ManualCockpitFreq3DialPos = 1;
-
         private volatile uint _r863ManualCockpitFreq4DialPos;
-
         private double _r863ManualCockpitFrequency = 100.000;
-
         private DCSBIOSOutput _r863ManualDcsbiosOutputCockpitFrequency;
-
         private const string R863_MANUAL_FREQ_1DIAL_COMMAND = "R863_FREQ1 ";
-
         private const string R863_MANUAL_FREQ_2DIAL_COMMAND = "R863_FREQ2 ";
-
         private const string R863_MANUAL_FREQ_3DIAL_COMMAND = "R863_FREQ3 ";
-
         private const string R863_MANUAL_FREQ_4DIAL_COMMAND = "R863_FREQ4 ";
-
         private Thread _r863ManualSyncThread;
-
         private long _r863ManualThreadNowSynching;
-
         private long _r863ManualDial1WaitingForFeedback;
-
         private long _r863ManualDial2WaitingForFeedback;
-
         private long _r863ManualDial3WaitingForFeedback;
-
         private long _r863ManualDial4WaitingForFeedback;
 
         /*
@@ -100,28 +76,19 @@
          * Small dial volume control
          * ACT/STBY Unit Switch, DIAL/MEMORY
          */
-        private readonly object _lockR863Preset1DialObject1 = new object();
-
+        private readonly object _lockR863Preset1DialObject1 = new();
         private DCSBIOSOutput _r863Preset1DcsbiosOutputPresetDial;
-
         private volatile uint _r863PresetCockpitDialPos = 1;
-
         private const string R863_PRESET_COMMAND_INC = "R863_CNL_SEL INC\n";
-
         private const string R863_PRESET_COMMAND_DEC = "R863_CNL_SEL DEC\n";
 
         // private int _r863PresetDialSkipper;
 
         private const string R863_PRESET_VOLUME_KNOB_COMMAND_INC = "R863_VOL +2500\n";
-
         private const string R863_PRESET_VOLUME_KNOB_COMMAND_DEC = "R863_VOL -2500\n";
-
-        private readonly object _lockR863UnitSwitchObject = new object();
-
+        private readonly object _lockR863UnitSwitchObject = new();
         private DCSBIOSOutput _r863UnitSwitchDcsbiosOutput;
-
         private volatile uint _r863UnitSwitchCockpitPos = 1;
-
         private const string R863_UNIT_SWITCH_COMMAND_TOGGLE = "R863_UNIT_SWITCH TOGGLE\n";
 
         /*
@@ -130,55 +97,30 @@
          * Small dial 0 - 99
          */
         private readonly ClickSpeedDetector _yadro1ABigFreqIncreaseChangeMonitor = new ClickSpeedDetector(20);
-
         private readonly ClickSpeedDetector _yadro1ABigFreqDecreaseChangeMonitor = new ClickSpeedDetector(20);
-
         private uint _yadro1ABigFrequencyStandby = 100;
-
         private uint _yadro1ASmallFrequencyStandby;
-
         private volatile uint _yadro1ASavedCockpitBigFrequency;
-
         private volatile uint _yadro1ASavedCockpitSmallFrequency;
-
-        private readonly object _lockYadro1ADialsObject1 = new object();
-
-        private readonly object _lockYadro1ADialsObject2 = new object();
-
-        private readonly object _lockYadro1ADialsObject3 = new object();
-
-        private readonly object _lockYadro1ADialsObject4 = new object();
-
+        private readonly object _lockYadro1ADialsObject1 = new();
+        private readonly object _lockYadro1ADialsObject2 = new();
+        private readonly object _lockYadro1ADialsObject3 = new();
+        private readonly object _lockYadro1ADialsObject4 = new();
         private volatile uint _yadro1ACockpitFreq1DialPos = 1;
-
         private volatile uint _yadro1ACockpitFreq2DialPos = 1;
-
         private volatile uint _yadro1ACockpitFreq3DialPos = 1;
-
         private volatile uint _yadro1ACockpitFreq4DialPos = 1;
-
         private double _yadro1ACockpitFrequency = 100;
-
         private DCSBIOSOutput _yadro1ADcsbiosOutputCockpitFrequency;
-
         private const string YADRO1_A_FREQ_1DIAL_COMMAND = "YADRO1A_FREQ1 ";
-
         private const string YADRO1_A_FREQ_2DIAL_COMMAND = "YADRO1A_FREQ2 ";
-
         private const string YADRO1_A_FREQ_3DIAL_COMMAND = "YADRO1A_FREQ3 ";
-
         private const string YADRO1_A_FREQ_4DIAL_COMMAND = "YADRO1A_FREQ4 ";
-
         private Thread _yadro1ASyncThread;
-
         private long _yadro1AThreadNowSynching;
-
         private long _yadro1ADial1WaitingForFeedback;
-
         private long _yadro1ADial2WaitingForFeedback;
-
         private long _yadro1ADial3WaitingForFeedback;
-
         private long _yadro1ADial4WaitingForFeedback;
 
         /*
@@ -187,24 +129,16 @@
          * Small dial volume control
          * ACT/STBY AGC, automatic gain control
          */
-        private readonly object _lockR828Preset1DialObject1 = new object();
-
+        private readonly object _lockR828Preset1DialObject1 = new();
         private DCSBIOSOutput _r828Preset1DcsbiosOutputDial;
-
         private volatile uint _r828PresetCockpitDialPos = 1;
-
         private const string R828_PRESET_COMMAND_INC = "R828_PRST_CHAN_SEL INC\n";
-
         private const string R828_PRESET_COMMAND_DEC = "R828_PRST_CHAN_SEL DEC\n";
-
         // private int _r828PresetDialSkipper;
 
         private const string R828_PRESET_VOLUME_KNOB_COMMAND_INC = "R828_VOL +2500\n";
-
         private const string R828_PRESET_VOLUME_KNOB_COMMAND_DEC = "R828_VOL -2500\n";
-
         private const string R828_GAIN_CONTROL_COMMAND_ON = "R828_TUNER INC\n";
-
         private const string R828_GAIN_CONTROL_COMMAND_OFF = "R828_TUNER DEC\n";
 
         /*
@@ -212,95 +146,62 @@
          * Large 100KHz 01 -> 12
          * Small 10Khz 00 -> 90 (10 steps)
          */
-        private readonly object _lockADFMainDialObject1 = new object();
-
-        private readonly object _lockADFMainDialObject2 = new object();
-
+        private readonly object _lockADFMainDialObject1 = new();
+        private readonly object _lockADFMainDialObject2 = new();
         private DCSBIOSOutput _adfMainDcsbiosOutputPresetDial1;
-
         private DCSBIOSOutput _adfMainDcsbiosOutputPresetDial2;
-
         private volatile uint _adfMainCockpitPresetDial1Pos = 1;
-
         private volatile uint _adfMainCockpitPresetDial2Pos = 1;
-
         private const string ADF_MAIN100_KHZ_PRESET_COMMAND_INC = "ARC_MAIN_100KHZ INC\n";
-
         private const string ADF_MAIN100_KHZ_PRESET_COMMAND_DEC = "ARC_MAIN_100KHZ DEC\n";
-
         private const string ADF_MAIN10_KHZ_PRESET_COMMAND_INC = "ARC_MAIN_10KHZ INC\n";
-
         private const string ADF_MAIN10_KHZ_PRESET_COMMAND_DEC = "ARC_MAIN_10KHZ DEC\n";
 
         /*
          *  ADF BACKUP
          */
-        private readonly object _lockADFBackupDialObject1 = new object();
-
-        private readonly object _lockADFBackupDialObject2 = new object();
-
+        private readonly object _lockADFBackupDialObject1 = new();
+        private readonly object _lockADFBackupDialObject2 = new();
         private DCSBIOSOutput _adfBackupDcsbiosOutputPresetDial1;
-
         private DCSBIOSOutput _adfBackupDcsbiosOutputPresetDial2;
-
         private volatile uint _adfBackupCockpitPresetDial1Pos = 1;
-
         private volatile uint _adfBackupCockpitPresetDial2Pos = 1;
-
         private const string ADF_BACKUP100_KHZ_PRESET_COMMAND_INC = "ARC_BCK_100KHZ INC\n";
-
         private const string ADF_BACKUP100_KHZ_PRESET_COMMAND_DEC = "ARC_BCK_100KHZ DEC\n";
-
         private const string ADF_BACKUP10_KHZ_PRESET_COMMAND_INC = "ARC_BCK_10KHZ INC\n";
-
         private const string ADF_BACKUP10_KHZ_PRESET_COMMAND_DEC = "ARC_BCK_10KHZ DEC\n";
 
         /*
          * 0 = Backup ADF
          * 1 = Main ADF
          */
-        private readonly object _lockADFBackupMainDialObject = new object();
-
+        private readonly object _lockADFBackupMainDialObject = new();
         private DCSBIOSOutput _adfBackupMainDcsbiosOutputPresetDial;
-
         private volatile uint _adfBackupMainCockpitDial1Pos;
-
         private const string ADF_BACKUP_MAIN_SWITCH_TOGGLE_COMMAND = "ARC9_MAIN_BACKUP TOGGLE\n";
 
         /*Mi-8 ARK-UD VHF Homing (DME)*/
         // Large Frequency 1-6
         // Small Mode
         // ACT/STBY   VHF/UHF
-        private readonly object _lockArkudPresetDialObject = new object();
-
+        private readonly object _lockArkudPresetDialObject = new();
         private DCSBIOSOutput _arkUdPresetDcsbiosOutputPresetDial;
-
         private volatile uint _arkUdPresetCockpitDial1Pos;
-
         private const string ARKUD_PRESET_COMMAND_INC = "ARCUD_CHL INC\n";
-
         private const string ARKUD_PRESET_COMMAND_DEC = "ARCUD_CHL DEC\n";
 
         // private int _arkUdPresetDialSkipper;
 
-        private readonly object _lockArkudModeDialObject = new object();
-
+        private readonly object _lockArkudModeDialObject = new();
         private DCSBIOSOutput _arkUdModeDcsbiosOutputDial;
-
         private volatile uint _arkUdModeCockpitDial1Pos;
-
         private const string ARKUD_MODE_COMMAND_INC = "ARCUD_MODE INC\n";
-
         private const string ARKUD_MODE_COMMAND_DEC = "ARCUD_MODE DEC\n";
 
         // private int _arkUdModeDialSkipper;
-
-        private readonly object _lockArkudVhfUhfModeDialObject = new object();
-
+        private readonly object _lockArkudVhfUhfModeDialObject = new();
         private DCSBIOSOutput _arkUdVhfUhfModeDcsbiosOutputDial;
-
         private volatile uint _arkUdVhfUhfModeCockpitDial1Pos;
-
         private const string ARKUD_VHF_UHF_MODE_COMMAND_TOGGLE = "ARCUD_WAVE TOGGLE\n";
 
         /* XPDR
@@ -309,34 +210,22 @@
            Small dial volume control
            ACT/STBY Toggle Radio/ICS Switch
         */
-        private readonly object _lockSpu7DialObject1 = new object();
-
+        private readonly object _lockSpu7DialObject1 = new();
         private DCSBIOSOutput _spu7DcsbiosOutputPresetDial;
-
         private volatile uint _spu7CockpitDialPos;
 
         // private int _spu7DialSkipper;
 
         private const string SPU7_COMMAND_INC = "RADIO_SEL_R INC\n";
-
         private const string SPU7_COMMAND_DEC = "RADIO_SEL_R DEC\n";
-
         private const string SPU7_VOLUME_KNOB_COMMAND_INC = "LST_VOL_KNOB_L +2500\n";
-
         private const string SPU7_VOLUME_KNOB_COMMAND_DEC = "LST_VOL_KNOB_L -2500\n";
-
-        private readonly object _lockSpu7ICSSwitchObject = new object();
-
+        private readonly object _lockSpu7ICSSwitchObject = new();
         private DCSBIOSOutput _spu7ICSSwitchDcsbiosOutput;
-
         private volatile uint _spu7ICSSwitchCockpitDialPos;
-
         private const string SPU7_ICS_SWITCH_TOGGLE_COMMAND = "SPU7_L_ICS TOGGLE\n";
-
-        private readonly object _lockShowFrequenciesOnPanelObject = new object();
-
+        private readonly object _lockShowFrequenciesOnPanelObject = new();
         private long _doUpdatePanelLCD;
-
         // private const int SKIP_CONSTANT = 0;
 
         public RadioPanelPZ69Mi8(HIDSkeleton hidSkeleton) : base(hidSkeleton)

--- a/Source/NonVisuals/Radios/RadioPanelPZ69MiG21Bis.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69MiG21Bis.cs
@@ -116,7 +116,6 @@ namespace NonVisuals.Radios
             // Radio
             if (e.Address == _radioDcsbiosOutputFreqSelectorPosition.Address)
             {
-
                 lock (_lockRadioFreqSelectorPositionObject)
                 {
                     var tmp = _radioFreqSelectorPositionCockpit;
@@ -132,7 +131,6 @@ namespace NonVisuals.Radios
             // RSBN Nav
             if (e.Address == _rsbnNavChannelCockpitOutput.Address)
             {
-
                 lock (_lockRsbnNavChannelObject)
                 {
                     var tmp = _rsbnNavChannelCockpit;
@@ -148,7 +146,6 @@ namespace NonVisuals.Radios
             // RSBN ILS
             if (e.Address == _rsbnILSChannelCockpitOutput.Address)
             {
-
                 lock (_lockRsbnilsChannelObject)
                 {
                     var tmp = _rsbnILSChannelCockpit;
@@ -164,7 +161,6 @@ namespace NonVisuals.Radios
             // ARC Sector
             if (e.Address == _arcSectorCockpitOutput.Address)
             {
-
                 lock (_lockARCSectorObject)
                 {
                     var tmp = _arcSectorCockpit;
@@ -180,7 +176,6 @@ namespace NonVisuals.Radios
             // ARC Preset
             if (e.Address == _arcPresetChannelCockpitOutput.Address)
             {
-
                 lock (_lockARCPresetChannelObject)
                 {
                     var tmp = _arcPresetChannelCockpit;
@@ -203,7 +198,6 @@ namespace NonVisuals.Radios
 
         private void SendFrequencyToDCSBIOS(RadioPanelPZ69KnobsMiG21Bis knob)
         {
-
             if (IgnoreSwitchButtonOnce() && (knob == RadioPanelPZ69KnobsMiG21Bis.UpperFreqSwitch || knob == RadioPanelPZ69KnobsMiG21Bis.LowerFreqSwitch))
             {
                 // Don't do anything on the very first button press as the panel sends ALL
@@ -298,7 +292,6 @@ namespace NonVisuals.Radios
                                 SetPZ69DisplayBytesUnsignedInteger(ref bytes, _radioFreqSelectorPositionCockpit, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
                                 SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.UPPER_STBY_RIGHT);
                             }
-
                             break;
                         }
 
@@ -313,7 +306,6 @@ namespace NonVisuals.Radios
                             {
                                 SetPZ69DisplayBytesUnsignedInteger(ref bytes, _rsbnILSChannelCockpit, PZ69LCDPosition.UPPER_STBY_RIGHT);
                             }
-
                             break;
                         }
 
@@ -328,7 +320,6 @@ namespace NonVisuals.Radios
                             {
                                 SetPZ69DisplayBytesUnsignedInteger(ref bytes, _arcPresetChannelCockpit, PZ69LCDPosition.UPPER_STBY_RIGHT);
                             }
-
                             break;
                         }
                 }
@@ -341,7 +332,6 @@ namespace NonVisuals.Radios
                                 SetPZ69DisplayBytesUnsignedInteger(ref bytes, _radioFreqSelectorPositionCockpit, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
                                 SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.LOWER_STBY_RIGHT);
                             }
-
                             break;
                         }
 
@@ -356,7 +346,6 @@ namespace NonVisuals.Radios
                             {
                                 SetPZ69DisplayBytesUnsignedInteger(ref bytes, _rsbnILSChannelCockpit, PZ69LCDPosition.LOWER_STBY_RIGHT);
                             }
-
                             break;
                         }
 
@@ -371,13 +360,11 @@ namespace NonVisuals.Radios
                             {
                                 SetPZ69DisplayBytesUnsignedInteger(ref bytes, _arcPresetChannelCockpit, PZ69LCDPosition.LOWER_STBY_RIGHT);
                             }
-
                             break;
                         }
                 }
                 SendLCDData(bytes);
             }
-
             Interlocked.Decrement(ref _doUpdatePanelLCD);
         }
 
@@ -624,7 +611,6 @@ namespace NonVisuals.Radios
                                 {
                                     _currentUpperRadioMode = CurrentMiG21BisRadioMode.Radio;
                                 }
-
                                 break;
                             }
 
@@ -634,7 +620,6 @@ namespace NonVisuals.Radios
                                 {
                                     _currentUpperRadioMode = CurrentMiG21BisRadioMode.RSBN;
                                 }
-
                                 break;
                             }
 
@@ -644,7 +629,6 @@ namespace NonVisuals.Radios
                                 {
                                     _currentUpperRadioMode = CurrentMiG21BisRadioMode.ARC;
                                 }
-
                                 break;
                             }
 
@@ -674,7 +658,6 @@ namespace NonVisuals.Radios
                                 {
                                     _currentLowerRadioMode = CurrentMiG21BisRadioMode.Radio;
                                 }
-
                                 break;
                             }
 
@@ -684,7 +667,6 @@ namespace NonVisuals.Radios
                                 {
                                     _currentLowerRadioMode = CurrentMiG21BisRadioMode.RSBN;
                                 }
-
                                 break;
                             }
 
@@ -694,7 +676,6 @@ namespace NonVisuals.Radios
                                 {
                                     _currentLowerRadioMode = CurrentMiG21BisRadioMode.ARC;
                                 }
-
                                 break;
                             }
 
@@ -764,7 +745,6 @@ namespace NonVisuals.Radios
                                 {
                                     SendFrequencyToDCSBIOS(RadioPanelPZ69KnobsMiG21Bis.UpperFreqSwitch);
                                 }
-
                                 break;
                             }
 
@@ -774,7 +754,6 @@ namespace NonVisuals.Radios
                                 {
                                     SendFrequencyToDCSBIOS(RadioPanelPZ69KnobsMiG21Bis.LowerFreqSwitch);
                                 }
-
                                 break;
                             }
                     }
@@ -784,7 +763,6 @@ namespace NonVisuals.Radios
                         PluginManager.DoEvent(DCSFPProfile.SelectedProfile.Description, HIDInstance, PluginGamingPanelEnum.PZ69RadioPanel_PreProg_MIG21BIS, (int)radioPanelKnob.RadioPanelPZ69Knob, radioPanelKnob.IsOn, null);
                     }
                 }
-
                 AdjustFrequency(hashSet);
             }
         }
@@ -818,7 +796,7 @@ namespace NonVisuals.Radios
 
         public override DcsOutputAndColorBinding CreateDcsOutputAndColorBinding(SaitekPanelLEDPosition saitekPanelLEDPosition, PanelLEDColor panelLEDColor, DCSBIOSOutput dcsBiosOutput)
         {
-            var dcsOutputAndColorBinding = new DcsOutputAndColorBindingPZ55
+            DcsOutputAndColorBindingPZ55 dcsOutputAndColorBinding = new()
             {
                 DCSBiosOutputLED = dcsBiosOutput,
                 LEDColor = panelLEDColor,
@@ -898,5 +876,4 @@ namespace NonVisuals.Radios
         {
         }
     }
-
 }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69MiG21Bis.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69MiG21Bis.cs
@@ -32,7 +32,7 @@ namespace NonVisuals.Radios
         // Small dial Radio volume RAD_VOL +/- 
         // STBY/ACT, radio on/off RAD_PWR TOGGLE
         private volatile uint _radioFreqSelectorPositionCockpit;
-        private readonly object _lockRadioFreqSelectorPositionObject = new object();
+        private readonly object _lockRadioFreqSelectorPositionObject = new();
         private DCSBIOSOutput _radioDcsbiosOutputFreqSelectorPosition;
         private const string RADIO_FREQ_SELECTOR_POSITION_COMMAND_INC = "RAD_CHAN INC\n";
         private const string RADIO_FREQ_SELECTOR_POSITION_COMMAND_DEC = "RAD_CHAN DEC\n";
@@ -45,10 +45,10 @@ namespace NonVisuals.Radios
         // Small dial RSBN ILS PRMG_CHAN
         // STBY/ACT, RSBN/ARC switch  RSBN_ARC_SEL
         private volatile uint _rsbnNavChannelCockpit = 1;
-        private readonly object _lockRsbnNavChannelObject = new object();
+        private readonly object _lockRsbnNavChannelObject = new();
         private DCSBIOSOutput _rsbnNavChannelCockpitOutput;
         private volatile uint _rsbnILSChannelCockpit = 1;
-        private readonly object _lockRsbnilsChannelObject = new object();
+        private readonly object _lockRsbnilsChannelObject = new();
         private DCSBIOSOutput _rsbnILSChannelCockpitOutput;
         private const string RSBN_NAV_CHANNEL_COMMAND_INC = "RSBN_CHAN INC\n";
         private const string RSBN_NAV_CHANNEL_COMMAND_DEC = "RSBN_CHAN DEC\n";
@@ -61,10 +61,10 @@ namespace NonVisuals.Radios
         // Small dial ARC Preset ARC_CHAN
         // STBY/ACT, RSBN/ARC switch  RSBN_ARC_SEL 1
         private volatile uint _arcSectorCockpit = 1;
-        private readonly object _lockARCSectorObject = new object();
+        private readonly object _lockARCSectorObject = new();
         private DCSBIOSOutput _arcSectorCockpitOutput;
         private volatile uint _arcPresetChannelCockpit = 1;
-        private readonly object _lockARCPresetChannelObject = new object();
+        private readonly object _lockARCPresetChannelObject = new();
         private DCSBIOSOutput _arcPresetChannelCockpitOutput;
         private const string ARC_SECTOR_COMMAND_INC = "ARC_ZONE INC\n";
         private const string ARC_SECTOR_COMMAND_DEC = "ARC_ZONE DEC\n";
@@ -72,7 +72,7 @@ namespace NonVisuals.Radios
         private const string ARC_PRESET_CHANNEL_COMMAND_DEC = "ARC_CHAN DEC\n";
         private const string SELECT_ARC_COMMAND = "RSBN_ARC_SEL DEC\n";
 
-        private readonly object _lockShowFrequenciesOnPanelObject = new object();
+        private readonly object _lockShowFrequenciesOnPanelObject = new();
         private long _doUpdatePanelLCD;
 
         public RadioPanelPZ69MiG21Bis(HIDSkeleton hidSkeleton) : base(hidSkeleton)

--- a/Source/NonVisuals/Radios/RadioPanelPZ69P51D.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69P51D.cs
@@ -74,12 +74,12 @@ namespace NonVisuals.Radios
                 UpdateCounter(e.Address, e.Data);
 
                 /*
-                                 * IMPORTANT INFORMATION REGARDING THE _*WaitingForFeedback variables
-                                 * Once a dial has been deemed to be "off" position and needs to be changed
-                                 * a change command is sent to DCS-BIOS.
-                                 * Only after a *change* has been acknowledged will the _*WaitingForFeedback be
-                                 * reset. Reading the dial's position with no change in value will not reset.
-                                 */
+                * IMPORTANT INFORMATION REGARDING THE _*WaitingForFeedback variables
+                * Once a dial has been deemed to be "off" position and needs to be changed
+                * a change command is sent to DCS-BIOS.
+                * Only after a *change* has been acknowledged will the _*WaitingForFeedback be
+                * reset. Reading the dial's position with no change in value will not reset.
+                */
 
                 // VHF On Off
                 if (e.Address == _vhf1DcsbiosOutputPresetButton0.Address)
@@ -210,7 +210,6 @@ namespace NonVisuals.Radios
                                     {
                                         SetUpperRadioMode(CurrentP51DRadioMode.VHF);
                                     }
-
                                     break;
                                 }
 
@@ -225,7 +224,6 @@ namespace NonVisuals.Radios
                                     {
                                         SetUpperRadioMode(CurrentP51DRadioMode.NOUSE);
                                     }
-
                                     break;
                                 }
 
@@ -235,7 +233,6 @@ namespace NonVisuals.Radios
                                     {
                                         SetLowerRadioMode(CurrentP51DRadioMode.VHF);
                                     }
-
                                     break;
                                 }
 
@@ -250,7 +247,6 @@ namespace NonVisuals.Radios
                                     {
                                         SetLowerRadioMode(CurrentP51DRadioMode.NOUSE);
                                     }
-
                                     break;
                                 }
 
@@ -276,7 +272,6 @@ namespace NonVisuals.Radios
 
                                         }
                                     }
-
                                     break;
                                 }
 
@@ -288,7 +283,6 @@ namespace NonVisuals.Radios
                                         {
                                         }
                                     }
-
                                     break;
                                 }
                         }
@@ -298,7 +292,6 @@ namespace NonVisuals.Radios
                             PluginManager.DoEvent(DCSFPProfile.SelectedProfile.Description, HIDInstance, PluginGamingPanelEnum.PZ69RadioPanel_PreProg_P51D, (int)radioPanelKnob.RadioPanelPZ69Knob, radioPanelKnob.IsOn, null);
                         }
                     }
-
                     AdjustFrequency(hashSet);
                 }
             }
@@ -335,7 +328,6 @@ namespace NonVisuals.Radios
                                                 {
                                                     SendIncVHFPresetCommand();
                                                 }
-
                                                 break;
                                             }
                                     }
@@ -352,7 +344,6 @@ namespace NonVisuals.Radios
                                                 {
                                                     SendDecVHFPresetCommand();
                                                 }
-
                                                 break;
                                             }
                                     }
@@ -395,7 +386,6 @@ namespace NonVisuals.Radios
                                                 {
                                                     SendIncVHFPresetCommand();
                                                 }
-
                                                 break;
                                             }
                                     }
@@ -412,7 +402,6 @@ namespace NonVisuals.Radios
                                                 {
                                                     SendDecVHFPresetCommand();
                                                 }
-
                                                 break;
                                             }
                                     }
@@ -456,7 +445,6 @@ namespace NonVisuals.Radios
             }
         }
 
-
         private bool SkipVhf1PresetDialChange()
         {
             try
@@ -468,7 +456,6 @@ namespace NonVisuals.Radios
                         _vhf1PresetDialSkipper = 0;
                         return false;
                     }
-
                     _vhf1PresetDialSkipper++;
                     return true;
                 }
@@ -731,7 +718,5 @@ namespace NonVisuals.Radios
         public override void AddOrUpdateOSCommandBinding(PanelSwitchOnOff panelSwitchOnOff, OSCommand operatingSystemCommand)
         {
         }
-
-
     }
 }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69P51D.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69P51D.cs
@@ -28,7 +28,7 @@ namespace NonVisuals.Radios
         /*P-51D VHF Presets 1-4*/
         // Large dial 1-4 [step of 1]
         // Small dial volume control
-        private readonly object _lockVhf1DialObject1 = new object();
+        private readonly object _lockVhf1DialObject1 = new();
         private DCSBIOSOutput _vhf1DcsbiosOutputPresetButton0;
         private DCSBIOSOutput _vhf1DcsbiosOutputPresetButton1;
         private DCSBIOSOutput _vhf1DcsbiosOutputPresetButton2;
@@ -39,7 +39,7 @@ namespace NonVisuals.Radios
         private const string VHF1_VOLUME_KNOB_COMMAND_INC = "RADIO_VOLUME +2000\n";
         private const string VHF1_VOLUME_KNOB_COMMAND_DEC = "RADIO_VOLUME -2000\n";
 
-        private readonly object _lockShowFrequenciesOnPanelObject = new object();
+        private readonly object _lockShowFrequenciesOnPanelObject = new();
         private long _doUpdatePanelLCD;
 
         public RadioPanelPZ69P51D(HIDSkeleton hidSkeleton) : base(hidSkeleton)

--- a/Source/NonVisuals/Radios/RadioPanelPZ69SA342.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69SA342.cs
@@ -82,6 +82,7 @@
         private long _vhfAmValue4WaitingForFeedback; // Decimal 100s
         private int _vhfAmLeftDialSkipper;
         private int _vhfAmRightDialSkipper;
+        private volatile bool _shutdownVHFAMThread;
 
         /*COM2 SA342 FM PR4G Radio*/
         // Large dial 0-7 Presets 1, 2, 3, 4, 5, 6, 0, RG
@@ -427,7 +428,6 @@
                                     break;
                                 }
                         }
-
                         break;
                     }
             }
@@ -460,7 +460,6 @@
             _vhfAmSyncThread.Start();
         }
 
-        private volatile bool _shutdownVHFAMThread;
         private void VhfAmSynchThreadMethod(int desiredPositionDialWholeNumbers, int desiredPositionDialDecimals)
         {
             try
@@ -468,9 +467,9 @@
                 try
                 {
                     /*
-                                      * COM1 VHF AM
-                                      * 
-                                      */
+                    * COM1 VHF AM
+                    * 
+                    */
                     Interlocked.Exchange(ref _vhfAmThreadNowSynching, 1);
                     long dial1Timeout = DateTime.Now.Ticks;
                     long dial2Timeout = DateTime.Now.Ticks;
@@ -585,7 +584,6 @@
             {
                 Interlocked.Exchange(ref _vhfAmThreadNowSynching, 0);
             }
-
             Interlocked.Increment(ref _doUpdatePanelLCD);
         }
 
@@ -981,7 +979,6 @@
                                                     _vhfAmBigFrequencyStandby = 118;
                                                 }
                                             }
-
                                             break;
                                         }
 
@@ -1017,7 +1014,6 @@
                                             {
                                                 _uhfBigFrequencyStandby = 225;
                                             }
-
                                             break;
                                         }
 
@@ -1028,7 +1024,6 @@
                                                 var command = GetAdfCommand(AdfDigit.Digit10S, true);
                                                 DCSBIOS.Send(command);
                                             }
-
                                             break;
                                         }
 
@@ -1038,7 +1033,6 @@
                                             break;
                                         }
                                 }
-
                                 break;
                             }
 
@@ -1056,7 +1050,6 @@
                                                     _vhfAmBigFrequencyStandby = 143;
                                                 }
                                             }
-
                                             break;
                                         }
 
@@ -1092,7 +1085,6 @@
                                             {
                                                 _uhfBigFrequencyStandby = 399;
                                             }
-
                                             break;
                                         }
 
@@ -1103,7 +1095,6 @@
                                                 var command = GetAdfCommand(AdfDigit.Digit100S, true);
                                                 DCSBIOS.Send(command);
                                             }
-
                                             break;
                                         }
 
@@ -1113,7 +1104,6 @@
                                             break;
                                         }
                                 }
-
                                 break;
                             }
 
@@ -1132,7 +1122,6 @@
                                                     _vhfAmSmallFrequencyStandby = 0;
                                                 }
                                             }
-
                                             break;
                                         }
 
@@ -1165,7 +1154,6 @@
                                                 // At max value
                                                 _uhfSmallFrequencyStandby = 0;
                                             }
-
                                             break;
                                         }
 
@@ -1176,7 +1164,6 @@
                                                 var command = GetAdfCommand(AdfDigit.Digits1S, true);
                                                 DCSBIOS.Send(command);
                                             }
-
                                             break;
                                         }
 
@@ -1186,7 +1173,6 @@
                                             break;
                                         }
                                 }
-
                                 break;
                             }
 
@@ -1205,7 +1191,6 @@
                                                     _vhfAmSmallFrequencyStandby = 0.975;
                                                 }
                                             }
-
                                             break;
                                         }
 
@@ -1238,7 +1223,6 @@
                                                 // At max value
                                                 _uhfSmallFrequencyStandby = 99;
                                             }
-
                                             break;
                                         }
 
@@ -1249,7 +1233,6 @@
                                                 var command = GetAdfCommand(AdfDigit.Digits1S, false);
                                                 DCSBIOS.Send(command);
                                             }
-
                                             break;
                                         }
 
@@ -1259,7 +1242,6 @@
                                             break;
                                         }
                                 }
-
                                 break;
                             }
 
@@ -1277,7 +1259,6 @@
                                                     _vhfAmBigFrequencyStandby = 118;
                                                 }
                                             }
-
                                             break;
                                         }
 
@@ -1318,7 +1299,6 @@
                                             {
                                                 _uhfBigFrequencyStandby = 225;
                                             }
-
                                             break;
                                         }
 
@@ -1329,7 +1309,6 @@
                                                 var command = GetAdfCommand(AdfDigit.Digit10S, true);
                                                 DCSBIOS.Send(command);
                                             }
-
                                             break;
                                         }
 
@@ -1339,7 +1318,6 @@
                                             break;
                                         }
                                 }
-
                                 break;
                             }
 
@@ -1357,7 +1335,6 @@
                                                     _vhfAmBigFrequencyStandby = 143;
                                                 }
                                             }
-
                                             break;
                                         }
 
@@ -1393,7 +1370,6 @@
                                             {
                                                 _uhfBigFrequencyStandby = 399;
                                             }
-
                                             break;
                                         }
 
@@ -1404,7 +1380,6 @@
                                                 var command = GetAdfCommand(AdfDigit.Digit100S, true);
                                                 DCSBIOS.Send(command);
                                             }
-
                                             break;
                                         }
 
@@ -1414,7 +1389,6 @@
                                             break;
                                         }
                                 }
-
                                 break;
                             }
 
@@ -1433,7 +1407,6 @@
                                                     _vhfAmSmallFrequencyStandby = 0;
                                                 }
                                             }
-
                                             break;
                                         }
 
@@ -1466,7 +1439,6 @@
                                                 // At max value
                                                 _uhfSmallFrequencyStandby = 0;
                                             }
-
                                             break;
                                         }
 
@@ -1477,7 +1449,6 @@
                                                 var command = GetAdfCommand(AdfDigit.Digits1S, true);
                                                 DCSBIOS.Send(command);
                                             }
-
                                             break;
                                         }
 
@@ -1487,7 +1458,6 @@
                                             break;
                                         }
                                 }
-
                                 break;
                             }
 
@@ -1506,7 +1476,6 @@
                                                     _vhfAmSmallFrequencyStandby = 0.975;
                                                 }
                                             }
-
                                             break;
                                         }
 
@@ -1539,7 +1508,6 @@
                                                 // At max value
                                                 _uhfSmallFrequencyStandby = 99;
                                             }
-
                                             break;
                                         }
 
@@ -1550,7 +1518,6 @@
                                                 var command = GetAdfCommand(AdfDigit.Digits1S, false);
                                                 DCSBIOS.Send(command);
                                             }
-
                                             break;
                                         }
 
@@ -1560,13 +1527,11 @@
                                             break;
                                         }
                                 }
-
                                 break;
                             }
                     }
                 }
             }
-
             ShowFrequenciesOnPanel();
         }
 
@@ -1607,7 +1572,6 @@
                                 {
                                     _currentUpperRadioMode = CurrentSA342RadioMode.VHFAM;
                                 }
-
                                 break;
                             }
 
@@ -1617,7 +1581,6 @@
                                 {
                                     _currentUpperRadioMode = CurrentSA342RadioMode.VHFFM;
                                 }
-
                                 break;
                             }
 
@@ -1627,7 +1590,6 @@
                                 {
                                     _currentUpperRadioMode = CurrentSA342RadioMode.UHF;
                                 }
-
                                 break;
                             }
 
@@ -1637,7 +1599,6 @@
                                 {
                                     _currentUpperRadioMode = CurrentSA342RadioMode.ADF;
                                 }
-
                                 break;
                             }
 
@@ -1647,7 +1608,6 @@
                                 {
                                     _currentUpperRadioMode = CurrentSA342RadioMode.NADIR;
                                 }
-
                                 break;
                             }
 
@@ -1658,7 +1618,6 @@
                                 {
                                     _currentUpperRadioMode = CurrentSA342RadioMode.NOUSE;
                                 }
-
                                 break;
                             }
 
@@ -1668,7 +1627,6 @@
                                 {
                                     _currentLowerRadioMode = CurrentSA342RadioMode.VHFAM;
                                 }
-
                                 break;
                             }
 
@@ -1678,7 +1636,6 @@
                                 {
                                     _currentLowerRadioMode = CurrentSA342RadioMode.VHFFM;
                                 }
-
                                 break;
                             }
 
@@ -1688,7 +1645,6 @@
                                 {
                                     _currentLowerRadioMode = CurrentSA342RadioMode.UHF;
                                 }
-
                                 break;
                             }
 
@@ -1698,7 +1654,6 @@
                                 {
                                     _currentLowerRadioMode = CurrentSA342RadioMode.ADF;
                                 }
-
                                 break;
                             }
 
@@ -1708,7 +1663,6 @@
                                 {
                                     _currentLowerRadioMode = CurrentSA342RadioMode.NADIR;
                                 }
-
                                 break;
                             }
 
@@ -1719,7 +1673,6 @@
                                 {
                                     _currentLowerRadioMode = CurrentSA342RadioMode.NOUSE;
                                 }
-
                                 break;
                             }
 
@@ -1769,7 +1722,6 @@
                                 {
                                     SendFrequencyToDCSBIOS(RadioPanelPZ69KnobsSA342.UPPER_FREQ_SWITCH);
                                 }
-
                                 break;
                             }
 
@@ -1779,7 +1731,6 @@
                                 {
                                     SendFrequencyToDCSBIOS(RadioPanelPZ69KnobsSA342.LOWER_FREQ_SWITCH);
                                 }
-
                                 break;
                             }
                     }
@@ -1795,7 +1746,6 @@
                             null);
                     }
                 }
-
                 AdjustFrequency(hashSet);
             }
         }
@@ -1836,7 +1786,7 @@
 
         public override DcsOutputAndColorBinding CreateDcsOutputAndColorBinding(SaitekPanelLEDPosition saitekPanelLEDPosition, PanelLEDColor panelLEDColor, DCSBIOSOutput dcsBiosOutput)
         {
-            var dcsOutputAndColorBinding = new DcsOutputAndColorBindingPZ55
+            DcsOutputAndColorBindingPZ55 dcsOutputAndColorBinding = new()
             {
                 DCSBiosOutputLED = dcsBiosOutput,
                 LEDColor = panelLEDColor,
@@ -1868,39 +1818,20 @@
                                 return i.ToString();
                             }
                         }
-
                         break;
                     }
 
                 case 1:
                     {
-                        switch (position)
+                        return position switch
                         {
-                            case 0:
-                                {
-                                    return "00";
-                                }
-
-                            case 16383:
-                                {
-                                    return "25";
-                                }
-
-                            case 32767:
-                                {
-                                    return "50";
-                                }
-
-                            case 49151:
-                                {
-                                    return "75";
-                                }
-                        }
+                            0 => "00",
+                            16383 => "25",
+                            32767 => "50",
+                            49151 => "75",
+                        };
                     }
-
-                    break;
             }
-
             return "00";
         }
 
@@ -1926,33 +1857,15 @@
 
                 case VhfAmDigit.LastTwoSpecial:
                     {
-                        switch (position)
+                        return position switch
                         {
-                            case 0:
-                                {
-                                    return "00";
-                                }
-
-                            case 16383:
-                                {
-                                    return "25";
-                                }
-
-                            case 32767:
-                                {
-                                    return "50";
-                                }
-
-                            case 49151:
-                                {
-                                    return "75";
-                                }
-                        }
+                            0 => "00",
+                            16383 => "25",
+                            32767 => "50",
+                            49151 => "75",
+                        };                        
                     }
-
-                    break;
             }
-
             return "00";
         }
 
@@ -2015,7 +1928,6 @@
                     return true;
                 }
             }
-
             return false;
         }
 
@@ -2028,7 +1940,6 @@
                     return true;
                 }
             }
-
             return false;
         }
 
@@ -2071,7 +1982,6 @@
             {
                 return true;
             }
-
             return false;
         }
 
@@ -2086,7 +1996,6 @@
                         _vhfAmLeftDialSkipper = 0;
                         return false;
                     }
-
                     _vhfAmLeftDialSkipper++;
                     return true;
                 }
@@ -2095,7 +2004,6 @@
             {
                 logger.Error(ex);
             }
-
             return false;
         }
 
@@ -2110,7 +2018,6 @@
                         _vhfAmRightDialSkipper = 0;
                         return false;
                     }
-
                     _vhfAmRightDialSkipper++;
                     return true;
                 }
@@ -2119,7 +2026,6 @@
             {
                 logger.Error(ex);
             }
-
             return false;
         }
 
@@ -2134,7 +2040,6 @@
                         _uhfBigFrequencySkipper = 0;
                         return false;
                     }
-
                     _uhfBigFrequencySkipper++;
                     return true;
                 }
@@ -2143,7 +2048,6 @@
             {
                 logger.Error(ex);
             }
-
             return false;
         }
 
@@ -2158,7 +2062,6 @@
                         _uhfSmallFrequencySkipper = 0;
                         return false;
                     }
-
                     _uhfSmallFrequencySkipper++;
                     return true;
                 }
@@ -2167,7 +2070,6 @@
             {
                 logger.Error(ex);
             }
-
             return false;
         }
 
@@ -2183,7 +2085,6 @@
                             {
                                 return ADF1_UNIT100_S_INCREASE;
                             }
-
                             return ADF2_UNIT100_S_INCREASE;
                         }
 
@@ -2193,7 +2094,6 @@
                             {
                                 return ADF1_UNIT10_S_INCREASE;
                             }
-
                             return ADF2_UNIT10_S_INCREASE;
                         }
 
@@ -2205,20 +2105,16 @@
                                 {
                                     return ADF1_UNIT1_S_DECIMALS_INCREASE;
                                 }
-
                                 return ADF1_UNIT1_S_DECIMALS_DECREASE;
                             }
-
                             if (increase)
                             {
                                 return ADF2_UNIT1_S_DECIMALS_INCREASE;
                             }
-
                             return ADF2_UNIT1_S_DECIMALS_DECREASE;
                         }
                 }
             }
-
             return string.Empty;
         }
 
@@ -2233,7 +2129,6 @@
                         _adf100SDialSkipper = 0;
                         return false;
                     }
-
                     _adf100SDialSkipper++;
                     return true;
                 }
@@ -2242,7 +2137,6 @@
             {
                 logger.Error(ex);
             }
-
             return false;
         }
 
@@ -2257,7 +2151,6 @@
                         _adf10SDialSkipper = 0;
                         return false;
                     }
-
                     _adf10SDialSkipper++;
                     return true;
                 }
@@ -2266,7 +2159,6 @@
             {
                 logger.Error(ex);
             }
-
             return false;
         }
 
@@ -2281,7 +2173,6 @@
                         _adf1SDialSkipper = 0;
                         return false;
                     }
-
                     _adf1SDialSkipper++;
                     return true;
                 }
@@ -2290,7 +2181,6 @@
             {
                 logger.Error(ex);
             }
-
             return false;
         }
 

--- a/Source/NonVisuals/Radios/RadioPanelPZ69SA342.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69SA342.cs
@@ -35,22 +35,16 @@
         private enum VhfAmDigit
         {
             First,
-
             Second,
-
             Third,
-
             Fourth,
-
             LastTwoSpecial
         }
 
         private enum AdfDigit
         {
             Digit100S,
-
             Digit10S,
-
             Digits1S
         }
 
@@ -58,139 +52,78 @@
         // Large dial 118-143
         // Small dial 0-975
         private readonly int[] _dialPositionsWholeNumbers = { 0, 6553, 13107, 19660, 26214, 32767, 39321, 45874, 52428, 58981 };
-
         private readonly int[] _dialPositionsDecial100S = { 0, 16383, 32767, 49151 };
-
         private double _vhfAmBigFrequencyStandby = 118;
-
         private double _vhfAmSmallFrequencyStandby;
-
         private double _vhfAmSavedCockpitBigFrequency;
-
         private double _vhfAmSavedCockpitSmallFrequency;
-
         private DCSBIOSOutput _vhfAmDcsbiosOutputReading10S; // 1[1]8.375
-
         private DCSBIOSOutput _vhfAmDcsbiosOutputReading1S; // 11[8].375
-
         private DCSBIOSOutput _vhfAmDcsbiosOutputReadingDecimal10S; // 118.[3]75
-
         private DCSBIOSOutput _vhfAmDcsbiosOutputReadingDecimal100S; // 118.3[75]
-
         private const string VHF_AM_LEFT_DIAL_DIAL_COMMAND_INC = "AM_RADIO_FREQUENCY_DIAL_LEFT +3200\n";
-
         private const string VHF_AM_LEFT_DIAL_DIAL_COMMAND_DEC = "AM_RADIO_FREQUENCY_DIAL_LEFT -3200\n";
-
         private const string VHF_AM_RIGHT_DIAL_DIAL_COMMAND_INC = "AM_RADIO_FREQUENCY_DIAL_RIGHT +3200\n";
-
         private const string VHF_AM_RIGHT_DIAL_DIAL_COMMAND_DEC = "AM_RADIO_FREQUENCY_DIAL_RIGHT -3200\n";
-
-        private readonly object _lockVhfAm10SObject = new object();
-
-        private readonly object _lockVhfAm1SObject = new object();
-
-        private readonly object _lockVhfAmDecimal10SObject = new object();
-
-        private readonly object _lockVhfAmDecimal100SObject = new object();
-
+        private readonly object _lockVhfAm10SObject = new();
+        private readonly object _lockVhfAm1SObject = new();
+        private readonly object _lockVhfAmDecimal10SObject = new();
+        private readonly object _lockVhfAmDecimal100SObject = new();
         private volatile uint _vhfAmCockpit10SFrequencyValue = 6553;
-
         private volatile uint _vhfAmCockpit1SFrequencyValue = 6553;
-
         private volatile uint _vhfAmCockpitDecimal10SFrequencyValue = 6553;
-
         private volatile uint _vhfAmCockpitDecimal100SFrequencyValue = 6553;
 
         private Thread _vhfAmSyncThread;
-
         private long _vhfAmThreadNowSynching;
-
         private long _vhfAmValue1WaitingForFeedback; // 10s
-
         private long _vhfAmValue2WaitingForFeedback; // 1s
-
         private long _vhfAmValue3WaitingForFeedback; // Decimal 10s
-
         private long _vhfAmValue4WaitingForFeedback; // Decimal 100s
-
         private int _vhfAmLeftDialSkipper;
-
         private int _vhfAmRightDialSkipper;
 
         /*COM2 SA342 FM PR4G Radio*/
         // Large dial 0-7 Presets 1, 2, 3, 4, 5, 6, 0, RG
         // Small dial 
         private DCSBIOSOutput _fmRadioPresetDcsbiosOutput;
-
         private volatile uint _fmRadioPresetCockpitDialPos = 1;
-
         private const string FM_RADIO_PRESET_COMMAND_INC = "FM_RADIO_CHANNEL INC\n";
-
         private const string FM_RADIO_PRESET_COMMAND_DEC = "FM_RADIO_CHANNEL DEC\n";
-
-        private readonly object _lockFmRadioPresetObject = new object();
+        private readonly object _lockFmRadioPresetObject = new();
 
         /*NAV1 SA342 UHF Radio*/
         // Large dial 225-399
         // Small dial 000-975 where only 2 digits can be used
         private readonly ClickSpeedDetector _uhfBigFreqIncreaseChangeMonitor = new ClickSpeedDetector(20);
-
         private readonly ClickSpeedDetector _uhfBigFreqDecreaseChangeMonitor = new ClickSpeedDetector(20);
-
         private readonly ClickSpeedDetector _uhfSmallFreqIncreaseChangeMonitor = new ClickSpeedDetector(20);
-
         private readonly ClickSpeedDetector _uhfSmallFreqDecreaseChangeMonitor = new ClickSpeedDetector(20);
-
         private double _uhfBigFrequencyStandby = 225;
-
         private double _uhfSmallFrequencyStandby;
-
         private const string UHF_BUTTON0_COMMAND_ON = "UHF_RADIO_BUTTON_0 1\n";
-
         private const string UHF_BUTTON0_COMMAND_OFF = "UHF_RADIO_BUTTON_0 0\n";
-
         private const string UHF_BUTTON1_COMMAND_ON = "UHF_RADIO_BUTTON_1 1\n";
-
         private const string UHF_BUTTON1_COMMAND_OFF = "UHF_RADIO_BUTTON_1 0\n";
-
         private const string UHF_BUTTON2_COMMAND_ON = "UHF_RADIO_BUTTON_2 1\n";
-
         private const string UHF_BUTTON2_COMMAND_OFF = "UHF_RADIO_BUTTON_2 0\n";
-
         private const string UHF_BUTTON3_COMMAND_ON = "UHF_RADIO_BUTTON_3 1\n";
-
         private const string UHF_BUTTON3_COMMAND_OFF = "UHF_RADIO_BUTTON_3 0\n";
-
         private const string UHF_BUTTON4_COMMAND_ON = "UHF_RADIO_BUTTON_4 1\n";
-
         private const string UHF_BUTTON4_COMMAND_OFF = "UHF_RADIO_BUTTON_4 0\n";
-
         private const string UHF_BUTTON5_COMMAND_ON = "UHF_RADIO_BUTTON_5 1\n";
-
         private const string UHF_BUTTON5_COMMAND_OFF = "UHF_RADIO_BUTTON_5 0\n";
-
         private const string UHF_BUTTON6_COMMAND_ON = "UHF_RADIO_BUTTON_6 1\n";
-
         private const string UHF_BUTTON6_COMMAND_OFF = "UHF_RADIO_BUTTON_6 0\n";
-
         private const string UHF_BUTTON7_COMMAND_ON = "UHF_RADIO_BUTTON_7 1\n";
-
         private const string UHF_BUTTON7_COMMAND_OFF = "UHF_RADIO_BUTTON_7 0\n";
-
         private const string UHF_BUTTON8_COMMAND_ON = "UHF_RADIO_BUTTON_8 1\n";
-
         private const string UHF_BUTTON8_COMMAND_OFF = "UHF_RADIO_BUTTON_8 0\n";
-
         private const string UHF_BUTTON9_COMMAND_ON = "UHF_RADIO_BUTTON_9 1\n";
-
         private const string UHF_BUTTON9_COMMAND_OFF = "UHF_RADIO_BUTTON_9 0\n";
-
         private const string UHF_BUTTON_VALIDATE_COMMAND_ON = "UHF_RADIO_BUTTON_VLD 1\n";
-
         private const string UHF_BUTTON_VALIDATE_COMMAND_OFF = "UHF_RADIO_BUTTON_VLD 0\n";
-
         private int _uhfBigFrequencySkipper;
-
         private int _uhfSmallFrequencySkipper;
 
         /*ADF SA342*/
@@ -198,33 +131,19 @@
         /*Large dial Clockwise 10s increase*/
         /*Small dial 1s and decimals*/
         private const string ADF1_UNIT100_S_INCREASE = "ADF_NAV1_100 +3200\n";
-
         private const string ADF1_UNIT10_S_INCREASE = "ADF_NAV1_10 +3200\n";
-
         private const string ADF1_UNIT1_S_DECIMALS_INCREASE = "ADF_NAV1_1 +3200\n";
-
         private const string ADF1_UNIT1_S_DECIMALS_DECREASE = "ADF_NAV1_1 -3200\n";
-
         private const string ADF2_UNIT100_S_INCREASE = "ADF_NAV2_100 +3200\n";
-
         private const string ADF2_UNIT10_S_INCREASE = "ADF_NAV2_10 +3200\n";
-
         private const string ADF2_UNIT1_S_DECIMALS_INCREASE = "ADF_NAV2_1 +3200\n";
-
         private const string ADF2_UNIT1_S_DECIMALS_DECREASE = "ADF_NAV2_1 -3200\n";
-
         private const string ADF_SWITCH_UNIT_COMMAND = "ADF1_ADF2_SELECT TOGGLE\n";
-
-        private readonly object _lockAdfUnitObject = new object();
-
+        private readonly object _lockAdfUnitObject = new();
         private volatile uint _adfCockpitSelectedUnitValue = 1;
-
         private DCSBIOSOutput _adfSwitchUnitDcsbiosOutput;
-
         private int _adf100SDialSkipper;
-
         private int _adf10SDialSkipper;
-
         private int _adf1SDialSkipper;
 
         // DME NADIR
@@ -232,26 +151,17 @@
         // Small dial Doppler modes ARRET, VEILLE, TERRE, MER, ANEMO,TEST SOL.
         // Large
         private const string NADIR_MODE_COMMAND_INC = "NADIR_PARAMETER INC\n";
-
         private const string NADIR_MODE_COMMAND_DEC = "NADIR_PARAMETER DEC\n";
 
         // Small
         private const string NADIR_DOPPLER_COMMAND_INC = "NADIR_DOPPLER_MODE INC\n";
-
         private const string NADIR_DOPPLER_COMMAND_DEC = "NADIR_DOPPLER_MODE DEC\n";
-
         private volatile uint _nadirModeCockpitValue;
-
         private volatile uint _nadirDopplerModeCockpitValue;
-
         private DCSBIOSOutput _nadirModeDcsbiosOutput;
-
         private DCSBIOSOutput _nadirDopplerModeDcsbiosOutput;
-
-        private readonly object _lockNADIRUnitObject = new object();
-
-        private readonly object _lockShowFrequenciesOnPanelObject = new object();
-
+        private readonly object _lockNADIRUnitObject = new();
+        private readonly object _lockShowFrequenciesOnPanelObject = new();
         private long _doUpdatePanelLCD;
 
         public RadioPanelPZ69SA342(HIDSkeleton hidSkeleton)
@@ -280,7 +190,7 @@
             // Call base class implementation.
             base.Dispose(disposing);
         }
-        
+       
 
         public override void DcsBiosDataReceived(object sender, DCSBIOSDataEventArgs e)
         {

--- a/Source/NonVisuals/Radios/RadioPanelPZ69UH1H.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69UH1H.cs
@@ -35,202 +35,115 @@ namespace NonVisuals.Radios
         /*UH-1H INTERCOMM*/
         // PVT INT 1 2 3 4  (6 positions 0-5)
         private volatile int _interCommSkipper;
-
-        private readonly object _lockIntercommDialObject = new object();
-        
+        private readonly object _lockIntercommDialObject = new();
         private DCSBIOSOutput _interCommDcsbiosOutputCockpitPos;
-
         private volatile uint _interCommCockpitDial1Pos;
-
         private const string INTERCOMM_DIAL_COMMAND_INC = "INT_MODE INC\n";
-
         private const string INTERCOMM_DIAL_COMMAND_DEC = "INT_MODE DEC\n";
-        
         private long _interCommDialWaitingForFeedback;
-
         private const string INTERCOMM_VOLUME_KNOB_COMMAND_INC = "INT_VOL +2500\n";
-
         private const string INTERCOMM_VOLUME_KNOB_COMMAND_DEC = "INT_VOL -2500\n";
 
         /*UH-1H AN/ARC-134 VHF Comm Radio Set Left side of lower control panel */
         // Large dial 116-149 [step of 1]
         // Small dial 0.00-0.95 [step 0 2 5 7]
-        private readonly object _lockVhfCommDialsObject1 = new object();
-
-        private readonly object _lockVhfCommDialsObject2 = new object();
-
+        private readonly object _lockVhfCommDialsObject1 = new();
+        private readonly object _lockVhfCommDialsObject2 = new();
         private volatile uint _vhfCommBigFrequencyStandby = 116;
-
         private volatile uint _vhfCommSmallFrequencyStandby;
-
         private volatile uint _vhfCommSavedCockpitSmallFrequency;
-
         private volatile uint _vhfCommSavedCockpitBigFrequency = 116;
-
         private double _vhfCommCockpitFrequency = 116.00;
-
         private long _vhfCommThreadNowSynching;
-
         private volatile uint _vhfCommCockpitDial1Frequency = 116;
-
         private volatile uint _vhfCommCockpitDial2Frequency = 95;
-
         private long _vhfCommDial1FreqWaitingForFeedback;
-
         private long _vhfCommDial2FreqWaitingForFeedback;
-
         private DCSBIOSOutput _vhfCommDcsbiosOutputCockpitFrequency;
-
         private const string VHF_COMM_FREQ1_DIAL_COMMAND = "VHFCOMM_MHZ ";
-
         private const string VHF_COMM_FREQ2_DIAL_COMMAND = "VHFCOMM_KHZ ";
-
         private Thread _vhfCommSyncThread;
 
         /*AN/ARC-51BX UHF radio set*/
         // Large dial 200-399 [step of 1]
         // Small dial 0.00-0.95 [step 0.05]
         private bool _uhfIncreasePresetChannel;
-
         private uint _uhfCockpitPresetChannel = 1;
-
         private const string UHF_PRESET_DIAL_COMMAND_INC = "UHF_PRESET INC\n";
-
         private const string UHF_PRESET_DIAL_COMMAND_DEC = "UHF_PRESET DEC\n";
-
         private DCSBIOSOutput _uhfDcsbiosOutputCockpitPresetChannel;
-
-        private readonly object _lockUhfPresetChannelObject = new object();
+        private readonly object _lockUhfPresetChannelObject = new();
 
         // private Thread _uhfPresetChannelSyncThread;
         // private long _uhfPresetChannelThreadNowSynching = 0;
         // private long _uhfPresetChannelWaitingForFeedback = 0;
-        private readonly object _lockUhfDialsObject1 = new object();
-
-        private readonly object _lockUhfDialsObject2 = new object();
-
-        private readonly object _lockUhfDialsObject3 = new object();
-
+        private readonly object _lockUhfDialsObject1 = new();
+        private readonly object _lockUhfDialsObject2 = new();
+        private readonly object _lockUhfDialsObject3 = new();
         private uint _uhfBigFrequencyStandby = 200;
-
         private uint _uhfSmallFrequencyStandby;
-
         private volatile uint _uhfSavedCockpitBigFrequency = 200;
-
         private volatile uint _uhfSavedCockpitSmallFrequency;
-
         private DCSBIOSOutput _uhfDcsbiosOutputCockpitFrequency;
-
         private double _uhfCockpitFrequency = 225.00;
-
         private volatile uint _uhfCockpitDial1Frequency = 22;
-
         private volatile uint _uhfCockpitDial2Frequency = 5;
-
         private volatile uint _uhfCockpitDial3Frequency;
-
         private const string UHF_FREQ1_DIAL_COMMAND = "UHF_10MHZ "; // 20-39
-
         private const string UHF_FREQ2_DIAL_COMMAND = "UHF_1MHZ "; // 0 1 2 3 4 5 6 7 8 9
-
         private const string UHF_FREQ3_DIAL_COMMAND = "UHF_50KHZ "; // 00 - 95
-
         private Thread _uhfSyncThread;
-
         private long _uhfThreadNowSynching;
-
         private long _uhfDial1WaitingForFeedback;
-
         private long _uhfDial2WaitingForFeedback;
-
         private long _uhfDial3WaitingForFeedback;
 
         /*UH-1H AN/ARN-82 VHF Navigation Set*/
         // Large dial 107-126 [step of 1]
         // Small dial 0.00-0.95 [step of 0.05]
-        private readonly object _lockVhfNavDialsObject1 = new object();
-
-        private readonly object _lockVhfNavDialsObject2 = new object();
-
+        private readonly object _lockVhfNavDialsObject1 = new();
+        private readonly object _lockVhfNavDialsObject2 = new();
         private volatile uint _vhfNavBigFrequencyStandby = 107;
-
         private volatile uint _vhfNavSmallFrequencyStandby;
-
         private volatile uint _vhfNavSavedCockpitBigFrequency = 107;
-
         private volatile uint _vhfNavSavedCockpitSmallFrequency;
-
         private DCSBIOSOutput _vhfNavDcsbiosOutputCockpitFrequency;
-
         private double _vhfNavCockpitFrequency = 107.00;
-
         private volatile uint _vhfNavCockpitDial1Frequency = 107;
-
         private volatile uint _vhfNavCockpitDial2Frequency;
-
         private const string VHF_NAV_FREQ1_DIAL_COMMAND = "VHFNAV_MHZ ";
-
         private const string VHF_NAV_FREQ2_DIAL_COMMAND = "VHFNAV_KHZ ";
-
         private Thread _vhfNavSyncThread;
-
         private long _vhfNavThreadNowSynching;
-
         private long _vhfNavDial1WaitingForFeedback;
-
         private long _vhfNavDial2WaitingForFeedback;
 
         /*UH-1H ARC-131 VHF FM*/
         private uint _vhfFmBigFrequencyStandby = 30;
-
         private uint _vhfFmSmallFrequencyStandby;
-
         private uint _vhfFmSavedCockpitBigFrequency = 30;
-
         private uint _vhfFmSavedCockpitSmallFrequency;
-
-        private readonly object _lockVhfFmDialsObject1 = new object();
-
-        private readonly object _lockVhfFmDialsObject2 = new object();
-
-        private readonly object _lockVhfFmDialsObject3 = new object();
-
-        private readonly object _lockVhfFmDialsObject4 = new object();
-
+        private readonly object _lockVhfFmDialsObject1 = new();
+        private readonly object _lockVhfFmDialsObject2 = new();
+        private readonly object _lockVhfFmDialsObject3 = new();
+        private readonly object _lockVhfFmDialsObject4 = new();
         private DCSBIOSOutput _vhfFmDcsbiosOutputFreqDial1;
-
         private DCSBIOSOutput _vhfFmDcsbiosOutputFreqDial2;
-
         private DCSBIOSOutput _vhfFmDcsbiosOutputFreqDial3;
-
         private DCSBIOSOutput _vhfFmDcsbiosOutputFreqDial4;
-
         private volatile uint _vhfFmCockpitFreq1DialPos = 1;
-
         private volatile uint _vhfFmCockpitFreq2DialPos = 1;
-
         private volatile uint _vhfFmCockpitFreq3DialPos = 1;
-
         private volatile uint _vhfFmCockpitFreq4DialPos = 1;
-
         private const string VHF_FM_FREQ_1DIAL_COMMAND = "VHFFM_FREQ1 "; // 3 4 5 6
-
         private const string VHF_FM_FREQ_2DIAL_COMMAND = "VHFFM_FREQ2 "; // 0 1 2 3 4 5 6 7 8 9
-
         private const string VHF_FM_FREQ_3DIAL_COMMAND = "VHFFM_FREQ3 "; // 0 1 2 3 4 5 6 7 8 9
-
         private const string VHF_FM_FREQ_4DIAL_COMMAND = "VHFFM_FREQ4 "; // 0 5
-
         private Thread _vhfFmSyncThread;
-
         private long _vhfFmThreadNowSynching;
-
         private long _vhfFmDial1WaitingForFeedback;
-
         private long _vhfFmDial2WaitingForFeedback;
-
         private long _vhfFmDial3WaitingForFeedback;
-
         private long _vhfFmDial4WaitingForFeedback;
 
         /*UH-1H ADF*/
@@ -244,49 +157,27 @@ namespace NonVisuals.Radios
             190-1800 kHz
          */
         private bool _increaseAdfBand;
-
-        private readonly object _lockAdfFrequencyBandObject = new object();
-
-        private readonly object _lockAdfCockpitFrequencyObject = new object();
-
-        private readonly object _lockAdfSignalStrengthObject = new object();
-
+        private readonly object _lockAdfFrequencyBandObject = new();
+        private readonly object _lockAdfCockpitFrequencyObject = new();
+        private readonly object _lockAdfSignalStrengthObject = new();
         private DCSBIOSOutput _adfDcsbiosOutputCockpitFrequencyBand;
-
         private DCSBIOSOutput _adfDcsbiosOutputCockpitFrequency;
-
         private DCSBIOSOutput _adfDcsbiosOutputSignalStrength;
-
         private volatile uint _adfCockpitFrequencyRaw = 0;
-
         private double _adfCockpitFrequency;
-
         private volatile uint _adfSignalStrengthRaw;
-
         private double _adfSignalStrength;
-
         private volatile uint _adfCockpitFrequencyBand;
-
         private volatile uint _adfStandbyFrequencyBand;
-
         private const string ADF_TUNE_KNOB_COMMAND_INC = "ADF_TUNE -1000\n";
-
         private const string ADF_TUNE_KNOB_COMMAND_DEC = "ADF_TUNE +1000\n";
-
         private const string ADF_GAIN_KNOB_COMMAND_INC = "ADF_GAIN -2000\n";
-
         private const string ADF_GAIN_KNOB_COMMAND_DEC = "ADF_GAIN +2000\n";
-
         private const string ADF_FREQUENCY_BAND_COMMAND = "ADF_BAND ";
-
         private Thread _adfSyncThread;
-
         private long _adfThreadNowSynching;
-
         private long _adfFrequencyBandWaitingForFeedback;
-
-        private readonly object _lockShowFrequenciesOnPanelObject = new object();
-
+        private readonly object _lockShowFrequenciesOnPanelObject = new();
         private long _doUpdatePanelLCD;
 
         public RadioPanelPZ69UH1H(HIDSkeleton hidSkeleton)

--- a/Source/NonVisuals/Radios/RadioPanelPZ69UH1H.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69UH1H.cs
@@ -145,6 +145,7 @@ namespace NonVisuals.Radios
         private long _vhfFmDial2WaitingForFeedback;
         private long _vhfFmDial3WaitingForFeedback;
         private long _vhfFmDial4WaitingForFeedback;
+        private volatile bool _shutdownVHFFMThread;
 
         /*UH-1H ADF*/
         /*
@@ -306,7 +307,6 @@ namespace NonVisuals.Radios
                         if (tmp != _uhfCockpitDial1Frequency)
                         {
                             Interlocked.Increment(ref _doUpdatePanelLCD);
-
                             Interlocked.Exchange(ref _uhfDial1WaitingForFeedback, 0);
                         }
                     }
@@ -318,7 +318,6 @@ namespace NonVisuals.Radios
                         if (tmp != _uhfCockpitDial2Frequency)
                         {
                             Interlocked.Increment(ref _doUpdatePanelLCD);
-
                             Interlocked.Exchange(ref _uhfDial2WaitingForFeedback, 0);
                         }
                     }
@@ -330,7 +329,6 @@ namespace NonVisuals.Radios
                         if (tmp != _uhfCockpitDial3Frequency)
                         {
                             Interlocked.Increment(ref _doUpdatePanelLCD);
-
                             Interlocked.Exchange(ref _uhfDial3WaitingForFeedback, 0);
                         }
                     }
@@ -363,7 +361,6 @@ namespace NonVisuals.Radios
                         if (tmp != _vhfNavCockpitDial1Frequency)
                         {
                             Interlocked.Increment(ref _doUpdatePanelLCD);
-
                             Interlocked.Exchange(ref _vhfNavDial1WaitingForFeedback, 0);
                         }
                     }
@@ -375,7 +372,6 @@ namespace NonVisuals.Radios
                         if (tmp != _vhfNavCockpitDial2Frequency)
                         {
                             Interlocked.Increment(ref _doUpdatePanelLCD);
-
                             Interlocked.Exchange(ref _vhfNavDial2WaitingForFeedback, 0);
                         }
                     }
@@ -385,7 +381,6 @@ namespace NonVisuals.Radios
             {
                 Common.ShowErrorMessageBox(ex, "DCSBIOSStringReceived()");
             }
-
             ShowFrequenciesOnPanel();
         }
 
@@ -401,7 +396,6 @@ namespace NonVisuals.Radios
                     if (tmp != _interCommCockpitDial1Pos)
                     {
                         Interlocked.Increment(ref _doUpdatePanelLCD);
-
                         Interlocked.Exchange(ref _interCommDialWaitingForFeedback, 0);
                     }
                 }
@@ -417,7 +411,6 @@ namespace NonVisuals.Radios
                     if (tmp != _vhfFmCockpitFreq1DialPos)
                     {
                         Interlocked.Increment(ref _doUpdatePanelLCD);
-
                         Interlocked.Exchange(ref _vhfFmDial1WaitingForFeedback, 0);
                     }
                 }
@@ -432,7 +425,6 @@ namespace NonVisuals.Radios
                     if (tmp != _vhfFmCockpitFreq2DialPos)
                     {
                         Interlocked.Increment(ref _doUpdatePanelLCD);
-
                         Interlocked.Exchange(ref _vhfFmDial2WaitingForFeedback, 0);
                     }
                 }
@@ -447,7 +439,6 @@ namespace NonVisuals.Radios
                     if (tmp != _vhfFmCockpitFreq3DialPos)
                     {
                         Interlocked.Increment(ref _doUpdatePanelLCD);
-
                         Interlocked.Exchange(ref _vhfFmDial3WaitingForFeedback, 0);
                     }
                 }
@@ -462,7 +453,6 @@ namespace NonVisuals.Radios
                     if (tmp != _vhfFmCockpitFreq4DialPos)
                     {
                         Interlocked.Increment(ref _doUpdatePanelLCD);
-
                         Interlocked.Exchange(ref _vhfFmDial4WaitingForFeedback, 0);
                     }
                 }
@@ -478,7 +468,6 @@ namespace NonVisuals.Radios
                     if (tmp != _adfCockpitFrequencyBand)
                     {
                         Interlocked.Increment(ref _doUpdatePanelLCD);
-
                         Interlocked.Exchange(ref _adfFrequencyBandWaitingForFeedback, 0);
                     }
                 }
@@ -558,7 +547,6 @@ namespace NonVisuals.Radios
                                     // A = B + ((B * 0.11291) - 100.61)
                                     _adfCockpitFrequency = b + ((b * 0.11291) - 96.11);
                                 }
-
                                 break;
                             }
 
@@ -660,7 +648,6 @@ namespace NonVisuals.Radios
                                     break;
                                 }
                         }
-
                         break;
                     }
 
@@ -704,7 +691,6 @@ namespace NonVisuals.Radios
                                     break;
                                 }
                         }
-
                         break;
                     }
             }
@@ -868,7 +854,6 @@ namespace NonVisuals.Radios
                                     dial1SendCount++;
                                     Interlocked.Exchange(ref _vhfCommDial1FreqWaitingForFeedback, 1);
                                 }
-
                                 Reset(ref dial1Timeout);
                             }
                         }
@@ -889,7 +874,6 @@ namespace NonVisuals.Radios
                                     dial2SendCount++;
                                     Interlocked.Exchange(ref _vhfCommDial2FreqWaitingForFeedback, 1);
                                 }
-
                                 Reset(ref dial2Timeout);
                             }
                         }
@@ -925,7 +909,6 @@ namespace NonVisuals.Radios
             {
                 Interlocked.Exchange(ref _vhfCommThreadNowSynching, 0);
             }
-
             Interlocked.Increment(ref _doUpdatePanelLCD);
         }
 
@@ -1019,7 +1002,6 @@ namespace NonVisuals.Radios
                                     dial1SendCount++;
                                     Interlocked.Exchange(ref _uhfDial1WaitingForFeedback, 1);
                                 }
-
                                 Reset(ref dial1Timeout);
                             }
                         }
@@ -1040,7 +1022,6 @@ namespace NonVisuals.Radios
                                     dial2SendCount++;
                                     Interlocked.Exchange(ref _uhfDial2WaitingForFeedback, 1);
                                 }
-
                                 Reset(ref dial2Timeout);
                             }
                         }
@@ -1061,7 +1042,6 @@ namespace NonVisuals.Radios
                                     dial3SendCount++;
                                     Interlocked.Exchange(ref _uhfDial3WaitingForFeedback, 1);
                                 }
-
                                 Reset(ref dial3Timeout);
                             }
                         }
@@ -1098,7 +1078,6 @@ namespace NonVisuals.Radios
             {
                 Interlocked.Exchange(ref _uhfThreadNowSynching, 0);
             }
-
             Interlocked.Increment(ref _doUpdatePanelLCD);
         }
 
@@ -1171,7 +1150,6 @@ namespace NonVisuals.Radios
                                     dial1SendCount++;
                                     Interlocked.Exchange(ref _vhfNavDial1WaitingForFeedback, 1);
                                 }
-
                                 Reset(ref dial1Timeout);
                             }
                         }
@@ -1194,7 +1172,6 @@ namespace NonVisuals.Radios
                                     dial2SendCount++;
                                     Interlocked.Exchange(ref _vhfNavDial2WaitingForFeedback, 1);
                                 }
-
                                 Reset(ref dial2Timeout);
                             }
                         }
@@ -1230,7 +1207,6 @@ namespace NonVisuals.Radios
             {
                 Interlocked.Exchange(ref _vhfNavThreadNowSynching, 0);
             }
-
             Interlocked.Increment(ref _doUpdatePanelLCD);
         }
 
@@ -1246,11 +1222,9 @@ namespace NonVisuals.Radios
             Thread.Sleep(Constants.ThreadShutDownWaitTime);
             _shutdownVHFFMThread = false;
             _vhfFmSyncThread = new Thread(VhfFmSynchThreadMethod);
-
             _vhfFmSyncThread.Start();
         }
 
-        private volatile bool _shutdownVHFFMThread;
         private void VhfFmSynchThreadMethod()
         {
             try
@@ -1352,7 +1326,6 @@ namespace NonVisuals.Radios
                                     dial1SendCount++;
                                     Interlocked.Exchange(ref _vhfFmDial1WaitingForFeedback, 1);
                                 }
-
                                 Reset(ref dial1Timeout);
                             }
                         }
@@ -1384,7 +1357,6 @@ namespace NonVisuals.Radios
                                     dial2SendCount++;
                                     Interlocked.Exchange(ref _vhfFmDial2WaitingForFeedback, 1);
                                 }
-
                                 Reset(ref dial2Timeout);
                             }
                         }
@@ -1416,7 +1388,6 @@ namespace NonVisuals.Radios
                                     dial3SendCount++;
                                     Interlocked.Exchange(ref _vhfFmDial3WaitingForFeedback, 1);
                                 }
-
                                 Reset(ref dial3Timeout);
                             }
                         }
@@ -1448,7 +1419,6 @@ namespace NonVisuals.Radios
                                     dial4SendCount++;
                                     Interlocked.Exchange(ref _vhfFmDial4WaitingForFeedback, 1);
                                 }
-
                                 Reset(ref dial4Timeout);
                             }
                         }
@@ -1466,7 +1436,6 @@ namespace NonVisuals.Radios
                             dial4SendCount = 0;
                             Thread.Sleep(5000);
                         }
-
                         Thread.Sleep(SynchSleepTime); // Should be enough to get an update cycle from DCS-BIOS
                     }
                     while ((IsTooShort(dial1OkTime) || IsTooShort(dial2OkTime) || IsTooShort(dial3OkTime) || IsTooShort(dial4OkTime)) && !_shutdownVHFFMThread);
@@ -1486,7 +1455,6 @@ namespace NonVisuals.Radios
             {
                 Interlocked.Exchange(ref _vhfFmThreadNowSynching, 0);
             }
-
             Interlocked.Increment(ref _doUpdatePanelLCD);
         }
 
@@ -1496,7 +1464,6 @@ namespace NonVisuals.Radios
             Thread.Sleep(Constants.ThreadShutDownWaitTime);
             _shutdownADFThread = false;
             _adfSyncThread = new Thread(AdfBandChangeSynchThreadMethod);
-
             _adfSyncThread.Start();
         }
 
@@ -1669,7 +1636,6 @@ namespace NonVisuals.Radios
             {
                 return "0" + _vhfCommSmallFrequencyStandby;
             }
-
             return _vhfCommSmallFrequencyStandby.ToString();
         }
 
@@ -1712,7 +1678,6 @@ namespace NonVisuals.Radios
                                 SetPZ69DisplayBytesUnsignedInteger(ref bytes, Convert.ToUInt32(_uhfCockpitPresetChannel), PZ69LCDPosition.UPPER_STBY_RIGHT);
                                 SetPZ69DisplayBytesUnsignedInteger(ref bytes, _interCommCockpitDial1Pos, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
                             }
-
                             break;
                         }
 
@@ -1729,7 +1694,6 @@ namespace NonVisuals.Radios
                                         PZ69LCDPosition.UPPER_STBY_RIGHT);
                                 }
                             }
-
                             break;
                         }
 
@@ -1763,7 +1727,6 @@ namespace NonVisuals.Radios
                                     }
                                 }
                             }
-
                             break;
                         }
 
@@ -1792,7 +1755,6 @@ namespace NonVisuals.Radios
                                     SetPZ69DisplayBytesDefault(ref bytes, lcdFrequencyStandby, PZ69LCDPosition.UPPER_STBY_RIGHT);
                                 }
                             }
-
                             break;
                         }
 
@@ -1826,7 +1788,6 @@ namespace NonVisuals.Radios
                                     }
                                 }
                             }
-
                             break;
                         }
 
@@ -1841,7 +1802,6 @@ namespace NonVisuals.Radios
                             {
                                 SetPZ69DisplayBytesUnsignedInteger(ref bytes, Convert.ToUInt32(Math.Truncate(_adfSignalStrength)), PZ69LCDPosition.UPPER_STBY_RIGHT);
                             }
-
                             break;
                         }
                 }
@@ -1855,7 +1815,6 @@ namespace NonVisuals.Radios
                                 SetPZ69DisplayBytesUnsignedInteger(ref bytes, Convert.ToUInt32(_uhfCockpitPresetChannel), PZ69LCDPosition.LOWER_STBY_RIGHT);
                                 SetPZ69DisplayBytesUnsignedInteger(ref bytes, _interCommCockpitDial1Pos, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
                             }
-
                             break;
                         }
 
@@ -1872,7 +1831,6 @@ namespace NonVisuals.Radios
                                         PZ69LCDPosition.LOWER_STBY_RIGHT);
                                 }
                             }
-
                             break;
                         }
 
@@ -1906,7 +1864,6 @@ namespace NonVisuals.Radios
                                     }
                                 }
                             }
-
                             break;
                         }
 
@@ -1935,7 +1892,6 @@ namespace NonVisuals.Radios
                                     SetPZ69DisplayBytesDefault(ref bytes, lcdFrequencyStandby, PZ69LCDPosition.LOWER_STBY_RIGHT);
                                 }
                             }
-
                             break;
                         }
 
@@ -1969,7 +1925,6 @@ namespace NonVisuals.Radios
                                     }
                                 }
                             }
-
                             break;
                         }
 
@@ -1984,14 +1939,11 @@ namespace NonVisuals.Radios
                             {
                                 SetPZ69DisplayBytesUnsignedInteger(ref bytes, Convert.ToUInt32(Math.Truncate(_adfSignalStrength)), PZ69LCDPosition.LOWER_STBY_RIGHT);
                             }
-
                             break;
                         }
                 }
-
                 SendLCDData(bytes);
             }
-
             Interlocked.Decrement(ref _doUpdatePanelLCD);
         }
 
@@ -2019,7 +1971,6 @@ namespace NonVisuals.Radios
                                             {
                                                 DCSBIOS.Send(INTERCOMM_VOLUME_KNOB_COMMAND_DEC);
                                             }
-
                                             break;
                                         }
 
@@ -2031,7 +1982,6 @@ namespace NonVisuals.Radios
                                                 // @ max value
                                                 break;
                                             }
-
                                             _vhfCommBigFrequencyStandby++;
                                             break;
                                         }
@@ -2044,7 +1994,6 @@ namespace NonVisuals.Radios
                                                 // @ max value
                                                 break;
                                             }
-
                                             _uhfBigFrequencyStandby++;
                                             break;
                                         }
@@ -2057,7 +2006,6 @@ namespace NonVisuals.Radios
                                                 // @ max value
                                                 break;
                                             }
-
                                             _vhfFmBigFrequencyStandby++;
                                             break;
                                         }
@@ -2069,7 +2017,6 @@ namespace NonVisuals.Radios
                                                 // @ max value
                                                 break;
                                             }
-
                                             _vhfNavBigFrequencyStandby++;
                                             break;
                                         }
@@ -2080,7 +2027,6 @@ namespace NonVisuals.Radios
                                             break;
                                         }
                                 }
-
                                 break;
                             }
 
@@ -2094,7 +2040,6 @@ namespace NonVisuals.Radios
                                             {
                                                 DCSBIOS.Send(INTERCOMM_VOLUME_KNOB_COMMAND_INC);
                                             }
-
                                             break;
                                         }
 
@@ -2106,7 +2051,6 @@ namespace NonVisuals.Radios
                                                 // @ min value
                                                 break;
                                             }
-
                                             _vhfCommBigFrequencyStandby--;
                                             break;
                                         }
@@ -2118,7 +2062,6 @@ namespace NonVisuals.Radios
                                                 // @ min value
                                                 break;
                                             }
-
                                             _uhfBigFrequencyStandby--;
                                             break;
                                         }
@@ -2131,7 +2074,6 @@ namespace NonVisuals.Radios
                                                 // @ min value
                                                 break;
                                             }
-
                                             _vhfFmBigFrequencyStandby--;
                                             break;
                                         }
@@ -2143,7 +2085,6 @@ namespace NonVisuals.Radios
                                                 // @ min value
                                                 break;
                                             }
-
                                             _vhfNavBigFrequencyStandby--;
                                             break;
                                         }
@@ -2154,7 +2095,6 @@ namespace NonVisuals.Radios
                                             break;
                                         }
                                 }
-
                                 break;
                             }
 
@@ -2168,7 +2108,6 @@ namespace NonVisuals.Radios
                                             {
                                                 DCSBIOS.Send(INTERCOMM_DIAL_COMMAND_INC);
                                             }
-
                                             break;
                                         }
 
@@ -2187,7 +2126,6 @@ namespace NonVisuals.Radios
                                                 _uhfSmallFrequencyStandby = 0;
                                                 break;
                                             }
-
                                             _uhfSmallFrequencyStandby += 5;
                                             break;
                                         }
@@ -2200,7 +2138,6 @@ namespace NonVisuals.Radios
                                                 _vhfFmSmallFrequencyStandby = 0;
                                                 break;
                                             }
-
                                             _vhfFmSmallFrequencyStandby += 5;
                                             break;
                                         }
@@ -2213,7 +2150,6 @@ namespace NonVisuals.Radios
                                                 _vhfNavSmallFrequencyStandby = 0;
                                                 break;
                                             }
-
                                             _vhfNavSmallFrequencyStandby += 5;
                                             break;
                                         }
@@ -2224,7 +2160,6 @@ namespace NonVisuals.Radios
                                             break;
                                         }
                                 }
-
                                 break;
                             }
 
@@ -2238,7 +2173,6 @@ namespace NonVisuals.Radios
                                             {
                                                 DCSBIOS.Send(INTERCOMM_DIAL_COMMAND_DEC);
                                             }
-
                                             break;
                                         }
 
@@ -2256,7 +2190,6 @@ namespace NonVisuals.Radios
                                                 _uhfSmallFrequencyStandby = 95;
                                                 break;
                                             }
-
                                             _uhfSmallFrequencyStandby -= 5;
                                             break;
                                         }
@@ -2269,7 +2202,6 @@ namespace NonVisuals.Radios
                                                 _vhfFmSmallFrequencyStandby = 95;
                                                 break;
                                             }
-
                                             _vhfFmSmallFrequencyStandby -= 5;
                                             break;
                                         }
@@ -2282,7 +2214,6 @@ namespace NonVisuals.Radios
                                                 _vhfNavSmallFrequencyStandby = 95;
                                                 break;
                                             }
-
                                             _vhfNavSmallFrequencyStandby -= 5;
                                             break;
                                         }
@@ -2293,7 +2224,6 @@ namespace NonVisuals.Radios
                                             break;
                                         }
                                 }
-
                                 break;
                             }
 
@@ -2307,7 +2237,6 @@ namespace NonVisuals.Radios
                                             {
                                                 DCSBIOS.Send(INTERCOMM_VOLUME_KNOB_COMMAND_DEC);
                                             }
-
                                             break;
                                         }
 
@@ -2319,7 +2248,6 @@ namespace NonVisuals.Radios
                                                 // @ max value
                                                 break;
                                             }
-
                                             _vhfCommBigFrequencyStandby++;
                                             break;
                                         }
@@ -2332,7 +2260,6 @@ namespace NonVisuals.Radios
                                                 // @ max value
                                                 break;
                                             }
-
                                             _uhfBigFrequencyStandby++;
                                             break;
                                         }
@@ -2345,7 +2272,6 @@ namespace NonVisuals.Radios
                                                 // @ max value
                                                 break;
                                             }
-
                                             _vhfFmBigFrequencyStandby++;
                                             break;
                                         }
@@ -2357,7 +2283,6 @@ namespace NonVisuals.Radios
                                                 // @ max value
                                                 break;
                                             }
-
                                             _vhfNavBigFrequencyStandby++;
                                             break;
                                         }
@@ -2368,7 +2293,6 @@ namespace NonVisuals.Radios
                                             break;
                                         }
                                 }
-
                                 break;
                             }
 
@@ -2382,7 +2306,6 @@ namespace NonVisuals.Radios
                                             {
                                                 DCSBIOS.Send(INTERCOMM_VOLUME_KNOB_COMMAND_INC);
                                             }
-
                                             break;
                                         }
 
@@ -2394,7 +2317,6 @@ namespace NonVisuals.Radios
                                                 // @ min value
                                                 break;
                                             }
-
                                             _vhfCommBigFrequencyStandby--;
                                             break;
                                         }
@@ -2406,7 +2328,6 @@ namespace NonVisuals.Radios
                                                 // @ min value
                                                 break;
                                             }
-
                                             _uhfBigFrequencyStandby--;
                                             break;
                                         }
@@ -2419,7 +2340,6 @@ namespace NonVisuals.Radios
                                                 // @ min value
                                                 break;
                                             }
-
                                             _vhfFmBigFrequencyStandby--;
                                             break;
                                         }
@@ -2431,7 +2351,6 @@ namespace NonVisuals.Radios
                                                 // @ min value
                                                 break;
                                             }
-
                                             _vhfNavBigFrequencyStandby--;
                                             break;
                                         }
@@ -2442,7 +2361,6 @@ namespace NonVisuals.Radios
                                             break;
                                         }
                                 }
-
                                 break;
                             }
 
@@ -2456,7 +2374,6 @@ namespace NonVisuals.Radios
                                             {
                                                 DCSBIOS.Send(INTERCOMM_DIAL_COMMAND_INC);
                                             }
-
                                             break;
                                         }
 
@@ -2475,7 +2392,6 @@ namespace NonVisuals.Radios
                                                 _uhfSmallFrequencyStandby = 0;
                                                 break;
                                             }
-
                                             _uhfSmallFrequencyStandby += 5;
                                             break;
                                         }
@@ -2488,7 +2404,6 @@ namespace NonVisuals.Radios
                                                 _vhfFmSmallFrequencyStandby = 0;
                                                 break;
                                             }
-
                                             _vhfFmSmallFrequencyStandby += 5;
                                             break;
                                         }
@@ -2501,7 +2416,6 @@ namespace NonVisuals.Radios
                                                 _vhfNavSmallFrequencyStandby = 0;
                                                 break;
                                             }
-
                                             _vhfNavSmallFrequencyStandby += 5;
                                             break;
                                         }
@@ -2512,7 +2426,6 @@ namespace NonVisuals.Radios
                                             break;
                                         }
                                 }
-
                                 break;
                             }
 
@@ -2526,7 +2439,6 @@ namespace NonVisuals.Radios
                                             {
                                                 DCSBIOS.Send(INTERCOMM_DIAL_COMMAND_DEC);
                                             }
-
                                             break;
                                         }
 
@@ -2544,7 +2456,6 @@ namespace NonVisuals.Radios
                                                 _uhfSmallFrequencyStandby = 95;
                                                 break;
                                             }
-
                                             _uhfSmallFrequencyStandby -= 5;
                                             break;
                                         }
@@ -2557,7 +2468,6 @@ namespace NonVisuals.Radios
                                                 _vhfFmSmallFrequencyStandby = 95;
                                                 break;
                                             }
-
                                             _vhfFmSmallFrequencyStandby -= 5;
                                             break;
                                         }
@@ -2570,7 +2480,6 @@ namespace NonVisuals.Radios
                                                 _vhfNavSmallFrequencyStandby = 95;
                                                 break;
                                             }
-
                                             _vhfNavSmallFrequencyStandby -= 5;
                                             break;
                                         }
@@ -2581,7 +2490,6 @@ namespace NonVisuals.Radios
                                             break;
                                         }
                                 }
-
                                 break;
                             }
                     }
@@ -2606,39 +2514,14 @@ namespace NonVisuals.Radios
                  */
                 if (tmp.Length == 1)
                 {
-                    switch (frequency)
+                    result = frequency switch
                     {
-                        case 0:
-                            {
-                                result = frequency + 2;
-                                break;
-                            }
-
-                        case 2:
-                            {
-                                result = frequency + 3;
-                                break;
-                            }
-
-                        case 5:
-                            {
-                                result = frequency + 2;
-                                break;
-                            }
-
-                        case 7:
-                            {
-                                result = frequency + 3;
-                                break;
-                            }
-
-                        default:
-                            {
-                                // In case it is an invalid position invalid
-                                result = 0;
-                                break;
-                            }
-                    }
+                        0 => frequency + 2,
+                        2 => frequency + 3,
+                        5 => frequency + 2,
+                        7 => frequency + 3,
+                        _ => 0 // In case it is an invalid position invalid
+                    };
                 }
                 else if (tmp.Length == 2)
                 {
@@ -2669,39 +2552,14 @@ namespace NonVisuals.Radios
             {
                 if (tmp.Length == 1)
                 {
-                    switch (frequency)
+                    result = frequency switch
                     {
-                        case 0:
-                            {
-                                result = 97;
-                                break;
-                            }
-
-                        case 2:
-                            {
-                                result = frequency - 2;
-                                break;
-                            }
-
-                        case 5:
-                            {
-                                result = frequency - 3;
-                                break;
-                            }
-
-                        case 7:
-                            {
-                                result = frequency - 2;
-                                break;
-                            }
-
-                        default:
-                            {
-                                // In case it is in an invalid position
-                                result = 0;
-                                break;
-                            }
-                    }
+                        0 => 97,
+                        2 => frequency - 2,
+                        5 => frequency - 3,
+                        7 => frequency - 2,
+                        _ => 0 // In case it is an invalid position invalid
+                    };
                 }
                 else if (tmp.Length == 2)
                 {
@@ -2774,11 +2632,9 @@ namespace NonVisuals.Radios
                     _interCommSkipper = 0;
                     return false;
                 }
-
                 Interlocked.Increment(ref _interCommSkipper);
                 return true;
             }
-
             return false;
         }
 
@@ -2804,7 +2660,6 @@ namespace NonVisuals.Radios
                                 {
                                     _currentUpperRadioMode = CurrentUH1HRadioMode.INTERCOMM;
                                 }
-
                                 break;
                             }
 
@@ -2814,7 +2669,6 @@ namespace NonVisuals.Radios
                                 {
                                     _currentUpperRadioMode = CurrentUH1HRadioMode.VHFCOMM;
                                 }
-
                                 break;
                             }
 
@@ -2824,7 +2678,6 @@ namespace NonVisuals.Radios
                                 {
                                     _currentUpperRadioMode = CurrentUH1HRadioMode.UHF;
                                 }
-
                                 break;
                             }
 
@@ -2834,7 +2687,6 @@ namespace NonVisuals.Radios
                                 {
                                     _currentUpperRadioMode = CurrentUH1HRadioMode.VHFFM;
                                 }
-
                                 break;
                             }
 
@@ -2844,7 +2696,6 @@ namespace NonVisuals.Radios
                                 {
                                     _currentUpperRadioMode = CurrentUH1HRadioMode.VHFNAV;
                                 }
-
                                 break;
                             }
 
@@ -2854,7 +2705,6 @@ namespace NonVisuals.Radios
                                 {
                                     _currentUpperRadioMode = CurrentUH1HRadioMode.ADF;
                                 }
-
                                 break;
                             }
 
@@ -2869,7 +2719,6 @@ namespace NonVisuals.Radios
                                 {
                                     _currentLowerRadioMode = CurrentUH1HRadioMode.INTERCOMM;
                                 }
-
                                 break;
                             }
 
@@ -2879,7 +2728,6 @@ namespace NonVisuals.Radios
                                 {
                                     _currentLowerRadioMode = CurrentUH1HRadioMode.VHFCOMM;
                                 }
-
                                 break;
                             }
 
@@ -2889,7 +2737,6 @@ namespace NonVisuals.Radios
                                 {
                                     _currentLowerRadioMode = CurrentUH1HRadioMode.UHF;
                                 }
-
                                 break;
                             }
 
@@ -2899,7 +2746,6 @@ namespace NonVisuals.Radios
                                 {
                                     _currentLowerRadioMode = CurrentUH1HRadioMode.VHFFM;
                                 }
-
                                 break;
                             }
 
@@ -2909,7 +2755,6 @@ namespace NonVisuals.Radios
                                 {
                                     _currentLowerRadioMode = CurrentUH1HRadioMode.VHFNAV;
                                 }
-
                                 break;
                             }
 
@@ -2919,7 +2764,6 @@ namespace NonVisuals.Radios
                                 {
                                     _currentLowerRadioMode = CurrentUH1HRadioMode.ADF;
                                 }
-
                                 break;
                             }
 
@@ -2984,7 +2828,6 @@ namespace NonVisuals.Radios
                                         SendFrequencyToDCSBIOS(RadioPanelPZ69KnobsUH1H.UPPER_FREQ_SWITCH);
                                     }
                                 }
-
                                 break;
                             }
 
@@ -3004,7 +2847,6 @@ namespace NonVisuals.Radios
                                         SendFrequencyToDCSBIOS(RadioPanelPZ69KnobsUH1H.LOWER_FREQ_SWITCH);
                                     }
                                 }
-
                                 break;
                             }
                     }
@@ -3020,7 +2862,6 @@ namespace NonVisuals.Radios
                             null);
                     }
                 }
-
                 AdjustFrequency(hashSet);
             }
         }

--- a/Source/NonVisuals/Radios/RadiopanelPZ69P47D.cs
+++ b/Source/NonVisuals/Radios/RadiopanelPZ69P47D.cs
@@ -284,7 +284,6 @@
                                     {
                                         SetUpperRadioMode(CurrentP47DRadioMode.NOUSE);
                                     }
-
                                     break;
                                 }
 
@@ -294,7 +293,6 @@
                                     {
                                         SetLowerRadioMode(CurrentP47DRadioMode.HFRADIO);
                                     }
-
                                     break;
                                 }
 
@@ -317,7 +315,6 @@
                                     {
                                         SetLowerRadioMode(CurrentP47DRadioMode.NOUSE);
                                     }
-
                                     break;
                                 }
 
@@ -343,7 +340,6 @@
                                             DCSBIOS.Send(HF_RADIO_LIGHT_SWITCH_COMMAND);
                                         }
                                     }
-
                                     break;
                                 }
 
@@ -356,7 +352,6 @@
                                             DCSBIOS.Send(HF_RADIO_LIGHT_SWITCH_COMMAND);
                                         }
                                     }
-
                                     break;
                                 }
                         }
@@ -372,7 +367,6 @@
                                 null);
                         }
                     }
-
                     AdjustFrequency(hashSet);
                 }
             }
@@ -413,7 +407,6 @@
                                                         DCSBIOS.Send(s);
                                                     }
                                                 }
-
                                                 break;
                                             }
 
@@ -430,7 +423,6 @@
                                                 break;
                                             }
                                     }
-
                                     break;
                                 }
 
@@ -449,7 +441,6 @@
                                                         DCSBIOS.Send(s);
                                                     }
                                                 }
-
                                                 break;
                                             }
 
@@ -462,7 +453,6 @@
                                                 break;
                                             }*/
                                     }
-
                                     break;
                                 }
 
@@ -481,7 +471,6 @@
                                                         DCSBIOS.Send(s);
                                                     }
                                                 }
-
                                                 break;
                                             }
 
@@ -494,7 +483,6 @@
                                                 break;
                                             }*/
                                     }
-
                                     break;
                                 }
 
@@ -513,7 +501,6 @@
                                                         DCSBIOS.Send(s);
                                                     }
                                                 }
-
                                                 break;
                                             }
 
@@ -526,7 +513,6 @@
                                                 break;
                                             }*/
                                     }
-
                                     break;
                                 }
 
@@ -545,7 +531,6 @@
                                                         DCSBIOS.Send(s);
                                                     }
                                                 }
-
                                                 break;
                                             }
 
@@ -558,7 +543,6 @@
                                                 break;
                                             }*/
                                     }
-
                                     break;
                                 }
 
@@ -577,7 +561,6 @@
                                                         DCSBIOS.Send(s);
                                                     }
                                                 }
-
                                                 break;
                                             }
 
@@ -590,7 +573,6 @@
                                                 break;
                                             }*/
                                     }
-
                                     break;
                                 }
 
@@ -609,7 +591,6 @@
                                                         DCSBIOS.Send(s);
                                                     }
                                                 }
-
                                                 break;
                                             }
 
@@ -622,7 +603,6 @@
                                                 break;
                                             }*/
                                     }
-
                                     break;
                                 }
 
@@ -641,7 +621,6 @@
                                                         DCSBIOS.Send(s);
                                                     }
                                                 }
-
                                                 break;
                                             }
 
@@ -654,13 +633,11 @@
                                                 break;
                                             }*/
                                     }
-
                                     break;
                                 }
                         }
                     }
                 }
-
                 ShowFrequenciesOnPanel();
             }
             catch (Exception ex)
@@ -851,7 +828,7 @@
 
         public override DcsOutputAndColorBinding CreateDcsOutputAndColorBinding(SaitekPanelLEDPosition saitekPanelLEDPosition, PanelLEDColor panelLEDColor, DCSBIOSOutput dcsBiosOutput)
         {
-            var dcsOutputAndColorBinding = new DcsOutputAndColorBindingPZ55
+            DcsOutputAndColorBindingPZ55 dcsOutputAndColorBinding = new()
             {
                 DCSBiosOutputLED = dcsBiosOutput,
                 LEDColor = panelLEDColor,
@@ -902,7 +879,6 @@
                         _hfRadioChannelPresetDialSkipper = 0;
                         return false;
                     }
-
                     _hfRadioChannelPresetDialSkipper++;
                     return true;
                 }
@@ -911,7 +887,6 @@
             {
                 logger.Error(ex);
             }
-
             return false;
         }
 
@@ -971,7 +946,6 @@
                         _hfRadioModePresetDialSkipper = 0;
                         return false;
                     }
-
                     _hfRadioModePresetDialSkipper++;
                     return true;
                 }
@@ -980,7 +954,6 @@
             {
                 logger.Error(ex);
             }
-
             return false;
         }
 
@@ -1034,7 +1007,6 @@
                     }
                 }
             }
-
             return null;
         }
 
@@ -1046,7 +1018,6 @@
                 {
                     return "RCTRL_T_MODE " + (_hfRadioModeCockpitDialPosition + 1) + "\n";
                 }
-
                 return "RCTRL_T_MODE " + (_hfRadioModeCockpitDialPosition - 1) + "\n";
             }
         }

--- a/Source/NonVisuals/Radios/RadiopanelPZ69P47D.cs
+++ b/Source/NonVisuals/Radios/RadiopanelPZ69P47D.cs
@@ -45,42 +45,24 @@
         *  COM1 Small Fine Channel/OFF 0 => 4
         *  Freq. Selector Light Switch        
         */
-        private readonly object _lockHFRadioPresetDialObject1 = new object();
-
+        private readonly object _lockHFRadioPresetDialObject1 = new();
         private DCSBIOSOutput _hfRadioOffDcsbiosOutput;
-
         private DCSBIOSOutput _hfRadioChannelAPresetDcsbiosOutput;
-
         private DCSBIOSOutput _hfRadioChannelBPresetDcsbiosOutput;
-
         private DCSBIOSOutput _hfRadioChannelCPresetDcsbiosOutput;
-
         private DCSBIOSOutput _hfRadioChannelDPresetDcsbiosOutput;
-
         private volatile uint _hfRadioOffCockpitButton = 1;
-
         private volatile uint _hfRadioChannelACockpitButton;
-
         private volatile uint _hfRadioChannelBCockpitButton;
-
         private volatile uint _hfRadioChannelCCockpitButton;
-
         private volatile uint _hfRadioChannelDCockpitButton;
-
         private int _hfRadioChannelPresetDialSkipper;
-
         private const string HF_RADIO_LIGHT_SWITCH_COMMAND = "RCTRL_DIM TOGGLE\n";
-
-        private readonly object _lockHFRadioModeDialObject1 = new object();
-
+        private readonly object _lockHFRadioModeDialObject1 = new();
         private volatile uint _hfRadioModeCockpitDialPosition = 1;
-
         private DCSBIOSOutput _hfRadioModeDialPresetDcsbiosOutput;
-
         private int _hfRadioModePresetDialSkipper;
-
-        private readonly object _lockShowFrequenciesOnPanelObject = new object();
-
+        private readonly object _lockShowFrequenciesOnPanelObject = new();
         private long _doUpdatePanelLCD;
 
         public RadioPanelPZ69P47D(HIDSkeleton hidSkeleton)

--- a/Source/NonVisuals/Radios/RadiopanelSpitfireLFMkIX.cs
+++ b/Source/NonVisuals/Radios/RadiopanelSpitfireLFMkIX.cs
@@ -278,7 +278,6 @@
                                     {
                                         SetUpperRadioMode(CurrentSpitfireLFMkIXRadioMode.HFRADIO);
                                     }
-
                                     break;
                                 }
 
@@ -288,7 +287,6 @@
                                     {
                                         SetUpperRadioMode(CurrentSpitfireLFMkIXRadioMode.IFF);
                                     }
-
                                     break;
                                 }
 
@@ -302,7 +300,6 @@
                                     {
                                         SetUpperRadioMode(CurrentSpitfireLFMkIXRadioMode.NOUSE);
                                     }
-
                                     break;
                                 }
 
@@ -312,7 +309,6 @@
                                     {
                                         SetLowerRadioMode(CurrentSpitfireLFMkIXRadioMode.HFRADIO);
                                     }
-
                                     break;
                                 }
 
@@ -322,7 +318,6 @@
                                     {
                                         SetLowerRadioMode(CurrentSpitfireLFMkIXRadioMode.IFF);
                                     }
-
                                     break;
                                 }
 
@@ -336,7 +331,6 @@
                                     {
                                         SetLowerRadioMode(CurrentSpitfireLFMkIXRadioMode.NOUSE);
                                     }
-
                                     break;
                                 }
 
@@ -362,7 +356,6 @@
                                             DCSBIOS.Send(HF_RADIO_LIGHT_SWITCH_COMMAND);
                                         }
                                     }
-
                                     break;
                                 }
 
@@ -375,7 +368,6 @@
                                             DCSBIOS.Send(HF_RADIO_LIGHT_SWITCH_COMMAND);
                                         }
                                     }
-
                                     break;
                                 }
                         }
@@ -432,7 +424,6 @@
                                                         DCSBIOS.Send(s);
                                                     }
                                                 }
-
                                                 break;
                                             }
 
@@ -442,7 +433,6 @@
                                                 {
                                                     DCSBIOS.Send(IFFD_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
 
@@ -451,7 +441,6 @@
                                                 break;
                                             }
                                     }
-
                                     break;
                                 }
 
@@ -470,7 +459,6 @@
                                                         DCSBIOS.Send(s);
                                                     }
                                                 }
-
                                                 break;
                                             }
 
@@ -480,11 +468,9 @@
                                                 {
                                                     DCSBIOS.Send(IFFD_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
                                     }
-
                                     break;
                                 }
 
@@ -503,7 +489,6 @@
                                                         DCSBIOS.Send(s);
                                                     }
                                                 }
-
                                                 break;
                                             }
 
@@ -513,11 +498,9 @@
                                                 {
                                                     DCSBIOS.Send(IFFB_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
                                     }
-
                                     break;
                                 }
 
@@ -536,7 +519,6 @@
                                                         DCSBIOS.Send(s);
                                                     }
                                                 }
-
                                                 break;
                                             }
 
@@ -546,11 +528,9 @@
                                                 {
                                                     DCSBIOS.Send(IFFB_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
                                     }
-
                                     break;
                                 }
 
@@ -569,7 +549,6 @@
                                                         DCSBIOS.Send(s);
                                                     }
                                                 }
-
                                                 break;
                                             }
 
@@ -579,11 +558,9 @@
                                                 {
                                                     DCSBIOS.Send(IFFD_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
                                     }
-
                                     break;
                                 }
 
@@ -602,7 +579,6 @@
                                                         DCSBIOS.Send(s);
                                                     }
                                                 }
-
                                                 break;
                                             }
 
@@ -612,11 +588,9 @@
                                                 {
                                                     DCSBIOS.Send(IFFD_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
                                     }
-
                                     break;
                                 }
 
@@ -635,7 +609,6 @@
                                                         DCSBIOS.Send(s);
                                                     }
                                                 }
-
                                                 break;
                                             }
 
@@ -645,11 +618,9 @@
                                                 {
                                                     DCSBIOS.Send(IFFB_COMMAND_INC);
                                                 }
-
                                                 break;
                                             }
                                     }
-
                                     break;
                                 }
 
@@ -668,7 +639,6 @@
                                                         DCSBIOS.Send(s);
                                                     }
                                                 }
-
                                                 break;
                                             }
 
@@ -678,11 +648,9 @@
                                                 {
                                                     DCSBIOS.Send(IFFB_COMMAND_DEC);
                                                 }
-
                                                 break;
                                             }
                                     }
-
                                     break;
                                 }
                         }
@@ -835,7 +803,6 @@
                                 break;
                             }
                     }
-
                     SendLCDData(bytes);
                 }
             }
@@ -933,7 +900,6 @@
                         _hfRadioChannelPresetDialSkipper = 0;
                         return false;
                     }
-
                     _hfRadioChannelPresetDialSkipper++;
                     return true;
                 }
@@ -942,7 +908,6 @@
             {
                 logger.Error(ex);
             }
-
             return false;
         }
 
@@ -957,7 +922,6 @@
                         _iffDiffDialSkipper = 0;
                         return false;
                     }
-
                     _iffDiffDialSkipper++;
                     return true;
                 }
@@ -966,7 +930,6 @@
             {
                 logger.Error(ex);
             }
-
             return false;
         }
 
@@ -981,7 +944,6 @@
                         _iffBiffDialSkipper = 0;
                         return false;
                     }
-
                     _iffBiffDialSkipper++;
                     return true;
                 }
@@ -990,7 +952,6 @@
             {
                 logger.Error(ex);
             }
-
             return false;
         }
 
@@ -1005,7 +966,6 @@
                         _hfRadioModePresetDialSkipper = 0;
                         return false;
                     }
-
                     _hfRadioModePresetDialSkipper++;
                     return true;
                 }
@@ -1014,7 +974,6 @@
             {
                 logger.Error(ex);
             }
-
             return false;
         }
 
@@ -1068,7 +1027,6 @@
                     }
                 }
             }
-
             return null;
         }
 
@@ -1080,7 +1038,6 @@
                 {
                     return "RCTRL_T_MODE " + (_hfRadioModeCockpitDialPosition + 1) + "\n";
                 }
-
                 return "RCTRL_T_MODE " + (_hfRadioModeCockpitDialPosition - 1) + "\n";
             }
         }

--- a/Source/NonVisuals/Radios/RadiopanelSpitfireLFMkIX.cs
+++ b/Source/NonVisuals/Radios/RadiopanelSpitfireLFMkIX.cs
@@ -45,38 +45,22 @@
         *  COM1 Small Fine Channel/OFF 0 => 4
         *  Freq. Selector Light Switch        
         */
-        private readonly object _lockHFRadioPresetDialObject1 = new object();
-
+        private readonly object _lockHFRadioPresetDialObject1 = new();
         private DCSBIOSOutput _hfRadioOffDcsbiosOutput;
-
         private DCSBIOSOutput _hfRadioChannelAPresetDcsbiosOutput;
-
         private DCSBIOSOutput _hfRadioChannelBPresetDcsbiosOutput;
-
         private DCSBIOSOutput _hfRadioChannelCPresetDcsbiosOutput;
-
         private DCSBIOSOutput _hfRadioChannelDPresetDcsbiosOutput;
-
         private volatile uint _hfRadioOffCockpitButton = 1;
-
         private volatile uint _hfRadioChannelACockpitButton;
-
         private volatile uint _hfRadioChannelBCockpitButton;
-
         private volatile uint _hfRadioChannelCCockpitButton;
-
         private volatile uint _hfRadioChannelDCockpitButton;
-
         private int _hfRadioChannelPresetDialSkipper;
-
         private const string HF_RADIO_LIGHT_SWITCH_COMMAND = "RCTRL_DIM TOGGLE\n";
-
-        private readonly object _lockHFRadioModeDialObject1 = new object();
-
+        private readonly object _lockHFRadioModeDialObject1 = new();
         private volatile uint _hfRadioModeCockpitDialPosition = 1;
-
         private DCSBIOSOutput _hfRadioModeDialPresetDcsbiosOutput;
-
         private int _hfRadioModePresetDialSkipper;
 
         /* 
@@ -84,30 +68,18 @@
                 *  COM2 Small IFF Circuit B
                 *  COM2 ACT/STBY IFF Destruction
                 */
-        private readonly object _lockIFFDialObject1 = new object();
-
+        private readonly object _lockIFFDialObject1 = new();
         private DCSBIOSOutput _iffBiffDcsbiosOutputDial;
-
         private DCSBIOSOutput _iffDiffDcsbiosOutputDial;
-
         private volatile uint _iffBiffCockpitDialPos = 1;
-
         private volatile uint _iffDiffCockpitDialPos;
-
         private int _iffBiffDialSkipper;
-
         private int _iffDiffDialSkipper;
-
         private const string IFFB_COMMAND_INC = "IFF_B INC\n";
-
         private const string IFFB_COMMAND_DEC = "IFF_B DEC\n";
-
         private const string IFFD_COMMAND_INC = "IFF_D INC\n";
-
         private const string IFFD_COMMAND_DEC = "IFF_D DEC\n";
-
-        private readonly object _lockShowFrequenciesOnPanelObject = new object();
-
+        private readonly object _lockShowFrequenciesOnPanelObject = new();
         private long _doUpdatePanelLCD;
 
         public RadioPanelPZ69SpitfireLFMkIX(HIDSkeleton hidSkeleton)


### PR DESCRIPTION
I swear it's the last big PR on the radios.

I tried to standardize a little the code between all the preprogrammed radios, mainly by removing unnecessary blank lines.

* The removing of the blank lines has been done without impeding code readability.
* Some simple pattern matching switches have been introduced for replacing long switch / case.
* In some generic radio classes, I replaced a lot of 'var' with the explicit type, I think it makes the code more understandable when reading, you directly see what object or type you are dealing with.

Tested some airframes and everything seems fine. All the changes are mainly syntax sugar without any impact on the logic.
