### PR TITLE
[StreamDeck] Improvement on button previews

### DIFF
--- a/Source/DCSFlightpanels/PanelUserControls/StreamDeck/UserControlStreamDeckButtonFace.xaml
+++ b/Source/DCSFlightpanels/PanelUserControls/StreamDeck/UserControlStreamDeckButtonFace.xaml
@@ -49,7 +49,7 @@
             <StackPanel Name="StackPanelButtonTextImage"  Grid.Column="1" MouseDown="MouseDownFocusLogTextBox" Margin="10,5,10,0" Visibility="Collapsed">
                 <Label Content="Choose Button Text and Color" Background="#e6e6e6" HorizontalContentAlignment="Center" Margin="0,5,0,0"  />
                 <StackPanel Orientation="Horizontal" Margin="0,5,0,0">
-                    <customControl:StreamDeckFaceTextBox x:Name="TextBoxButtonTextFace" FontSize="10" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Height="72" Width="72"  TextWrapping="Wrap" AcceptsReturn="True" HorizontalAlignment="Left" Margin="4,0,0,0" TextChanged="TextBoxButtonTextFace_OnTextChanged"  KeyUp="TextBoxButtonTextFace_OnKeyUp" />
+                    <customControl:StreamDeckFaceTextBox x:Name="TextBoxButtonTextFace" FontSize="10" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Height="72" Width="72"  TextWrapping="Wrap" AcceptsReturn="True" HorizontalAlignment="Left" Margin="0,0,0,10" TextChanged="TextBoxButtonTextFace_OnTextChanged"  KeyUp="TextBoxButtonTextFace_OnKeyUp" />
                     <StackPanel>
                         <RepeatButton Name="RepeatButtonActionPressUp" Content="{StaticResource UpArrow}" Height="{StaticResource ArrowHeight}" Click="RepeatButtonActionPressUp_OnClick"/>
                         <RepeatButton Name="RepeatButtonActionPressDown" Content="{StaticResource DownArrow}" Height="{StaticResource ArrowHeight}" Click="RepeatButtonActionPressDown_OnClick"/>
@@ -63,8 +63,13 @@
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Margin="0,2,0,0" >
                             <Button Name="ButtonTextFaceBackgroundColor" Width="80" Height="20" Content="Background" Margin="10,2,2,0" Click="ButtonTextFaceBackgroundColor_OnClick"/>
-                            <Button Name="ButtonTestTextFace" Width="40" Height="20" Content="Test" Margin="0,2,2,0" Click="ButtonTestTextFace_OnClick"/>
                         </StackPanel>
+                    </StackPanel>
+                    <StackPanel>
+                        <Border BorderThickness="1" BorderBrush="#FF000000" HorizontalAlignment="Left" Height="73" Width="73" Margin="10,3,0,0">
+                            <Image x:Name="TextBoxImagePreview" Height="72" Width="72">
+                            </Image>
+                        </Border>
                     </StackPanel>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal">
@@ -89,7 +94,7 @@
                 <StackPanel Orientation="Horizontal" Margin="0,5,0,0">
                     <Button Name="ButtonBrowseForImage" Width="65" Content="Browse..." Margin="0,2,2,0" Click="ButtonBrowseForImage_OnClick"/>
                 </StackPanel>
-                <Border BorderThickness="1" BorderBrush="#FF000000" HorizontalAlignment="Left" Height="73" Width="73" Margin="10,20,0,0">
+                <Border BorderThickness="1" BorderBrush="#FF000000" HorizontalAlignment="Left" Height="73" Width="73" Margin="00,20,0,0">
                     <Image x:Name="ButtonImagePreview" Height="72" Width="72">
                     </Image>
                 </Border>

--- a/Source/DCSFlightpanels/PanelUserControls/StreamDeck/UserControlStreamDeckButtonFace.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/StreamDeck/UserControlStreamDeckButtonFace.xaml.cs
@@ -111,7 +111,6 @@ namespace DCSFlightpanels.PanelUserControls.StreamDeck
                 ButtonTextFaceFont.IsEnabled = !string.IsNullOrEmpty(TextBoxButtonTextFace.Text);
                 ButtonTextFaceFontColor.IsEnabled = !string.IsNullOrEmpty(TextBoxButtonTextFace.Text);
                 ButtonTextFaceBackgroundColor.IsEnabled = !string.IsNullOrEmpty(TextBoxButtonTextFace.Text);
-                ButtonTestTextFace.IsEnabled = !string.IsNullOrEmpty(TextBoxButtonTextFace.Text);
 
                 DisplayImagePreview();
             }
