### PR TITLE
[Code analysis] Reduce compilation messages count

### DIFF
--- a/Source/.editorconfig
+++ b/Source/.editorconfig
@@ -1,0 +1,86 @@
+
+[*.{cs,vb}]
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_compound_assignment = true:suggestion
+dotnet_style_prefer_simplified_interpolation = true:suggestion
+dotnet_style_namespace_match_folder = true:suggestion
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+tab_width = 4
+indent_size = 4
+end_of_line = crlf
+
+[*.cs]
+csharp_using_directive_placement = outside_namespace:silent
+csharp_prefer_simple_using_statement = true:suggestion
+csharp_prefer_braces = true:silent
+csharp_style_namespace_declarations = block_scoped:silent
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_prefer_top_level_statements = true:silent
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = false:silent
+csharp_style_throw_expression = true:suggestion
+csharp_indent_labels = one_less_than_current
+csharp_style_prefer_range_operator = true:silent

--- a/Source/ClassLibraryCommon/Common.cs
+++ b/Source/ClassLibraryCommon/Common.cs
@@ -66,7 +66,7 @@
             };
         }
 
-        public static readonly List<GamingPanelSkeleton> GamingPanelSkeletons = new List<GamingPanelSkeleton>
+        public static readonly List<GamingPanelSkeleton> GamingPanelSkeletons = new()
         {
             new GamingPanelSkeleton(GamingPanelVendorEnum.Saitek, GamingPanelEnum.PZ55SwitchPanel),
             new GamingPanelSkeleton(GamingPanelVendorEnum.Saitek, GamingPanelEnum.PZ69RadioPanel),

--- a/Source/ClassLibraryCommon/EnumEx.cs
+++ b/Source/ClassLibraryCommon/EnumEx.cs
@@ -33,7 +33,7 @@
                 }
             }
 
-            throw new ArgumentException($"Could not find enum value {description} in enum {typeof(T)}", "description");
+            throw new ArgumentException($"Could not find enum value {description} in enum {typeof(T)}", nameof(description));
         }
         
         public static IEnumerable<T> GetValues<T>()

--- a/Source/DCS-BIOS/JaceExtended.cs
+++ b/Source/DCS-BIOS/JaceExtended.cs
@@ -32,7 +32,7 @@ namespace DCS_BIOS
             }
         }
 
-        private void AddFunctions()
+        private static void AddFunctions()
         {
             //_calculationEngine.AddFunction("floor", Math.Floor);
             //_calculationEngine.AddFunction("ceiling", Math.Ceiling);

--- a/Source/DCSFlightpanels.local.sln
+++ b/Source/DCSFlightpanels.local.sln
@@ -19,6 +19,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MEF", "MEF\MEF.csproj", "{0
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{6CF35974-7D78-4027-BB40-76E724C4CE14}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		ExecutePublishReleaseVersion.cmd = ExecutePublishReleaseVersion.cmd
 		PublishReleaseVersion.ps1 = PublishReleaseVersion.ps1
 	EndProjectSection

--- a/Source/DCSFlightpanels/App.xaml.cs
+++ b/Source/DCSFlightpanels/App.xaml.cs
@@ -17,21 +17,21 @@ namespace DCSFlightpanels
 
         private void InitNotificationIcon()
         {
-            System.Windows.Forms.ToolStripMenuItem notifyIconContextMenuShow = new System.Windows.Forms.ToolStripMenuItem
+            System.Windows.Forms.ToolStripMenuItem notifyIconContextMenuShow = new()
             {
                // Index = 0,
                 Text = "Show"
             };
             notifyIconContextMenuShow.Click += new EventHandler(NotifyIcon_Show);
 
-            System.Windows.Forms.ToolStripMenuItem notifyIconContextMenuQuit = new System.Windows.Forms.ToolStripMenuItem
+            System.Windows.Forms.ToolStripMenuItem notifyIconContextMenuQuit = new()
             {
               //  Index = 1,
                 Text = "Quit"
             };
             notifyIconContextMenuQuit.Click += new EventHandler(NotifyIcon_Quit);
 
-            System.Windows.Forms.ContextMenuStrip notifyIconContextMenu = new System.Windows.Forms.ContextMenuStrip();
+            System.Windows.Forms.ContextMenuStrip notifyIconContextMenu = new();
             notifyIconContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripMenuItem[] { notifyIconContextMenuShow, notifyIconContextMenuQuit });
 
             _notifyIcon = new System.Windows.Forms.NotifyIcon

--- a/Source/DCSFlightpanels/MainWindow.xaml.cs
+++ b/Source/DCSFlightpanels/MainWindow.xaml.cs
@@ -181,7 +181,7 @@
         /// Try to find the path of the log with a file target given as parameter
         /// See NLog.config in the main folder of the application for configured log targets
         /// </summary>
-        private string GetLogFilePathByTarget(string targetName)
+        private static string GetLogFilePathByTarget(string targetName)
         {
             string fileName;
             if (LogManager.Configuration != null && LogManager.Configuration.ConfiguredNamedTargets.Count != 0)
@@ -1411,12 +1411,12 @@
             }
         }
 
-        public void DeviceAttached(GamingPanelEnum gamingPanelsEnum)
+        public static void DeviceAttached(GamingPanelEnum gamingPanelsEnum)
         {
             // ignore
         }
 
-        public void DeviceDetached(GamingPanelEnum gamingPanelsEnum)
+        public static void DeviceDetached(GamingPanelEnum gamingPanelsEnum)
         {
             // ignore
         }
@@ -1462,7 +1462,7 @@
             }
         }
 
-        private void TryOpenLogFileWithTarget(string targetName)
+        private static void TryOpenLogFileWithTarget(string targetName)
         {
             try
             {
@@ -1672,7 +1672,7 @@
             informationWindow.ShowDialog();
         }
 
-        private string GetProductId(string saitekVID, string usbDeviceKeyName)
+        private static string GetProductId(string saitekVID, string usbDeviceKeyName)
         {
             var pos = usbDeviceKeyName.IndexOf("&", StringComparison.InvariantCulture);
             var vid = usbDeviceKeyName.Substring(0, pos);

--- a/Source/DCSFlightpanels/PanelUserControls/BackLitPanelUserControl.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/BackLitPanelUserControl.xaml.cs
@@ -226,7 +226,7 @@
             }
         }
 
-        private BIPLedPositionEnum GetLedPosition(string imageName)
+        private static BIPLedPositionEnum GetLedPosition(string imageName)
         {
             var result = BIPLedPositionEnum.Position_1_1;
             //ImagePosition3_4

--- a/Source/DCSFlightpanels/PanelUserControls/PreProgrammed/Cdu737UserControlA10C.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/PreProgrammed/Cdu737UserControlA10C.xaml.cs
@@ -100,7 +100,7 @@
         {
 
         }
-        private void HideAllImages()
+        private static void HideAllImages()
         {
 
         }

--- a/Source/DCSFlightpanels/PanelUserControls/PreProgrammed/Cdu737UserControlAH64D.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/PreProgrammed/Cdu737UserControlAH64D.xaml.cs
@@ -114,7 +114,7 @@ namespace DCSFlightpanels.PanelUserControls.PreProgrammed
             ));
 
         }
-        private void HideAllImages()
+        private static void HideAllImages()
         {
         }
 

--- a/Source/DCSFlightpanels/PanelUserControls/PreProgrammed/Cdu737UserControlF14.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/PreProgrammed/Cdu737UserControlF14.xaml.cs
@@ -100,7 +100,7 @@
         {
 
         }
-        private void HideAllImages()
+        private static void HideAllImages()
         {
 
         }

--- a/Source/DCSFlightpanels/PanelUserControls/PreProgrammed/Cdu737UserControlFA18C.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/PreProgrammed/Cdu737UserControlFA18C.xaml.cs
@@ -100,7 +100,7 @@
         {
 
         }
-        private void HideAllImages()
+        private static void HideAllImages()
         {
 
         }

--- a/Source/DCSFlightpanels/PanelUserControls/PreProgrammed/Cdu737UserControlM2000C.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/PreProgrammed/Cdu737UserControlM2000C.xaml.cs
@@ -99,7 +99,7 @@
         {
 
         }
-        private void HideAllImages()
+        private static void HideAllImages()
         {
 
         }

--- a/Source/DCSFlightpanels/PanelUserControls/PreProgrammed/Cdu737UserControlSA342.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/PreProgrammed/Cdu737UserControlSA342.xaml.cs
@@ -114,7 +114,7 @@ namespace DCSFlightpanels.PanelUserControls.PreProgrammed
             ));
 
         }
-        private void HideAllImages()
+        private static void HideAllImages()
         {
         }
 

--- a/Source/DCSFlightpanels/PanelUserControls/StreamDeck/UserControlStreamDeckButtonAction.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/StreamDeck/UserControlStreamDeckButtonAction.xaml.cs
@@ -526,7 +526,7 @@ namespace DCSFlightpanels.PanelUserControls.StreamDeck
             return  CheckBoxPlaySoundFile.IsChecked == true && !string.IsNullOrEmpty(TextBoxSoundFile.Text) && File.Exists(TextBoxSoundFile.Text);
         }
 