@@ -127,6 +126,11 @@ namespace DCSFlightpanels.PanelUserControls.StreamDeck
             {
                 var bitmap = BitMapCreator.BitmapOrFileNotFound(TextBoxImageFace.Bill.ImageFileRelativePath);
                 ButtonImagePreview.Source = BitMapCreator.Bitmap2BitmapImage(bitmap);
+            }
+            if (TextBoxButtonTextFace.Bill.ContainsTextFace())
+            {
+                var bitmap = BitMapCreator.CreateStreamDeckBitmap(TextBoxButtonTextFace.Text, TextBoxButtonTextFace.Bill.TextFont, TextBoxButtonTextFace.Bill.FontColor, TextBoxButtonTextFace.Bill.OffsetX, TextBoxButtonTextFace.Bill.OffsetY, TextBoxButtonTextFace.Bill.BackgroundColor);
+                TextBoxImagePreview.Source = BitMapCreator.Bitmap2BitmapImage(bitmap);
             }
         }
 
@@ -274,19 +278,6 @@ namespace DCSFlightpanels.PanelUserControls.StreamDeck
                     SetIsDirty();
 
                 }
-                TextBoxButtonTextFace.TestImage(_streamDeckPanel);
-                SetFormState();
-            }
-            catch (Exception ex)
-            {
-                Common.ShowErrorMessageBox(ex);
-            }
-        }
-
-        private void ButtonTestTextFace_OnClick(object sender, RoutedEventArgs e)
-        {
-            try
-            {
                 TextBoxButtonTextFace.TestImage(_streamDeckPanel);
                 SetFormState();
             }
@@ -499,7 +490,7 @@ namespace DCSFlightpanels.PanelUserControls.StreamDeck
                 TextBoxButtonTextFace.Bill.OffsetY -= StreamDeckConstants.ADJUST_OFFSET_CHANGE_VALUE;
                 TextBoxOffsetInfo.OffSetY = TextBoxButtonTextFace.Bill.OffsetY;
                 SettingsManager.OffsetY = TextBoxButtonTextFace.Bill.OffsetY;
-                TextBoxButtonTextFace.TestImage(_streamDeckPanel);
+                TextBoxButtonTextFace.TestImage(_streamDeckPanel);                
                 SetIsDirty();
             }
             catch (Exception ex)
@@ -507,7 +498,6 @@ namespace DCSFlightpanels.PanelUserControls.StreamDeck
                 Common.ShowErrorMessageBox(ex);
             }
         }
-
         private void RepeatButtonActionPressDown_OnClick(object sender, RoutedEventArgs e)
         {
             try

--- a/Source/DCSFlightpanels/Windows/StreamDeck/StreamDeckDCSBIOSConverterWindow.xaml
+++ b/Source/DCSFlightpanels/Windows/StreamDeck/StreamDeckDCSBIOSConverterWindow.xaml
@@ -187,7 +187,6 @@
                         <customControls:StreamDeckFaceTextBox FontSize="10" Height="18"  Margin="0,0,10,0" Width="300" IsReadOnly="True" x:Name="TextBoxOverlayImagePath"  IsEnabled="False" Background="LightSteelBlue"/>
                         <StackPanel Orientation="Horizontal" Margin="0,5,0,0">
                             <Button Name="ButtonBrowseOverlayImage" Width="65" Content="Browse..." Margin="0,2,2,0" Click="ButtonBrowseImage_OnClick"/>
-                            <Button Name="ButtonTestSelectOverlayImage" Width="65" Content="Test"  Margin="0,2,2,0" Click="ButtonTestDCSBIOSDecoder_OnClick"/>
                         </StackPanel>
                     </StackPanel>
                 </GroupBox>

--- a/Source/DCSFlightpanels/Windows/StreamDeck/StreamDeckDCSBIOSConverterWindow.xaml
+++ b/Source/DCSFlightpanels/Windows/StreamDeck/StreamDeckDCSBIOSConverterWindow.xaml
@@ -147,7 +147,7 @@
                             <Button Name="ButtonTestSelectImage" Width="65" Content="Test"  Margin="0,2,2,0" Click="ButtonTestDCSBIOSDecoder_OnClick"/>
                         </StackPanel>
                         <StackPanel  Margin="0,0,0,0" Orientation="Horizontal">
-                            <Border BorderThickness="1" BorderBrush="#FF000000" HorizontalAlignment="Left" Height="73" Width="73" Margin="10,10,5,5">
+                            <Border BorderThickness="1" BorderBrush="#FF000000" HorizontalAlignment="Left" Height="73" Width="73" Margin="0,10,0,5">
                                 <Image Name="ButtonImagePreviewImage"  Height="72" Width="72" Margin="0,0,0,0"/>
                             </Border>
                         </StackPanel>


### PR DESCRIPTION
Improvements in code and preview button
* Fixed overlay text on image that was previously only displaying the background image.
* Added preview on static text construction.
* Minor adjustment in control position
* Removing duplicate or useless "Test" button


![Text overlay on image fix](https://user-images.githubusercontent.com/67550369/199224132-69dc715b-c9cc-4cbe-b256-636006812fc0.jpg)

 
![StaticText_Preview](https://user-images.githubusercontent.com/67550369/199224182-6b17fcd3-7548-4dcf-addb-9e1ff149bd70.jpg)

Lot of small PRs regarding StreamDeck improvement but I prefer this way since it's quite extensive code.