-        private bool SoundConfigIsOk(IStreamDeckButtonAction streamDeckButtonAction)
+        private static bool SoundConfigIsOk(IStreamDeckButtonAction streamDeckButtonAction)
         {
             return !string.IsNullOrEmpty(streamDeckButtonAction.SoundFile) && File.Exists(streamDeckButtonAction.SoundFile);
         }

--- a/Source/DCSFlightpanels/PanelUserControls/StreamDeck/UserControlStreamDeckUIBase.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/StreamDeck/UserControlStreamDeckUIBase.cs
@@ -363,7 +363,7 @@ namespace DCSFlightpanels.PanelUserControls.StreamDeck
             }
         }
 
-        public void HideAllDotImages()
+        public static void HideAllDotImages()
         {
 
         }

--- a/Source/DCSFlightpanels/PanelUserControls/StreamDeck/UserControlStreamDeckUIBase.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/StreamDeck/UserControlStreamDeckUIBase.cs
@@ -26,7 +26,7 @@ namespace DCSFlightpanels.PanelUserControls.StreamDeck
     public abstract class UserControlStreamDeckUIBase : UserControl, IIsDirty, INvStreamDeckListener, IStreamDeckConfigListener, IOledImageListener
     {
         internal static Logger logger = LogManager.GetCurrentClassLogger();
-        protected readonly List<StreamDeckImage> ButtonImages = new List<StreamDeckImage>();
+        protected readonly List<StreamDeckImage> ButtonImages = new();
         protected bool UserControlLoaded;
         protected StreamDeckPanel _streamDeckPanel;
         private string _lastShownLayer = string.Empty;

--- a/Source/DCSFlightpanels/PanelUserControls/StreamDeck/UserControlStreamDeckUIBase.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/StreamDeck/UserControlStreamDeckUIBase.cs
@@ -610,7 +610,7 @@ namespace DCSFlightpanels.PanelUserControls.StreamDeck
                 //This error should not happen in theory if the screen is correctly designed, Debug.assert to warn the dev.
                 //Clear lists to show to the user that something wrong happened.
                 Common.ShowErrorMessageBox(
-                    new Exception($"Error initializing streamdeck buttons list. Expecting [{ButtonAmount()}] got [{ButtonImages.Count()}]"
+                    new Exception($"Error initializing streamdeck buttons list. Expecting [{ButtonAmount()}] got [{ButtonImages.Count}]"
                     ));
                 Debug.Assert(false);
                 ButtonImages.Clear();

--- a/Source/DCSFlightpanels/ProfileHandler.cs
+++ b/Source/DCSFlightpanels/ProfileHandler.cs
@@ -641,7 +641,7 @@ namespace DCSFlightpanels
             }
         }
 
-        private string GetFooter()
+        private static string GetFooter()
         {
             var stringBuilder = new StringBuilder();
             stringBuilder.AppendLine(Environment.NewLine + Environment.NewLine + Environment.NewLine + Environment.NewLine + "#--------------------------------------------------------------------");

--- a/Source/DCSFlightpanels/Radios/Emulators/RadioPanelPZ69UserControlEmulator.xaml.cs
+++ b/Source/DCSFlightpanels/Radios/Emulators/RadioPanelPZ69UserControlEmulator.xaml.cs
@@ -411,7 +411,7 @@
             {
                 var textBox = ((TextBox)sender);
 
-                if (textBox.Text.Contains("."))
+                if (textBox.Text.Contains('.'))
                 {
                     textBox.MaxLength = 6;
                 }
@@ -425,7 +425,7 @@
                     e.Handled = true;
                     return;
                 }
-                if (textBox.Text.Contains(".") && e.Key == Key.OemPeriod)
+                if (textBox.Text.Contains('.') && e.Key == Key.OemPeriod)
                 {
                     e.Handled = true;
                 }

--- a/Source/DCSFlightpanels/Radios/Emulators/RadioPanelPZ69UserControlGeneric.xaml.cs
+++ b/Source/DCSFlightpanels/Radios/Emulators/RadioPanelPZ69UserControlGeneric.xaml.cs
@@ -368,7 +368,7 @@
             {
                 var textBox = ((TextBox)sender);
 
-                if (textBox.Text.Contains("."))
+                if (textBox.Text.Contains('.'))
                 {
                     textBox.MaxLength = 6;
                 }
@@ -382,7 +382,7 @@
                     e.Handled = true;
                     return;
                 }
-                if (textBox.Text.Contains(".") && e.Key == Key.OemPeriod)
+                if (textBox.Text.Contains('.') && e.Key == Key.OemPeriod)
                 {
                     e.Handled = true;
                 }

--- a/Source/DCSFlightpanels/Windows/DCSBIOSInputControlsWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/DCSBIOSInputControlsWindow.xaml.cs
@@ -16,7 +16,7 @@
     public partial class DCSBIOSInputControlsWindow : Window, IIsDirty
     {
         private readonly string _header;
-        private List<DCSBIOSInput> _dcsbiosInputs = new List<DCSBIOSInput>();
+        private List<DCSBIOSInput> _dcsbiosInputs = new();
         private string _description;
         private bool _isDirty = false;
         private readonly bool _showSequenced = false;

--- a/Source/DCSFlightpanels/Windows/StreamDeck/ImportWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/StreamDeck/ImportWindow.xaml.cs
@@ -571,7 +571,7 @@ namespace DCSFlightpanels.Windows.StreamDeck
                 {
                     if (File.Exists(Path.Combine(TextBoxImageImportFolder.Text, file.Name)))
                     {
-                        stringBuilder.Append(file.Name).Append("\n");
+                        stringBuilder.Append(file.Name).Append('\n');
                         show = true;
                     }
                     else

--- a/Source/DCSFlightpanels/Windows/StreamDeck/ImportWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/StreamDeck/ImportWindow.xaml.cs
@@ -24,7 +24,7 @@ namespace DCSFlightpanels.Windows.StreamDeck
     {
         private readonly string _bindingHash;
         private bool _formLoaded = false;
-        private List<ButtonExport> _buttonExports = new List<ButtonExport>();
+        private List<ButtonExport> _buttonExports = new();
         private string _extractedFilesFolder = string.Empty;
 
         public ImportWindow(string bindingHash)

--- a/Source/DCSFlightpanels/Windows/StreamDeck/ImportWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/StreamDeck/ImportWindow.xaml.cs
@@ -295,7 +295,7 @@ namespace DCSFlightpanels.Windows.StreamDeck
             }
         }
 
-        private bool VerifyImportArchive(string filename)
+        private static bool VerifyImportArchive(string filename)
         {
             return ZipArchiver.ZipFileContainsFile(filename, StreamDeckConstants.BUTTON_EXPORT_FILENAME);
         }
@@ -417,7 +417,7 @@ namespace DCSFlightpanels.Windows.StreamDeck
             }
         }
 
-        private bool PreCheckBeforeImport()
+        private static bool PreCheckBeforeImport()
         {
             return true;
         }

--- a/Source/HidLibrary/HidDevice.cs
+++ b/Source/HidLibrary/HidDevice.cs
@@ -414,7 +414,7 @@ namespace HidLibrary
                 return (NativeMethods.HidD_SetOutputReport(WriteHandle, buffer, buffer.Length));
             }
             else
-                throw new ArgumentException("The output report is null, it must be allocated before you call this method", "report");
+                throw new ArgumentException("The output report is null, it must be allocated before you call this method", nameof(report));
         }
 
         public async Task<bool> WriteReportAsync(HidReport report, int timeout = 0)

--- a/Source/NonVisuals/BindingClasses/BIP/BIPLinkBase.cs
+++ b/Source/NonVisuals/BindingClasses/BIP/BIPLinkBase.cs
@@ -17,7 +17,7 @@ namespace NonVisuals.BindingClasses.BIP
          The user can map a physical switch so that whenever it is flicked
          the BIP will light up in a position chosen by the user.
          */
-        internal SortedList<int, BIPLight> _bipLights = new SortedList<int, BIPLight>();
+        internal SortedList<int, BIPLight> _bipLights = new();
         internal bool WhenOnTurnedOn = true;
         internal string _description;
         [NonSerialized]

--- a/Source/NonVisuals/BindingClasses/BIP/BIPLinkBase.cs
+++ b/Source/NonVisuals/BindingClasses/BIP/BIPLinkBase.cs
@@ -29,8 +29,8 @@ namespace NonVisuals.BindingClasses.BIP
 
         public Tuple<string, string> ParseSettingV1(string config)
         {
-            var mode = "";
-            var key = "";
+            string mode = "";
+            string key;
 
             // SwitchPanelBIPLink{1KNOB_ENGINE_LEFT}\o/BIPLight{Position_1_4|GREEN|FourSec|f5fe6e63e0c05a20f519d4b9e46fab3e}\o/BIPLight{Position_1_4|GREEN|FourSec|f5fe6e63e0c05a20f519d4b9e46fab3e}\o/Description["Set Engines On"]
             // MultipanelBIPLink{ALT|1KNOB_ENGINE_LEFT}\o/BIPLight{Position_1_4|GREEN|FourSec|f5fe6e63e0c05a20f519d4b9e46fab3e}\o/BIPLight{Position_1_4|GREEN|FourSec|f5fe6e63e0c05a20f519d4b9e46fab3e}\o/Description["Set Engines On"]

--- a/Source/NonVisuals/BindingClasses/DCSBIOSBindings/DCSBIOSActionBindingBase.cs
+++ b/Source/NonVisuals/BindingClasses/DCSBIOSBindings/DCSBIOSActionBindingBase.cs
@@ -146,8 +146,8 @@ namespace NonVisuals.BindingClasses.DCSBIOSBindings
 
         public Tuple<string, string> ParseSettingV2(string config)
         {
-            var mode = "";
-            var key = "";
+            string mode = "";
+            string key;
 
             //MultiPanelDCSBIOSControlV2{32}\o/{ALT}\o/{FLAPS_LEVER_DOWN|BESKRIVNING}\o/\o/DCSBIOSInput{AAP_CDUPWR|SET_STATE|0|0}\o/DCSBIOSInput{AAP_CDUPWR|SET_STATE|1|1000}
             //SwitchPanelDCSBIOSControlV2{32}\o/{SWITCHKEY_LIGHTS_PANEL|AAP_STEER}\o/\o/DCSBIOSInput{AAP_STEER|SET_STATE|1|0}
@@ -201,8 +201,8 @@ namespace NonVisuals.BindingClasses.DCSBIOSBindings
 
         public Tuple<string, string> ParseSettingV1(string config)
         {
-            var mode = "";
-            var key = "";
+            string mode = "";
+            string key;
             //RadioPanelDCSBIOSControl{UpperCOM1}\o/{1UpperLargeFreqWheelInc|PLT_INTL_PRIMARY_L_KNB}\o/\o/DCSBIOSInput{PLT_INTL_PRIMARY_L_KNB|VARIABLE_STEP|2000|0}	
             //MultiPanelDCSBIOSControl{ALT}\o/{1FLAPS_LEVER_DOWN|BESKRIVNING}\o/\o/DCSBIOSInput{AAP_CDUPWR|SET_STATE|0|0}\o/DCSBIOSInput{AAP_CDUPWR|SET_STATE|1|1000}
             //SwitchPanelDCSBIOSControl{1SWITCHKEY_LIGHTS_PANEL|AAP_STEER}\o/\o/DCSBIOSInput{AAP_STEER|SET_STATE|1|0}

--- a/Source/NonVisuals/BindingClasses/Key/KeyBindingBase.cs
+++ b/Source/NonVisuals/BindingClasses/Key/KeyBindingBase.cs
@@ -44,8 +44,8 @@ namespace NonVisuals.BindingClasses.Key
 
         public Tuple<string, string> ParseSettingV1(string config)
         {
-            var mode = "";
-            var key = "";
+            string mode = "";
+            string key;
 
             if (string.IsNullOrEmpty(config))
             {

--- a/Source/NonVisuals/BindingClasses/OSCommand/OSCommandBindingBase.cs
+++ b/Source/NonVisuals/BindingClasses/OSCommand/OSCommandBindingBase.cs
@@ -22,8 +22,8 @@ namespace NonVisuals.BindingClasses.OSCommand
 
         public Tuple<string, string> ParseSettingV1(string config)
         {
-            var mode = "";
-            var key = "";
+            string mode = "";
+            string key;
 
             if (string.IsNullOrEmpty(config))
             {

--- a/Source/NonVisuals/BindingMappingManager.cs
+++ b/Source/NonVisuals/BindingMappingManager.cs
@@ -11,7 +11,7 @@ namespace NonVisuals
     public static class BindingMappingManager
     {
         private static object _genericBindingsLock = new();
-        private static volatile List<GenericPanelBinding> _genericBindings = new List<GenericPanelBinding>();
+        private static volatile List<GenericPanelBinding> _genericBindings = new();
 
 
         public static void ClearBindings()

--- a/Source/NonVisuals/CockpitMaster/Panels/CDU737PanelBase.cs
+++ b/Source/NonVisuals/CockpitMaster/Panels/CDU737PanelBase.cs
@@ -109,7 +109,7 @@
         {
             if (hidSkeleton.GamingPanelType != GamingPanelEnum.CDU737)
             {
-                throw new ArgumentException();
+                throw new ArgumentException($"GamingPanelType {GamingPanelEnum.CDU737} expected");
             }
 
             initCDU();
@@ -337,13 +337,13 @@
 
         public void SetLine(int line, string text)
         {
-            if (line < 0 || line > LINES_ON_CDU-1) throw new ArgumentOutOfRangeException("CDU Line must be 0 to 13");
+            if (line < 0 || line > LINES_ON_CDU-1) throw new ArgumentOutOfRangeException(nameof(line), "CDU Line must be 0 to 13");
             _TextLines[line].Line = text;
         }
 
         public void SetDisplayCharAt( int line, DisplayedChar ch, int index)
         {
-            if (line < 0 || line > LINES_ON_CDU - 1) throw new ArgumentOutOfRangeException("CDU Line must be 0 to 13");
+            if (line < 0 || line > LINES_ON_CDU - 1) throw new ArgumentOutOfRangeException(nameof(line), "CDU Line must be 0 to 13");
             _TextLines[line].setDisplayedCharAt(ch, index);
 
         }

--- a/Source/NonVisuals/CockpitMaster/Panels/CDU737PanelBase.cs
+++ b/Source/NonVisuals/CockpitMaster/Panels/CDU737PanelBase.cs
@@ -461,7 +461,7 @@
 
         private HashSet<object> GetHashSetOfChangedKnobs(byte[] oldValue, byte[] newValue)
         {
-            HashSet<object> result = new HashSet<object>();
+            HashSet<object> result = new();
 
             for (int i = 0; i < 64; i++)
             {

--- a/Source/NonVisuals/CockpitMaster/Panels/CDU737PanelBase.cs
+++ b/Source/NonVisuals/CockpitMaster/Panels/CDU737PanelBase.cs
@@ -519,7 +519,7 @@
 
         }
 
-        protected (bool, uint) ShouldHandleDCSBiosData(DCSBIOSDataEventArgs e, DCSBIOSOutput output)
+        protected static (bool, uint) ShouldHandleDCSBiosData(DCSBIOSDataEventArgs e, DCSBIOSOutput output)
         {
             if (e.Address != output.Address) return (false, 0);
             var oldValue = output.LastIntValue;

--- a/Source/NonVisuals/CockpitMaster/Panels/CDUTextLine.cs
+++ b/Source/NonVisuals/CockpitMaster/Panels/CDUTextLine.cs
@@ -44,7 +44,7 @@ namespace NonVisuals.CockpitMaster.Panels
             set
             {
 
-                if (value.Length > MAX_CHAR) throw new ArgumentException();
+                if (value.Length > MAX_CHAR) throw new ArgumentException($"Length must be less than or equal to {MAX_CHAR}");
 
                 _line = value;
 

--- a/Source/NonVisuals/CockpitMaster/Panels/CDUTextLineHelpers.cs
+++ b/Source/NonVisuals/CockpitMaster/Panels/CDUTextLineHelpers.cs
@@ -6,7 +6,7 @@ namespace NonVisuals.CockpitMaster.Panels
     {
 
         public static readonly Dictionary<char, CDUCharset> defaultConvertTable =
-            new Dictionary<char, CDUCharset>()
+            new()
             {
                 { ' ' , CDUCharset.space },
                 { '.' , CDUCharset.dot },
@@ -115,7 +115,7 @@ namespace NonVisuals.CockpitMaster.Panels
             };
 
         public static readonly Dictionary<char, CDUCharset> AH64ConvertTable =
-            new Dictionary<char, CDUCharset>()
+            new()
             {
                 { ' ' , CDUCharset.space },
                 { '.' , CDUCharset.dot },

--- a/Source/NonVisuals/GamingPanel.cs
+++ b/Source/NonVisuals/GamingPanel.cs
@@ -42,7 +42,7 @@
         public bool ForwardPanelEvent { get; set; }
         public int VendorId { get; set; }
         public int ProductId { get; set; }
-        public static readonly List<GamingPanel> GamingPanels = new List<GamingPanel>(); 
+        public static readonly List<GamingPanel> GamingPanels = new(); 
 
         public string HIDInstance
         {

--- a/Source/NonVisuals/HIDHandler.cs
+++ b/Source/NonVisuals/HIDHandler.cs
@@ -48,7 +48,7 @@ namespace NonVisuals
             stringBuilder.AppendLine($"HIDHandler has the following skeletons ({_instance.HIDSkeletons.Count}) :");
             foreach (var skeleton in _instance.HIDSkeletons)
             {
-                stringBuilder.Append("\t").Append(skeleton.PanelInfo).Append("\n");
+                stringBuilder.Append('\t').Append(skeleton.PanelInfo).Append('\n');
             }
 
             return stringBuilder.ToString();

--- a/Source/NonVisuals/JaceExtendedFactory.cs
+++ b/Source/NonVisuals/JaceExtendedFactory.cs
@@ -11,7 +11,7 @@ namespace NonVisuals
     public static class JaceExtendedFactory
     {
         internal static Logger logger = LogManager.GetCurrentClassLogger();
-        private static readonly Dictionary<int, JaceExtended> JaceEngines = new Dictionary<int, JaceExtended>();
+        private static readonly Dictionary<int, JaceExtended> JaceEngines = new();
         private static readonly object LockObject = new();
         public static JaceExtended Instance(ref int id)
         {

--- a/Source/NonVisuals/KeyPress.cs
+++ b/Source/NonVisuals/KeyPress.cs
@@ -399,7 +399,7 @@ namespace NonVisuals
                 throw new ArgumentException("Import string empty. (KeyBinding)");
             }
 
-            if (str.Contains("["))
+            if (str.Contains('['))
             {
                 ImportStringMultiKeySequence(str);
             }

--- a/Source/NonVisuals/KeyPress.cs
+++ b/Source/NonVisuals/KeyPress.cs
@@ -606,7 +606,7 @@ namespace NonVisuals
                 result.Append("[" + Enum.GetName(typeof(KeyPressLength), keyPressInfo.LengthOfBreak) + "," + GetVirtualKeyCodesAsString(keyPressInfo) + "," + Enum.GetName(typeof(KeyPressLength), keyPressInfo.LengthOfKeyPress) + "]");
             }
 
-            result.Append("}");
+            result.Append('}');
             return result.ToString();
         }
 

--- a/Source/NonVisuals/KeyPress.cs
+++ b/Source/NonVisuals/KeyPress.cs
@@ -207,7 +207,7 @@ namespace NonVisuals
             {
                 // Debug.WriteLine("VK = " + virtualKeyCodes[1] + " length = " + keyPressLength);
                 // Press modifiers
-                for (var i = 0; i < virtualKeyCodes.Count(); i++)
+                for (var i = 0; i < virtualKeyCodes.Length; i++)
                 {
                     var virtualKeyCode = virtualKeyCodes[i];
                     if (CommonVirtualKey.IsModifierKey(virtualKeyCode))
@@ -229,7 +229,7 @@ namespace NonVisuals
                 Thread.Sleep(millisecondsTimeout: 32); 
 
                 // Press normal keys
-                for (var i = 0; i < virtualKeyCodes.Count(); i++)
+                for (var i = 0; i < virtualKeyCodes.Length; i++)
                 {
                     var virtualKeyCode = virtualKeyCodes[i];
                     if (!CommonVirtualKey.IsModifierKey(virtualKeyCode) && virtualKeyCode != VirtualKeyCode.VK_NULL)
@@ -269,7 +269,7 @@ namespace NonVisuals
         private void ReleaseKeys(VirtualKeyCode[] virtualKeyCodes)
         {
             // Release normal keys
-            for (var i = 0; i < virtualKeyCodes.Count(); i++)
+            for (var i = 0; i < virtualKeyCodes.Length; i++)
             {
                 var virtualKeyCode = virtualKeyCodes[i];
                 if (!CommonVirtualKey.IsModifierKey(virtualKeyCode))
@@ -279,7 +279,7 @@ namespace NonVisuals
             }
 
             // Release modifiers
-            for (var i = 0; i < virtualKeyCodes.Count(); i++)
+            for (var i = 0; i < virtualKeyCodes.Length; i++)
             {
                 var virtualKeyCode = virtualKeyCodes[i];
                 if (CommonVirtualKey.IsModifierKey(virtualKeyCode))
@@ -483,7 +483,7 @@ namespace NonVisuals
                 // [FiftyMilliSec,VK_C,FiftyMilliSec]
                 // [FiftyMilliSec,VK_D,FiftyMilliSec]}
                 // ...
-                for (int i = 0; i < array.Count(); i++)
+                for (int i = 0; i < array.Length; i++)
                 {
                     var keyPressInfo = new KeyPressInfo();
                     var entry = array[i];
@@ -646,7 +646,7 @@ namespace NonVisuals
                 }
             }
 
-            var inputs = new NativeMethods.INPUT[virtualKeyCodes.Count()];
+            var inputs = new NativeMethods.INPUT[virtualKeyCodes.Length];
 
             while (keyPressLengthTimeConsumed < (int)keyPressLength)
             {
@@ -660,7 +660,7 @@ namespace NonVisuals
                 }
 
                 // Add modifiers
-                for (var i = 0; i < virtualKeyCodes.Count(); i++)
+                for (var i = 0; i < virtualKeyCodes.Length; i++)
                 {
                     var virtualKeyCode = virtualKeyCodes[i];
                     if (CommonVirtualKey.IsModifierKey(virtualKeyCode))
@@ -683,7 +683,7 @@ namespace NonVisuals
                 // 0  1  2  3
                 // 1  2  3  4
                 // Add normal keys
-                for (var i = modifierCount; i < virtualKeyCodes.Count(); i++)
+                for (var i = modifierCount; i < virtualKeyCodes.Length; i++)
                 {
                     var virtualKeyCode = virtualKeyCodes[i];
                     if (!CommonVirtualKey.IsModifierKey(virtualKeyCode) && virtualKeyCode != VirtualKeyCode.VK_NULL)
@@ -698,7 +698,7 @@ namespace NonVisuals
                     }
                 }
 
-                NativeMethods.SendInput((uint)inputs.Count(), inputs, Marshal.SizeOf(typeof(NativeMethods.INPUT)));
+                NativeMethods.SendInput((uint)inputs.Length, inputs, Marshal.SizeOf(typeof(NativeMethods.INPUT)));
 
                 if (keyPressLength != KeyPressLength.Indefinite)
                 {
@@ -717,7 +717,7 @@ namespace NonVisuals
                 }
             }
 
-            for (var i = 0; i < inputs.Count(); i++)
+            for (var i = 0; i < inputs.Length; i++)
             {
                 inputs[i].InputUnion.ki.dwFlags |= NativeMethods.KEYEVENTF_KEYUP;
             }
@@ -725,7 +725,7 @@ namespace NonVisuals
             Array.Reverse(inputs);
 
             // Release same keys
-            NativeMethods.SendInput((uint)inputs.Count(), inputs, Marshal.SizeOf(typeof(NativeMethods.INPUT)));
+            NativeMethods.SendInput((uint)inputs.Length, inputs, Marshal.SizeOf(typeof(NativeMethods.INPUT)));
         }
 
         [JsonProperty("Abort", Required = Required.Default)]

--- a/Source/NonVisuals/KeyPress.cs
+++ b/Source/NonVisuals/KeyPress.cs
@@ -296,7 +296,7 @@ namespace NonVisuals
             }
         }
 
-        public string GetVirtualKeyCodesAsString(IKeyPressInfo keyPressInfo)
+        public static string GetVirtualKeyCodesAsString(IKeyPressInfo keyPressInfo)
         {
             var result = new StringBuilder();
 

--- a/Source/NonVisuals/KeyPress.cs
+++ b/Source/NonVisuals/KeyPress.cs
@@ -19,7 +19,7 @@ namespace NonVisuals
     public class KeyPress
     {
         private const int SLEEP_VALUE = 32;
-        private SortedList<int, IKeyPressInfo> _sortedKeyPressInfoList = new SortedList<int, IKeyPressInfo>();
+        private SortedList<int, IKeyPressInfo> _sortedKeyPressInfoList = new();
         private string _description = "Key press sequence";
         [NonSerialized] private Thread _executingThread;
 
@@ -29,7 +29,7 @@ namespace NonVisuals
          * depends on what the user has configured.
          * It is the binding class that must make sure to set these.
          */
-        private List<KeyPress> _negatorOSKeyPresses = new List<KeyPress>();
+        private List<KeyPress> _negatorOSKeyPresses = new();
         private volatile bool _abort;
 
 
@@ -558,7 +558,7 @@ namespace NonVisuals
             return _sortedKeyPressInfoList == null || _sortedKeyPressInfoList.Count == 0;
         }
 
-        private SortedList<int, KeyPressInfo> _oldSortedKeyPressInfoList = new SortedList<int, KeyPressInfo>();
+        private SortedList<int, KeyPressInfo> _oldSortedKeyPressInfoList = new();
         [Obsolete]
         [JsonProperty("KeySequence", Required = Required.Default)]
         public SortedList<int, KeyPressInfo> KeySequenceObsolete

--- a/Source/NonVisuals/Radios/Misc/PZ69DisplayBytes.cs
+++ b/Source/NonVisuals/Radios/Misc/PZ69DisplayBytes.cs
@@ -202,7 +202,7 @@
             while (i < 5);
         }
 
-        private int GetArrayPosition(PZ69LCDPosition pz69LCDPosition)
+        private static int GetArrayPosition(PZ69LCDPosition pz69LCDPosition)
         {
             switch (pz69LCDPosition)
             {

--- a/Source/NonVisuals/Radios/RadioPanelPZ69A10C.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69A10C.cs
@@ -3888,7 +3888,7 @@ namespace NonVisuals.Radios
             SaitekPanelKnobs = RadioPanelKnobA10C.GetRadioPanelKnobs();
         }
 
-        private string GetVhfAmDialFrequencyForPosition(int dial, uint position)
+        private static string GetVhfAmDialFrequencyForPosition(int dial, uint position)
         {
 
             // Frequency selector 1      VHFAM_FREQ1
@@ -3956,7 +3956,7 @@ namespace NonVisuals.Radios
             return string.Empty;
         }
 
-        private string GetUhfDialFrequencyForPosition(int dial, uint position)
+        private static string GetUhfDialFrequencyForPosition(int dial, uint position)
         {
             // Frequency selector 1     
             // //"2"  "3"  "A"
@@ -4015,7 +4015,7 @@ namespace NonVisuals.Radios
             return string.Empty;
         }
 
-        private string GetVhfFmDialFrequencyForPosition(int dial, uint position)
+        private static string GetVhfFmDialFrequencyForPosition(int dial, uint position)
         {
 
             // Frequency selector 1      VHFFM_FREQ1
@@ -4084,7 +4084,7 @@ namespace NonVisuals.Radios
             return string.Empty;
         }
 
-        private string GetILSDialFrequencyForPosition(int dial, uint position)
+        private static string GetILSDialFrequencyForPosition(int dial, uint position)
         {
             // 1 Mhz   "108" "109" "110" "111"
             // 0     1     2     3
@@ -4129,7 +4129,7 @@ namespace NonVisuals.Radios
             return string.Empty;
         }
 
-        private int GetILSDialPosForFrequency(int dial, int freq)
+        private static int GetILSDialPosForFrequency(int dial, int freq)
         {
             // 1 Mhz   "108" "109" "110" "111"
             // 0     1     2     3
@@ -4174,7 +4174,7 @@ namespace NonVisuals.Radios
             return 0;
         }
 
-        private string GetCommandDirectionForVhfDial1(int desiredDialPosition, uint actualDialPosition)
+        private static string GetCommandDirectionForVhfDial1(int desiredDialPosition, uint actualDialPosition)
         {
             const string inc = "INC\n";
             const string dec = "DEC\n";
@@ -4654,7 +4654,7 @@ namespace NonVisuals.Radios
             throw new Exception("Should not reach this code. private String GetCommandDirectionForVhfDial1(uint desiredDialPosition, uint actualDialPosition) -> " + desiredDialPosition + "   " + actualDialPosition);
         }
 
-        private string GetCommandDirectionForVhfDial23(int desiredDialPosition, uint actualDialPosition)
+        private static string GetCommandDirectionForVhfDial23(int desiredDialPosition, uint actualDialPosition)
         {
             const string inc = "INC\n";
             const string dec = "DEC\n";

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
@@ -44,7 +44,7 @@
         {
             if (hidSkeleton.GamingPanelType != GamingPanelEnum.PZ69RadioPanel)
             {
-                throw new ArgumentException();
+                throw new ArgumentException($"GamingPanelType {GamingPanelEnum.PZ69RadioPanel} expected");
             }
 
             _numberFormatInfoFullDisplay = new NumberFormatInfo

--- a/Source/NonVisuals/Radios/RadioPanelPZ69F14B.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69F14B.cs
@@ -163,7 +163,7 @@ namespace NonVisuals.Radios
         private const string VUHF_MODE_DECREASE = "RIO_VUHF_MODE DEC\n";
         private DCSBIOSOutput _vuhfDcsbiosOutputMode;
         private volatile uint _vuhfCockpitMode; // OFF = 0
-        private readonly ClickSpeedDetector _vuhfModeClickSpeedDetector = new ClickSpeedDetector(8);
+        private readonly ClickSpeedDetector _vuhfModeClickSpeedDetector = new(8);
         private byte _skipVuhfSmallFreqChange;
         private long _vuhfThreadNowSynching;
         private Thread _vuhfSyncThread;

--- a/Source/NonVisuals/Radios/RadioPanelPZ69F14B.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69F14B.cs
@@ -3441,7 +3441,7 @@ namespace NonVisuals.Radios
             return Interlocked.Read(ref _vuhfThreadNowSynching) > 0;
         }
 
-        private string GetCommandDirection10Dial(int desiredDialPosition, uint actualDialPosition)
+        private static string GetCommandDirection10Dial(int desiredDialPosition, uint actualDialPosition)
         {
             const string inc = "INC\n";
             const string dec = "DEC\n";

--- a/Source/NonVisuals/Radios/RadioPanelPZ69F5E.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69F5E.cs
@@ -1946,7 +1946,7 @@ namespace NonVisuals.Radios
             SaitekPanelKnobs = RadioPanelKnobF5E.GetRadioPanelKnobs();
         }
 
-        private string GetUhfDialFrequencyForPosition(int dial, uint position)
+        private static string GetUhfDialFrequencyForPosition(int dial, uint position)
         {
             // Frequency selector 1     
             // // "T"  "2"  "3"  "A"

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Ka50.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Ka50.cs
@@ -2085,7 +2085,7 @@ namespace NonVisuals.Radios
             return inc;
         }
 
-        private string GetCommandDirectionFor0To9Dials(int desiredDialPosition, uint actualDialPosition)
+        private static string GetCommandDirectionFor0To9Dials(int desiredDialPosition, uint actualDialPosition)
         {
             try
             {
@@ -2433,7 +2433,7 @@ namespace NonVisuals.Radios
                 $"Should not reach this code. private String GetCommandDirectionFor0To9Dials(uint desiredDialPosition, uint actualDialPosition) -> {desiredDialPosition}   {actualDialPosition}");
         }
 
-        private string GetR800L1DialFrequencyForPosition(uint position)
+        private static string GetR800L1DialFrequencyForPosition(uint position)
         {
             try
             {

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Mi24P.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Mi24P.cs
@@ -1741,7 +1741,7 @@ namespace NonVisuals.Radios
             Interlocked.Decrement(ref _doUpdatePanelLCD);
         }
 
-        private string DivideBy2AndFormatForDisplay(uint position)
+        private static string DivideBy2AndFormatForDisplay(uint position)
         {
             double frequencyAsDouble = (double)position / 2;
             return frequencyAsDouble.ToString("0.0", CultureInfo.InvariantCulture);
@@ -1885,7 +1885,7 @@ namespace NonVisuals.Radios
             }
         }
 
-        private string GetCommandDirectionFor0To9Dials(int desiredDialPosition, uint actualDialPosition)
+        private static string GetCommandDirectionFor0To9Dials(int desiredDialPosition, uint actualDialPosition)
         {
             try
             {

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Mi8.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Mi8.cs
@@ -2907,7 +2907,7 @@ namespace NonVisuals.Radios
             }
         }
 
-        private string GetCommandDirectionForR863ManualDial1(int desiredDialPosition, uint actualDialPosition)
+        private static string GetCommandDirectionForR863ManualDial1(int desiredDialPosition, uint actualDialPosition)
         {
             const string inc = "INC\n";
             const string dec = "DEC\n";
@@ -2975,7 +2975,7 @@ namespace NonVisuals.Radios
             return inc;
         }
 
-        private string GetCommandDirectionFor0To9Dials(int desiredDialPosition, uint actualDialPosition)
+        private static string GetCommandDirectionFor0To9Dials(int desiredDialPosition, uint actualDialPosition)
         {
             try
             {

--- a/Source/NonVisuals/Radios/RadioPanelPZ69SA342.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69SA342.cs
@@ -1952,7 +1952,7 @@ namespace NonVisuals.Radios
             return Interlocked.Read(ref _vhfAmThreadNowSynching) > 0;
         }
 
-        private bool SwitchVhfAmDecimalDirectionUp(int cockpitValue, int desiredValue)
+        private static bool SwitchVhfAmDecimalDirectionUp(int cockpitValue, int desiredValue)
         {
             var upCount = 0;
             var downCount = 0;

--- a/Source/NonVisuals/Radios/RadioPanelPZ69UH1H.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69UH1H.cs
@@ -2505,7 +2505,7 @@ namespace NonVisuals.Radios
             ShowFrequenciesOnPanel();
         }
 
-        private uint QuarterFrequencyStandbyAdjust(uint frequency, bool increase)
+        private static uint QuarterFrequencyStandbyAdjust(uint frequency, bool increase)
         {
             uint result = 0;
             var tmp = frequency.ToString(CultureInfo.InvariantCulture);
@@ -2930,7 +2930,7 @@ namespace NonVisuals.Radios
             SaitekPanelKnobs = RadioPanelKnobUH1H.GetRadioPanelKnobs();
         }
 
-        private string GetCommandDirectionForVhfCommDial1(uint desiredFreq, uint actualFreq)
+        private static string GetCommandDirectionForVhfCommDial1(uint desiredFreq, uint actualFreq)
         {
             /*UH-1H AN/ARC-134 VHF Comm Radio Set*/
             // Large dial 116 - 149 [step of 1]
@@ -2964,7 +2964,7 @@ namespace NonVisuals.Radios
             throw new Exception("Should reach this code. GetCommandDirectionForVhfCommDial1(int desiredFreq, uint actualFreq)) -> " + desiredFreq + "   " + actualFreq);
         }
 
-        private string GetCommandDirectionForVhfCommDial2(uint desiredFreq, uint actualFreq)
+        private static string GetCommandDirectionForVhfCommDial2(uint desiredFreq, uint actualFreq)
         {
             /*UH-1H AN/ARC-134 VHF Comm Radio Set*/
 
@@ -3000,7 +3000,7 @@ namespace NonVisuals.Radios
             throw new Exception("Should reach this code. GetCommandDirectionForVhfCommDial2(int desiredFreq, uint actualFreq)) -> " + desiredFreq + "   " + actualFreq);
         }
 
-        private string GetCommandDirectionForUhfDial1(uint desiredFreq, uint actualFreq)
+        private static string GetCommandDirectionForUhfDial1(uint desiredFreq, uint actualFreq)
         {
             // Large dial 20 - 39 [step of 1]
             // d19 +/-10
@@ -3029,7 +3029,7 @@ namespace NonVisuals.Radios
             throw new Exception("Should reach this code. GetCommandDirectionForUhfDial1(int desiredFreq, uint actualFreq)) -> " + desiredFreq + "   " + actualFreq);
         }
 
-        private string GetCommandDirectionForUhfDial2(uint desiredFreq, uint actualFreq)
+        private static string GetCommandDirectionForUhfDial2(uint desiredFreq, uint actualFreq)
         {
             // 2nd dial 0 - 9 [step of 1]
             // +/-9
@@ -3058,7 +3058,7 @@ namespace NonVisuals.Radios
             throw new Exception("Should reach this code. GetCommandDirectionForUhfDial2(int desiredFreq, uint actualFreq)) -> " + desiredFreq + "   " + actualFreq);
         }
 
-        private string GetCommandDirectionForUhfDial3(uint desiredFreq, uint actualFreq)
+        private static string GetCommandDirectionForUhfDial3(uint desiredFreq, uint actualFreq)
         {
             // 00 05 10 15 20 25 30 35 40 45 50 55 60 65 70 75 80 85 90 95
             // 1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20   
@@ -3088,7 +3088,7 @@ namespace NonVisuals.Radios
             throw new Exception("Should reach this code. GetCommandDirectionForUhfDial3(int desiredFreq, uint actualFreq)) -> " + desiredFreq + "   " + actualFreq);
         }
 
-        private string GetCommandDirectionForVhfNavDial1(uint desiredFreq, uint actualFreq)
+        private static string GetCommandDirectionForVhfNavDial1(uint desiredFreq, uint actualFreq)
         {
             /*UH-1H AN/ARC-134 VHF Comm Radio Set*/
             // Large dial 107-126  [step of 1]

--- a/Source/NonVisuals/Saitek/BIPFactory.cs
+++ b/Source/NonVisuals/Saitek/BIPFactory.cs
@@ -10,7 +10,7 @@
      */
     public static class BipFactory
     {
-        private static readonly BipEventHandlerManager BIPEventHandlerManager = new BipEventHandlerManager();
+        private static readonly BipEventHandlerManager BIPEventHandlerManager = new();
 
         public static void BroadcastRegisteredBips()
         {

--- a/Source/NonVisuals/Saitek/PZ70LCDButtonByteList.cs
+++ b/Source/NonVisuals/Saitek/PZ70LCDButtonByteList.cs
@@ -95,7 +95,7 @@
             }
         }
 
-        public int GetMaskForDialPosition(PZ70DialPosition pz70DialPosition)
+        public static int GetMaskForDialPosition(PZ70DialPosition pz70DialPosition)
         {
             try
             {
@@ -136,7 +136,7 @@
             }
         }
 
-        public byte GetMaskForButton(MultiPanelPZ70Knobs multiPanelPZ70Knob)
+        public static byte GetMaskForButton(MultiPanelPZ70Knobs multiPanelPZ70Knob)
         {
             try
             {

--- a/Source/NonVisuals/Saitek/Panels/BacklitPanelBIP.cs
+++ b/Source/NonVisuals/Saitek/Panels/BacklitPanelBIP.cs
@@ -71,7 +71,7 @@ namespace NonVisuals.Saitek.Panels
         {
             if (hidSkeleton.GamingPanelType != GamingPanelEnum.BackLitPanel)
             {
-                throw new ArgumentException();
+                throw new ArgumentException($"GamingPanelType {GamingPanelEnum.BackLitPanel} expected");
             }
 
             VendorId = 0x6A3;

--- a/Source/NonVisuals/Saitek/Panels/FarmingSidePanel.cs
+++ b/Source/NonVisuals/Saitek/Panels/FarmingSidePanel.cs
@@ -34,7 +34,7 @@ namespace NonVisuals.Saitek.Panels
         {
             if (hidSkeleton.GamingPanelType != GamingPanelEnum.FarmingPanel)
             {
-                throw new ArgumentException();
+                throw new ArgumentException($"GamingPanelType {GamingPanelEnum.FarmingPanel} expected");
             }
 
             // Fixed values

--- a/Source/NonVisuals/Saitek/Panels/MultiPanelPZ70.cs
+++ b/Source/NonVisuals/Saitek/Panels/MultiPanelPZ70.cs
@@ -64,7 +64,7 @@ namespace NonVisuals.Saitek.Panels
         {
             if (hidSkeleton.GamingPanelType != GamingPanelEnum.PZ70MultiPanel)
             {
-                throw new ArgumentException();
+                throw new ArgumentException($"GamingPanelType {GamingPanelEnum.PZ70MultiPanel} expected");
             }
 
             VendorId = 0x6A3;

--- a/Source/NonVisuals/Saitek/Panels/SwitchPanelPZ55.cs
+++ b/Source/NonVisuals/Saitek/Panels/SwitchPanelPZ55.cs
@@ -172,13 +172,13 @@ namespace NonVisuals.Saitek.Panels
             _keyBindings = KeyBindingPZ55.SetNegators(_keyBindings);
         }
 
-        private string GetValueFromSetting(string setting)
+        private static string GetValueFromSetting(string setting)
         {
             int pos = setting.IndexOf('{');
             return setting.Substring(pos + 1, setting.LastIndexOf('}') - pos - 1);
         }
 
-        private PanelLEDColor GetSettingPanelLEDColor(string setting)
+        private static PanelLEDColor GetSettingPanelLEDColor(string setting)
         {
             return (PanelLEDColor)Enum.Parse(typeof(PanelLEDColor), GetValueFromSetting(setting));
         }
@@ -980,7 +980,7 @@ namespace NonVisuals.Saitek.Panels
             }
         }
 
-        private SwitchPanelPZ55LEDs GetSwitchPanelPZ55LEDColor(SwitchPanelPZ55LEDPosition switchPanelPZ55LEDPosition, PanelLEDColor panelLEDColor)
+        private static SwitchPanelPZ55LEDs GetSwitchPanelPZ55LEDColor(SwitchPanelPZ55LEDPosition switchPanelPZ55LEDPosition, PanelLEDColor panelLEDColor)
         {
             var result = SwitchPanelPZ55LEDs.ALL_DARK;
 

--- a/Source/NonVisuals/Saitek/Panels/SwitchPanelPZ55.cs
+++ b/Source/NonVisuals/Saitek/Panels/SwitchPanelPZ55.cs
@@ -61,7 +61,7 @@ namespace NonVisuals.Saitek.Panels
         {
             if (hidSkeleton.GamingPanelType != GamingPanelEnum.PZ55SwitchPanel)
             {
-                throw new ArgumentException();
+                throw new ArgumentException($"GamingPanelType {GamingPanelEnum.PZ55SwitchPanel} expected");
             }
 
             // Fixed values

--- a/Source/NonVisuals/Saitek/Panels/TPMPanel.cs
+++ b/Source/NonVisuals/Saitek/Panels/TPMPanel.cs
@@ -36,7 +36,7 @@ namespace NonVisuals.Saitek.Panels
         {
             if (hidSkeleton.GamingPanelType != GamingPanelEnum.TPM)
             {
-                throw new ArgumentException();
+                throw new ArgumentException($"GamingPanelType {GamingPanelEnum.TPM} expected");
             }
 
             // Fixed values

--- a/Source/NonVisuals/StreamDeck/ActionTypeKey.cs
+++ b/Source/NonVisuals/StreamDeck/ActionTypeKey.cs
@@ -56,7 +56,7 @@ namespace NonVisuals.StreamDeck
                 stringBuilder.Append("Key press");
                 if (OSKeyPress != null)
                 {
-                    stringBuilder.Append(" ").Append(OSKeyPress.GetKeyPressInformation());
+                    stringBuilder.Append(' ').Append(OSKeyPress.GetKeyPressInformation());
                 }
 
                 return stringBuilder.ToString();

--- a/Source/NonVisuals/StreamDeck/ActionTypeLayer.cs
+++ b/Source/NonVisuals/StreamDeck/ActionTypeLayer.cs
@@ -92,7 +92,7 @@ namespace NonVisuals.StreamDeck
                 stringBuilder.Append("Layer Nav.");
                 if (!string.IsNullOrEmpty(TargetLayer))
                 {
-                    stringBuilder.Append(" ").Append(TargetLayer);
+                    stringBuilder.Append(' ').Append(TargetLayer);
                 }
 
                 return stringBuilder.ToString();

--- a/Source/NonVisuals/StreamDeck/ActionTypeOS.cs
+++ b/Source/NonVisuals/StreamDeck/ActionTypeOS.cs
@@ -53,7 +53,7 @@ namespace NonVisuals.StreamDeck
                 stringBuilder.Append("OS Command");
                 if (OSCommandObject != null)
                 {
-                    stringBuilder.Append(" ").Append(OSCommandObject.Name);
+                    stringBuilder.Append(' ').Append(OSCommandObject.Name);
                 }
 
                 return stringBuilder.ToString();

--- a/Source/NonVisuals/StreamDeck/DCSBIOSConverter.cs
+++ b/Source/NonVisuals/StreamDeck/DCSBIOSConverter.cs
@@ -23,8 +23,8 @@ namespace NonVisuals.StreamDeck
         private bool _criteria1IsOk;
         private bool _criteria2IsOk;
 
-        private FaceTypeText _faceTypeText = new FaceTypeText();
-        private FaceTypeImage _faceTypeImage = new FaceTypeImage();
+        private FaceTypeText _faceTypeText = new();
+        private FaceTypeImage _faceTypeImage = new();
         private FaceTypeDCSBIOSOverlay _faceTypeDCSBIOSOverlay;
 
         [NonSerialized]

--- a/Source/NonVisuals/StreamDeck/DCSBIOSConverter.cs
+++ b/Source/NonVisuals/StreamDeck/DCSBIOSConverter.cs
@@ -297,7 +297,7 @@ namespace NonVisuals.StreamDeck
             set => _referenceValue2 = value;
         }
 
-        private string GetOutputAsString(EnumConverterOutputType converterOutputType)
+        private static string GetOutputAsString(EnumConverterOutputType converterOutputType)
         {
             string result;
             switch (converterOutputType)
@@ -336,7 +336,7 @@ namespace NonVisuals.StreamDeck
             return result;
         }
 
-        private string GetComparatorAsString(EnumComparator comparator)
+        private static string GetComparatorAsString(EnumComparator comparator)
         {
             var result = string.Empty;
 

--- a/Source/NonVisuals/StreamDeck/DCSBIOSDecoder.cs
+++ b/Source/NonVisuals/StreamDeck/DCSBIOSDecoder.cs
@@ -28,7 +28,7 @@ namespace NonVisuals.StreamDeck
         private bool _useFormula;
         private double _formulaResult = double.MaxValue;
         private string _lastFormulaError = string.Empty;
-        private List<DCSBIOSConverter> _dcsbiosConverters = new List<DCSBIOSConverter>();
+        private List<DCSBIOSConverter> _dcsbiosConverters = new();
         private volatile bool _valueUpdated = true;
         private DCSBiosOutputType _decoderSourceType = DCSBiosOutputType.IntegerType;
         private bool _treatStringAsNumber;

--- a/Source/NonVisuals/StreamDeck/DCSBIOSDecoder.cs
+++ b/Source/NonVisuals/StreamDeck/DCSBIOSDecoder.cs
@@ -98,11 +98,11 @@ namespace NonVisuals.StreamDeck
                 stringBuilder.Append("Face DCS-BIOS Decoder");
                 if (FormulaSelectedAndOk())
                 {
-                    stringBuilder.Append(" ").Append(_dcsbiosOutputFormula.DCSBIOSOutputs()[0].ControlId);
+                    stringBuilder.Append(' ').Append(_dcsbiosOutputFormula.DCSBIOSOutputs()[0].ControlId);
                 }
                 else if (_dcsbiosOutput != null)
                 {
-                    stringBuilder.Append(" ").Append(_dcsbiosOutput.ControlId);
+                    stringBuilder.Append(' ').Append(_dcsbiosOutput.ControlId);
                 }
 
                 return stringBuilder.ToString();

--- a/Source/NonVisuals/StreamDeck/Events/SDEventHandler.cs
+++ b/Source/NonVisuals/StreamDeck/Events/SDEventHandler.cs
@@ -60,14 +60,14 @@ namespace NonVisuals.StreamDeck.Events
         {
             var stringBuilder = new StringBuilder(200);
 
-            stringBuilder.Append("\nOnDirtyConfigurationsEventHandler :").Append(OnDirtyConfigurationsEventHandler != null ? OnDirtyConfigurationsEventHandler.GetInvocationList().Length.ToString() : "0").Append("\n");
-            stringBuilder.Append("OnDirtyNotificationEventHandler :").Append(OnDirtyNotificationEventHandler != null ? OnDirtyNotificationEventHandler.GetInvocationList().Length.ToString() : "0").Append("\n");
-            stringBuilder.Append("OnStreamDeckShowNewLayerEventHandler :").Append(OnStreamDeckShowNewLayerEventHandler != null ? OnStreamDeckShowNewLayerEventHandler.GetInvocationList().Length.ToString() : "0").Append("\n");
-            stringBuilder.Append("OnStreamDeckSelectedButtonChangedEventHandler :").Append(OnStreamDeckSelectedButtonChangedEventHandler != null ? OnStreamDeckSelectedButtonChangedEventHandler.GetInvocationList().Length.ToString() : "0").Append("\n");
-            stringBuilder.Append("OnStreamDeckClearSettingsEventHandler :").Append(OnStreamDeckClearSettingsEventHandler != null ? OnStreamDeckClearSettingsEventHandler.GetInvocationList().Length.ToString() : "0").Append("\n");
-            stringBuilder.Append("OnStreamDeckSyncConfigurationEventHandler :").Append(OnStreamDeckSyncConfigurationEventHandler != null ? OnStreamDeckSyncConfigurationEventHandler.GetInvocationList().Length.ToString() : "0").Append("\n");
-            stringBuilder.Append("OnStreamDeckConfigurationChangeEventHandler :").Append(OnStreamDeckConfigurationChangeEventHandler != null ? OnStreamDeckConfigurationChangeEventHandler.GetInvocationList().Length.ToString() : "0").Append("\n");
-            stringBuilder.Append("OnStreamDeckHideDecodersEventHandler :").Append(OnStreamDeckHideDecodersEventHandler != null ? OnStreamDeckHideDecodersEventHandler.GetInvocationList().Length.ToString() : "0").Append("\n");
+            stringBuilder.Append("\nOnDirtyConfigurationsEventHandler :").Append(OnDirtyConfigurationsEventHandler != null ? OnDirtyConfigurationsEventHandler.GetInvocationList().Length.ToString() : "0").Append('\n');
+            stringBuilder.Append("OnDirtyNotificationEventHandler :").Append(OnDirtyNotificationEventHandler != null ? OnDirtyNotificationEventHandler.GetInvocationList().Length.ToString() : "0").Append('\n');
+            stringBuilder.Append("OnStreamDeckShowNewLayerEventHandler :").Append(OnStreamDeckShowNewLayerEventHandler != null ? OnStreamDeckShowNewLayerEventHandler.GetInvocationList().Length.ToString() : "0").Append('\n');
+            stringBuilder.Append("OnStreamDeckSelectedButtonChangedEventHandler :").Append(OnStreamDeckSelectedButtonChangedEventHandler != null ? OnStreamDeckSelectedButtonChangedEventHandler.GetInvocationList().Length.ToString() : "0").Append('\n');
+            stringBuilder.Append("OnStreamDeckClearSettingsEventHandler :").Append(OnStreamDeckClearSettingsEventHandler != null ? OnStreamDeckClearSettingsEventHandler.GetInvocationList().Length.ToString() : "0").Append('\n');
+            stringBuilder.Append("OnStreamDeckSyncConfigurationEventHandler :").Append(OnStreamDeckSyncConfigurationEventHandler != null ? OnStreamDeckSyncConfigurationEventHandler.GetInvocationList().Length.ToString() : "0").Append('\n');
+            stringBuilder.Append("OnStreamDeckConfigurationChangeEventHandler :").Append(OnStreamDeckConfigurationChangeEventHandler != null ? OnStreamDeckConfigurationChangeEventHandler.GetInvocationList().Length.ToString() : "0").Append('\n');
+            stringBuilder.Append("OnStreamDeckHideDecodersEventHandler :").Append(OnStreamDeckHideDecodersEventHandler != null ? OnStreamDeckHideDecodersEventHandler.GetInvocationList().Length.ToString() : "0").Append('\n');
 
             return stringBuilder.ToString();
         }

--- a/Source/NonVisuals/StreamDeck/FaceTypeImage.cs
+++ b/Source/NonVisuals/StreamDeck/FaceTypeImage.cs
@@ -63,7 +63,7 @@ namespace NonVisuals.StreamDeck
                 stringBuilder.Append("Face Image");
                 if (!string.IsNullOrEmpty(_imageFile))
                 {
-                    stringBuilder.Append(" ").Append(_imageFile);
+                    stringBuilder.Append(' ').Append(_imageFile);
                 }
 
                 return stringBuilder.ToString();

--- a/Source/NonVisuals/StreamDeck/FaceTypeText.cs
+++ b/Source/NonVisuals/StreamDeck/FaceTypeText.cs
@@ -57,7 +57,7 @@
                 stringBuilder.Append("Face Text");
                 if (!string.IsNullOrEmpty(_buttonTextTemplate))
                 {
-                    stringBuilder.Append(" ").Append(_buttonTextTemplate);
+                    stringBuilder.Append(' ').Append(_buttonTextTemplate);
                 }
 
                 return stringBuilder.ToString();

--- a/Source/NonVisuals/StreamDeck/LockedBitmap.cs
+++ b/Source/NonVisuals/StreamDeck/LockedBitmap.cs
@@ -39,7 +39,7 @@ namespace NonVisuals.StreamDeck
             int pixelCount = Width * Height;
 
             // Create rectangle to lock
-            Rectangle rect = new Rectangle(0, 0, Width, Height);
+            Rectangle rect = new(0, 0, Width, Height);
 
             // get source bitmap pixel format size
             Depth = Image.GetPixelFormatSize(_source.PixelFormat);

--- a/Source/NonVisuals/StreamDeck/StreamDeckButton.cs
+++ b/Source/NonVisuals/StreamDeck/StreamDeckButton.cs
@@ -23,7 +23,7 @@ namespace NonVisuals.StreamDeck
         private IStreamDeckButtonFace _buttonFace;
         private IStreamDeckButtonAction _buttonActionForPress;
         private IStreamDeckButtonAction _buttonActionForRelease;
-        [NonSerialized] private volatile CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
+        [NonSerialized] private volatile CancellationTokenSource _cancellationTokenSource = new();
         [NonSerialized] private Thread _keyPressedThread;
         [NonSerialized] private StreamDeckPanel _streamDeckPanel;
         private volatile bool _isVisible;

--- a/Source/NonVisuals/StreamDeck/StreamDeckButton.cs
+++ b/Source/NonVisuals/StreamDeck/StreamDeckButton.cs
@@ -310,17 +310,17 @@ namespace NonVisuals.StreamDeck
                 var stringBuilder = new StringBuilder();
                 if (ActionForPress != null)
                 {
-                    stringBuilder.Append("ActionPress : ").Append(_buttonActionForPress.ActionDescription).Append(" ");
+                    stringBuilder.Append("ActionPress : ").Append(_buttonActionForPress.ActionDescription).Append(' ');
                 }
 
                 if (ActionForRelease != null)
                 {
-                    stringBuilder.Append("ActionRelease : ").Append(_buttonActionForRelease.ActionDescription).Append(" ");
+                    stringBuilder.Append("ActionRelease : ").Append(_buttonActionForRelease.ActionDescription).Append(' ');
                 }
 
                 if (Face != null)
                 {
-                    stringBuilder.Append(Face.FaceDescription).Append(" ");
+                    stringBuilder.Append(Face.FaceDescription).Append(' ');
                 }
 
                 return stringBuilder.ToString();

--- a/Source/NonVisuals/StreamDeck/StreamDeckLayerHandler.cs
+++ b/Source/NonVisuals/StreamDeck/StreamDeckLayerHandler.cs
@@ -249,7 +249,7 @@ namespace NonVisuals.StreamDeck
             SystemSounds.Asterisk.Play();
         }
 
-        private List<string> AddFileForCompression(List<string> list, string file)
+        private static List<string> AddFileForCompression(List<string> list, string file)
         {
             if (string.IsNullOrEmpty(file) || !File.Exists(file) || list.Contains(file))
             {

--- a/Source/NonVisuals/StreamDeck/StreamDeckLayerHandler.cs
+++ b/Source/NonVisuals/StreamDeck/StreamDeckLayerHandler.cs
@@ -420,7 +420,7 @@ namespace NonVisuals.StreamDeck
         public string GetConfigurationInformation()
         {
             var stringBuilder = new StringBuilder(500);
-            stringBuilder.Append("\n");
+            stringBuilder.Append('\n');
 
             stringBuilder.Append($"Layer count : {_layerList.Count}, button count = {_streamDeckPanel.GetButtons().Count}\n");
             stringBuilder.Append("Existing layers:\n");
@@ -429,7 +429,7 @@ namespace NonVisuals.StreamDeck
                 stringBuilder.Append($"\t{streamDeckLayer.Name} ({streamDeckLayer.StreamDeckButtons.Count})\n");
             }
 
-            stringBuilder.Append("\n");
+            stringBuilder.Append('\n');
 
             return stringBuilder.ToString();
         }

--- a/Source/NonVisuals/StreamDeck/StreamDeckLayerHandler.cs
+++ b/Source/NonVisuals/StreamDeck/StreamDeckLayerHandler.cs
@@ -40,7 +40,7 @@ namespace NonVisuals.StreamDeck
 
         private readonly UnicodeEncoding _uniCodeEncoding = new();
         private const Formatting INDENTED_FORMATTING = Formatting.Indented;
-        private readonly JsonSerializerSettings _jsonSettings = new JsonSerializerSettings
+        private readonly JsonSerializerSettings _jsonSettings = new()
                                                                     {
                                                                         ContractResolver = new ExcludeObsoletePropertiesResolver(),
                                                                         TypeNameHandling = TypeNameHandling.All,

--- a/Source/Tests/NonVisuals/BitmapCreatorTests.cs
+++ b/Source/Tests/NonVisuals/BitmapCreatorTests.cs
@@ -179,8 +179,8 @@ namespace Tests.NonVisuals
                 for (int y = 0; y < bmp1.Height; y++)
                     if (bmp1.GetPixel(x, y) != bmp2.GetPixel(x, y))
                     {
-                        Color c1 = bmp1.GetPixel(x, y); //for debug purpose only
-                        Color c2 = bmp2.GetPixel(x, y); //for debug purpose only
+                        //Color c1 = bmp1.GetPixel(x, y); //for debug purpose only
+                        //Color c2 = bmp2.GetPixel(x, y); //for debug purpose only
                         return false;
                     }
 

--- a/Source/Tests/NonVisuals/BitmapCreatorTests.cs
+++ b/Source/Tests/NonVisuals/BitmapCreatorTests.cs
@@ -161,7 +161,7 @@ namespace Tests.NonVisuals
         /// This is quite a dumb comparison function. 
         /// We only care about the size & pixel values, no encoding check or other fancy stuff.
         /// </summary>
-        private bool CompareBitmaps(Bitmap bmp1, Bitmap bmp2)
+        private static bool CompareBitmaps(Bitmap bmp1, Bitmap bmp2)
         {
             if (bmp1 == null || bmp2 == null)
                 return false;

--- a/Source/Tests/NonVisuals/CloneTests.cs
+++ b/Source/Tests/NonVisuals/CloneTests.cs
@@ -144,7 +144,7 @@ namespace Tests.NonVisuals
         public void DCSBIOSConverter_MustBe_Clonable() {
             var gamingPanelSkeleton =
                new GamingPanelSkeleton(GamingPanelVendorEnum.Saitek, GamingPanelEnum.PZ70MultiPanel);
-            StreamDeckPanel streamdeckPanel = new StreamDeckPanel(GamingPanelEnum.StreamDeck, new HIDSkeleton(gamingPanelSkeleton, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"), true);
+            StreamDeckPanel streamdeckPanel = new(GamingPanelEnum.StreamDeck, new HIDSkeleton(gamingPanelSkeleton, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"), true);
             DCSBIOSConverter source = new(streamdeckPanel);
             source.ConverterOutputType = EnumConverterOutputType.Image;
             source.BackgroundColor = _colorValue1;


### PR DESCRIPTION
When working on the Github action, I saw that there was quite a lot of message from the code analysis. I Wanted to try to reduce the number of message given by the code analyser. I don't adhere to everyone of them but some are quite handy at improving the code readability / security / performances.

From 487 we are down to 262.

Those modifications are on the "Safe side" and should not impact the way the program work. I tested with the A10 and everything works fine.

Every "Fix" is in it's own Commit

With all this I already spotted some part of the code that I want to modify to simplify some things.

Current master:
![487](https://user-images.githubusercontent.com/67550369/201544030-4f07f9a8-3b5a-4fb1-910a-0ed1b81108e3.jpg)

This PR:
![262](https://user-images.githubusercontent.com/67550369/201544037-b8c1b013-7a7c-4456-bb80-a55999597f5c.jpg)

That's a good start :-)