### PR TITLE
[Code] Add Test units - refacto some code

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.

--- a/Source/ClassLibraryCommon/EnumEx.cs
+++ b/Source/ClassLibraryCommon/EnumEx.cs
@@ -1,9 +1,7 @@
 ﻿namespace ClassLibraryCommon
 {
     using System;
-    using System.Collections.Generic;
     using System.ComponentModel;
-    using System.Linq;
 
     public static class EnumEx
     {
@@ -34,21 +32,6 @@
             }
 
             throw new ArgumentException($"Could not find enum value {description} in enum {typeof(T)}", nameof(description));
-        }
-        
-        public static String ToPaddedHexString(int i, int padLength = 4)
-        {
-            return "0x" + i.ToString("x").PadLeft(padLength, '0');
-        }
-
-        public static String ToPaddedHexString(uint i, int padLength = 4)
-        {
-            return "0x" + i.ToString("x").PadLeft(padLength, '0');
-        }
-
-        private static int SetBitToZeroAtPosition(int value, int position)
-        {
-            return value & ~(1 << position);
         }
     }
 }

--- a/Source/ClassLibraryCommon/EnumEx.cs
+++ b/Source/ClassLibraryCommon/EnumEx.cs
@@ -36,11 +36,6 @@
             throw new ArgumentException($"Could not find enum value {description} in enum {typeof(T)}", nameof(description));
         }
         
-        public static IEnumerable<T> GetValues<T>()
-        {
-            return Enum.GetValues(typeof(T)).Cast<T>();
-        }
-
         public static String ToPaddedHexString(int i, int padLength = 4)
         {
             return "0x" + i.ToString("x").PadLeft(padLength, '0');

--- a/Source/DCS-BIOS/DCSBIOSCommon.cs
+++ b/Source/DCS-BIOS/DCSBIOSCommon.cs
@@ -48,21 +48,6 @@ namespace DCS_BIOS
             return result;
         }
 
-        public static string ToPaddedHexString(int i, int padLength = 4)
-        {
-            return "0x" + i.ToString("x").PadLeft(padLength, '0');
-        }
-
-        public static string ToPaddedHexString(uint i, int padLength = 4)
-        {
-            return "0x" + i.ToString("x").PadLeft(padLength, '0');
-        }
-
-        private static int SetBitToZeroAtPosition(int value, int position)
-        {
-            return value & ~(1 << position);
-        }
-
         public static string GetDCSBIOSJSONDirectory(string jsonDirectory)
         {
             var replaceString = "$USERDIRECTORY$";

--- a/Source/DCSFlightpanels/PanelUserControls/BackLitPanelUserControl.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/BackLitPanelUserControl.xaml.cs
@@ -179,8 +179,7 @@
                     return;
                 }
                 HideAllConfigurationExistsImages();
-                var bipPositions = ClassLibraryCommon.EnumEx.GetValues<BIPLedPositionEnum>();
-                foreach (var position in bipPositions)
+                foreach (BIPLedPositionEnum position in Enum.GetValues(typeof(BIPLedPositionEnum)))
                 {
                     SetLEDImage(position, _backlitPanelBIP.GetColor(position));
                     SetConfigExistsImageVisibility(_backlitPanelBIP.HasConfiguration(position), position);

--- a/Source/DCSFlightpanels/PanelUserControls/BackLitPanelUserControl.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/BackLitPanelUserControl.xaml.cs
@@ -210,7 +210,7 @@
                 var menuItem = (MenuItem)sender;
                 var contextMenu = (ContextMenu)menuItem.Parent;
                 var imageName = contextMenu.Tag.ToString();
-                var position = GetLedPosition(imageName);
+                var position = BacklitPanelBIP.GetLedPosition(imageName);
 
                 var ledConfigsWindow = new LEDConfigsWindow("Set configuration for LED : " + position, new SaitekPanelLEDPosition(position), _backlitPanelBIP.GetLedDcsBiosOutputs(position), _backlitPanelBIP);
                 if (ledConfigsWindow.ShowDialog() == true)
@@ -226,167 +226,6 @@
             }
         }
 
-        private static BIPLedPositionEnum GetLedPosition(string imageName)
-        {
-            var result = BIPLedPositionEnum.Position_1_1;
-            //ImagePosition3_4
-            var str = imageName.Remove(0, 14);
-            //3_4
-            var row = int.Parse(str.Substring(0, 1));
-            var index = int.Parse(str.Substring(2, 1));
-            try
-            {
-                switch (row)
-                {
-                    case 1:
-                        {
-                            switch (index)
-                            {
-                                case 1:
-                                    {
-                                        result = BIPLedPositionEnum.Position_1_1;
-                                        break;
-                                    }
-                                case 2:
-                                    {
-                                        result = BIPLedPositionEnum.Position_1_2;
-                                        break;
-                                    }
-                                case 3:
-                                    {
-                                        result = BIPLedPositionEnum.Position_1_3;
-                                        break;
-                                    }
-                                case 4:
-                                    {
-                                        result = BIPLedPositionEnum.Position_1_4;
-                                        break;
-                                    }
-                                case 5:
-                                    {
-                                        result = BIPLedPositionEnum.Position_1_5;
-                                        break;
-                                    }
-                                case 6:
-                                    {
-                                        result = BIPLedPositionEnum.Position_1_6;
-                                        break;
-                                    }
-                                case 7:
-                                    {
-                                        result = BIPLedPositionEnum.Position_1_7;
-                                        break;
-                                    }
-                                case 8:
-                                    {
-                                        result = BIPLedPositionEnum.Position_1_8;
-                                        break;
-                                    }
-                            }
-                            break;
-                        }
-                    case 2:
-                        {
-                            switch (index)
-                            {
-                                case 1:
-                                    {
-                                        result = BIPLedPositionEnum.Position_2_1;
-                                        break;
-                                    }
-                                case 2:
-                                    {
-                                        result = BIPLedPositionEnum.Position_2_2;
-                                        break;
-                                    }
-                                case 3:
-                                    {
-                                        result = BIPLedPositionEnum.Position_2_3;
-                                        break;
-                                    }
-                                case 4:
-                                    {
-                                        result = BIPLedPositionEnum.Position_2_4;
-                                        break;
-                                    }
-                                case 5:
-                                    {
-                                        result = BIPLedPositionEnum.Position_2_5;
-                                        break;
-                                    }
-                                case 6:
-                                    {
-                                        result = BIPLedPositionEnum.Position_2_6;
-                                        break;
-                                    }
-                                case 7:
-                                    {
-                                        result = BIPLedPositionEnum.Position_2_7;
-                                        break;
-                                    }
-                                case 8:
-                                    {
-                                        result = BIPLedPositionEnum.Position_2_8;
-                                        break;
-                                    }
-                            }
-                            break;
-                        }
-                    case 3:
-                        {
-                            switch (index)
-                            {
-                                case 1:
-                                    {
-                                        result = BIPLedPositionEnum.Position_3_1;
-                                        break;
-                                    }
-                                case 2:
-                                    {
-                                        result = BIPLedPositionEnum.Position_3_2;
-                                        break;
-                                    }
-                                case 3:
-                                    {
-                                        result = BIPLedPositionEnum.Position_3_3;
-                                        break;
-                                    }
-                                case 4:
-                                    {
-                                        result = BIPLedPositionEnum.Position_3_4;
-                                        break;
-                                    }
-                                case 5:
-                                    {
-                                        result = BIPLedPositionEnum.Position_3_5;
-                                        break;
-                                    }
-                                case 6:
-                                    {
-                                        result = BIPLedPositionEnum.Position_3_6;
-                                        break;
-                                    }
-                                case 7:
-                                    {
-                                        result = BIPLedPositionEnum.Position_3_7;
-                                        break;
-                                    }
-                                case 8:
-                                    {
-                                        result = BIPLedPositionEnum.Position_3_8;
-                                        break;
-                                    }
-                            }
-                            break;
-                        }
-                }
-            }
-            catch (Exception ex)
-            {
-                Common.ShowErrorMessageBox(ex);
-            }
-            return result;
-        }
 
         private void SetContextMenuClickHandlers()
         {
@@ -514,7 +353,7 @@
 
         private void SetPhysicalLED(Image image, PanelLEDColor newColor)
         {
-            var position = GetLedPosition(image.Name);
+            var position = BacklitPanelBIP.GetLedPosition(image.Name);
             _backlitPanelBIP.SetLED(position, newColor);
         }
 

--- a/Source/NonVisuals/Radios/Misc/PZ69DisplayBytes.cs
+++ b/Source/NonVisuals/Radios/Misc/PZ69DisplayBytes.cs
@@ -19,14 +19,14 @@
      * 0xFF -> blank, nothing is shown in that spot.
      *
      */
-    public class PZ69DisplayBytes
+    public static class PZ69DisplayBytes
     {
         internal static Logger logger = LogManager.GetCurrentClassLogger();
 
         /// <summary>
         /// Right justify, pad left with blanks.
         /// </summary>
-        public void UnsignedInteger(ref byte[] bytes, uint digits, PZ69LCDPosition pz69LCDPosition)
+        public static void UnsignedInteger(ref byte[] bytes, uint digits, PZ69LCDPosition pz69LCDPosition)
         {
             var arrayPosition = GetArrayPosition(pz69LCDPosition);
             var maxArrayPosition = GetArrayPosition(pz69LCDPosition) + 4;
@@ -56,7 +56,7 @@
         /// Can deal with multiple '.' chars.
         /// If size does not match 5, it will NOT replace previous characters in the array (no padding left or right).
         /// </summary>
-        public void DefaultStringAsIs(ref byte[] bytes, string digits, PZ69LCDPosition pz69LCDPosition)
+        public static void DefaultStringAsIs(ref byte[] bytes, string digits, PZ69LCDPosition pz69LCDPosition)
         {
             var arrayPosition = GetArrayPosition(pz69LCDPosition);
             var maxArrayPosition = GetArrayPosition(pz69LCDPosition) + 4;
@@ -94,7 +94,7 @@
             while (i < digits.Length && arrayPosition < maxArrayPosition + 1);
         }
        
-        public void DoubleWithSpecifiedDecimalsPlaces(ref byte[] bytes, double digits, int decimals, PZ69LCDPosition pz69LCDPosition)
+        public static void DoubleWithSpecifiedDecimalsPlaces(ref byte[] bytes, double digits, int decimals, PZ69LCDPosition pz69LCDPosition)
         {
             var arrayPosition = GetArrayPosition(pz69LCDPosition);
             var maxArrayPosition = GetArrayPosition(pz69LCDPosition) + 4;
@@ -131,7 +131,7 @@
             while (i < digitsAsString.Length && arrayPosition < maxArrayPosition + 1);
         }
 
-        public void DoubleJustifyLeft(ref byte[] bytes, double digits, PZ69LCDPosition pz69LCDPosition)
+        public static void DoubleJustifyLeft(ref byte[] bytes, double digits, PZ69LCDPosition pz69LCDPosition)
         {
             var arrayPosition = GetArrayPosition(pz69LCDPosition);
             var maxArrayPosition = GetArrayPosition(pz69LCDPosition) + 4;
@@ -189,7 +189,7 @@
         /// <summary>
         /// Sets the given position to blank without modifying the other positions in the array
         /// </summary>
-        public void SetPositionBlank(ref byte[] bytes, PZ69LCDPosition pz69LCDPosition)
+        public static void SetPositionBlank(ref byte[] bytes, PZ69LCDPosition pz69LCDPosition)
         {
             var arrayPosition = GetArrayPosition(pz69LCDPosition);
             var i = 0;
@@ -204,30 +204,14 @@
 
         private static int GetArrayPosition(PZ69LCDPosition pz69LCDPosition)
         {
-            switch (pz69LCDPosition)
+            return pz69LCDPosition switch
             {
-                case PZ69LCDPosition.UPPER_ACTIVE_LEFT:
-                    {
-                        return 1;
-                    }
-
-                case PZ69LCDPosition.UPPER_STBY_RIGHT:
-                    {
-                        return 6;
-                    }
-
-                case PZ69LCDPosition.LOWER_ACTIVE_LEFT:
-                    {
-                        return 11;
-                    }
-
-                case PZ69LCDPosition.LOWER_STBY_RIGHT:
-                    {
-                        return 16;
-                    }
-            }
-
-            return 1;
+                PZ69LCDPosition.UPPER_ACTIVE_LEFT => 1,
+                PZ69LCDPosition.UPPER_STBY_RIGHT => 6,
+                PZ69LCDPosition.LOWER_ACTIVE_LEFT => 11,
+                PZ69LCDPosition.LOWER_STBY_RIGHT => 16,
+                _ => 1
+            };            
         }
     }
 }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69Base.cs
@@ -38,7 +38,6 @@
         public long ResetSyncTimeout { get; set; } = 35000000;
 
         private long _syncOKDelayTimeout = 50000000; // 5s
-        private readonly PZ69DisplayBytes _pZ69DisplayBytes = new();
 
         protected RadioPanelPZ69Base(HIDSkeleton hidSkeleton) : base(GamingPanelEnum.PZ69RadioPanel, hidSkeleton)
         {
@@ -96,7 +95,7 @@
         /// </summary>
         protected void SetPZ69DisplayBlank(ref byte[] bytes, PZ69LCDPosition pz69LCDPosition)
         {
-            _pZ69DisplayBytes.SetPositionBlank(ref bytes, pz69LCDPosition);
+            PZ69DisplayBytes.SetPositionBlank(ref bytes, pz69LCDPosition);
         }
 
         public override void SavePanelSettingsJSON(object sender, ProfileHandlerEventArgs e)
@@ -108,12 +107,12 @@
         /// </summary>
         protected void SetPZ69DisplayBytesUnsignedInteger(ref byte[] bytes, uint digits, PZ69LCDPosition pz69LCDPosition)
         {
-            _pZ69DisplayBytes.UnsignedInteger(ref bytes, digits, pz69LCDPosition);
+            PZ69DisplayBytes.UnsignedInteger(ref bytes, digits, pz69LCDPosition);
         }
 
         protected void SetPZ69DisplayBytes(ref byte[] bytes, double digits, int decimals, PZ69LCDPosition pz69LCDPosition)
         {
-            _pZ69DisplayBytes.DoubleWithSpecifiedDecimalsPlaces(ref bytes, digits, decimals, pz69LCDPosition);
+            PZ69DisplayBytes.DoubleWithSpecifiedDecimalsPlaces(ref bytes, digits, decimals, pz69LCDPosition);
         }
 
         public override void Identify()
@@ -189,7 +188,7 @@
         {
             try
             {
-                _pZ69DisplayBytes.DefaultStringAsIs(ref bytes, digits, pz69LCDPosition);
+                PZ69DisplayBytes.DefaultStringAsIs(ref bytes, digits, pz69LCDPosition);
             }
             catch (Exception ex)
             {
@@ -199,7 +198,7 @@
 
         protected void SetPZ69DisplayBytesDefault(ref byte[] bytes, double digits, PZ69LCDPosition pz69LCDPosition)
         {
-            _pZ69DisplayBytes.DoubleJustifyLeft(ref bytes, digits, pz69LCDPosition);
+            PZ69DisplayBytes.DoubleJustifyLeft(ref bytes, digits, pz69LCDPosition);
         }
 
         public void SendLCDData(byte[] array)

--- a/Source/NonVisuals/Saitek/PZ70LCDButtonByteList.cs
+++ b/Source/NonVisuals/Saitek/PZ70LCDButtonByteList.cs
@@ -146,21 +146,6 @@
             }
         }
 
-        public void SetButtonOnOrOff(PZ70DialPosition pz70DialPosition, MultiPanelPZ70Knobs multiPanelPZ70Knob, bool on)
-        {
-            SetButtonOnOrOff(GetMaskForDialPosition(pz70DialPosition), GetMaskForButton(multiPanelPZ70Knob), on);
-        }
-
-        public bool SetButtonOnOrOff(int buttonDialMask, byte buttonMask, bool on)
-        {
-            if (on)
-            {
-                return SetButtonOn(buttonDialMask, buttonMask);
-            }
-
-            return SetButtonOff(buttonDialMask, buttonMask);
-        }
-
         public void SetButtonOff(PZ70DialPosition pz70DialPosition, MultiPanelPZ70Knobs multiPanelPZ70Knob)
         {
             SetButtonOff(GetMaskForDialPosition(pz70DialPosition), GetMaskForButton(multiPanelPZ70Knob));
@@ -180,33 +165,6 @@
                 }
 
                 throw new Exception("Multipanel ButtonOff : Failed to find Mask for dial " + buttonDialMask + " button " + buttonMask);
-            }
-            catch (Exception ex)
-            {
-                logger.Error(ex);
-                throw;
-            }
-        }
-
-        public void SetButtonOn(PZ70DialPosition pz70DialPosition, MultiPanelPZ70Knobs multiPanelPZ70Knob)
-        {
-            SetButtonOn(GetMaskForDialPosition(pz70DialPosition), GetMaskForButton(multiPanelPZ70Knob));
-        }
-
-        public bool SetButtonOn(int buttonDialMask, byte buttonMask)
-        {
-            try
-            {
-                for (int i = 0; i < _buttonDialPosition.Length; i++)
-                {
-                    if ((_buttonDialPosition[i] & buttonDialMask) != 0)
-                    {
-                        _buttonBytes[i] |= buttonMask;
-                        return (_buttonBytes[i] & buttonMask) != 0;
-                    }
-                }
-
-                throw new Exception("Multipanel ButtonOn : Failed to find Mask for dial " + buttonDialMask + " button " + buttonMask);
             }
             catch (Exception ex)
             {
@@ -237,30 +195,5 @@
                 throw;
             }
         }
-
-        public byte GetButtonByte(int buttonDialMask)
-        {
-            try
-            {
-                for (int i = 0; i < _buttonDialPosition.Length; i++)
-                {
-                    if ((_buttonDialPosition[i] & buttonDialMask) != 0)
-                    {
-                        return _buttonBytes[i];
-                    }
-                }
-
-                throw new Exception("Multipanel GetButtonByte : Failed to find Mask for dial " + buttonDialMask);
-            }
-            catch (Exception ex)
-            {
-                logger.Error(ex);
-                throw;
-            }
-        }
-
-        
-
-
     }
 }

--- a/Source/NonVisuals/Saitek/PZ70LCDButtonByteList.cs
+++ b/Source/NonVisuals/Saitek/PZ70LCDButtonByteList.cs
@@ -97,98 +97,31 @@
 
         public static int GetMaskForDialPosition(PZ70DialPosition pz70DialPosition)
         {
-            try
+            return pz70DialPosition switch
             {
-
-                switch (pz70DialPosition)
-                {
-                    case PZ70DialPosition.ALT:
-                        {
-                            return DIAL_ALT_MASK;
-                        }
-
-                    case PZ70DialPosition.VS:
-                        {
-                            return DIAL_VS_MASK;
-                        }
-
-                    case PZ70DialPosition.IAS:
-                        {
-                            return DIAL_IAS_MASK;
-                        }
-
-                    case PZ70DialPosition.HDG:
-                        {
-                            return DIAL_HDG_MASK;
-                        }
-
-                    case PZ70DialPosition.CRS:
-                        {
-                            return DIAL_CRS_MASK;
-                        }
-                }
-                throw new Exception("Multipanel : Failed to find Mask for dial position " + pz70DialPosition);
-            }
-            catch (Exception ex)
-            {
-                logger.Error(ex);
-                throw;
-            }
+                PZ70DialPosition.ALT => DIAL_ALT_MASK,
+                PZ70DialPosition.VS  => DIAL_VS_MASK,
+                PZ70DialPosition.IAS => DIAL_IAS_MASK,
+                PZ70DialPosition.HDG => DIAL_HDG_MASK,
+                PZ70DialPosition.CRS => DIAL_CRS_MASK,
+                _ => throw new Exception($"Multipanel : Failed to find Mask for dial position {pz70DialPosition}")
+            };
         }
 
         public static byte GetMaskForButton(MultiPanelPZ70Knobs multiPanelPZ70Knob)
         {
-            try
+            return multiPanelPZ70Knob switch
             {
-                switch (multiPanelPZ70Knob)
-                {
-                    case MultiPanelPZ70Knobs.AP_BUTTON:
-                        {
-                            return AP_MASK;
-                        }
-
-                    case MultiPanelPZ70Knobs.HDG_BUTTON:
-                        {
-                            return HDG_MASK;
-                        }
-
-                    case MultiPanelPZ70Knobs.NAV_BUTTON:
-                        {
-                            return NAV_MASK;
-                        }
-
-                    case MultiPanelPZ70Knobs.IAS_BUTTON:
-                        {
-                            return IAS_MASK;
-                        }
-
-                    case MultiPanelPZ70Knobs.ALT_BUTTON:
-                        {
-                            return ALT_MASK;
-                        }
-
-                    case MultiPanelPZ70Knobs.VS_BUTTON:
-                        {
-                            return VS_MASK;
-                        }
-
-                    case MultiPanelPZ70Knobs.APR_BUTTON:
-                        {
-                            return APR_MASK;
-                        }
-
-                    case MultiPanelPZ70Knobs.REV_BUTTON:
-                        {
-                            return REV_MASK;
-                        }
-                }
-                throw new Exception("Multipanel : Failed to find Mask for button " + multiPanelPZ70Knob);
-            }
-            catch (Exception ex)
-            {
-                logger.Error(ex);
-                throw;
-            }
+                MultiPanelPZ70Knobs.AP_BUTTON  => AP_MASK,
+                MultiPanelPZ70Knobs.HDG_BUTTON => HDG_MASK,
+                MultiPanelPZ70Knobs.NAV_BUTTON => NAV_MASK,
+                MultiPanelPZ70Knobs.IAS_BUTTON => IAS_MASK,
+                MultiPanelPZ70Knobs.ALT_BUTTON => ALT_MASK,
+                MultiPanelPZ70Knobs.VS_BUTTON  => VS_MASK,
+                MultiPanelPZ70Knobs.APR_BUTTON => APR_MASK,
+                MultiPanelPZ70Knobs.REV_BUTTON => REV_MASK,
+                _ => throw new Exception($"Multipanel : Failed to find Mask for button {multiPanelPZ70Knob}")
+            };
         }
 
         public bool FlipButton(int buttonDialMask, byte buttonMask)

--- a/Source/NonVisuals/Saitek/Panels/BacklitPanelBIP.cs
+++ b/Source/NonVisuals/Saitek/Panels/BacklitPanelBIP.cs
@@ -731,6 +731,168 @@ namespace NonVisuals.Saitek.Panels
 
             _dcsbiosBrightnessControl = DCSBIOSControlLocator.GetDCSBIOSOutput(_dcsBiosBrightnessBinding.ControlId);
         }
+
+        public static BIPLedPositionEnum GetLedPosition(string imageName)
+        {
+            var result = BIPLedPositionEnum.Position_1_1;
+            //ImagePosition3_4
+            var str = imageName.Remove(0, 14);
+            //3_4
+            var row = int.Parse(str.Substring(0, 1));
+            var index = int.Parse(str.Substring(2, 1));
+            try
+            {
+                switch (row)
+                {
+                    case 1:
+                        {
+                            switch (index)
+                            {
+                                case 1:
+                                    {
+                                        result = BIPLedPositionEnum.Position_1_1;
+                                        break;
+                                    }
+                                case 2:
+                                    {
+                                        result = BIPLedPositionEnum.Position_1_2;
+                                        break;
+                                    }
+                                case 3:
+                                    {
+                                        result = BIPLedPositionEnum.Position_1_3;
+                                        break;
+                                    }
+                                case 4:
+                                    {
+                                        result = BIPLedPositionEnum.Position_1_4;
+                                        break;
+                                    }
+                                case 5:
+                                    {
+                                        result = BIPLedPositionEnum.Position_1_5;
+                                        break;
+                                    }
+                                case 6:
+                                    {
+                                        result = BIPLedPositionEnum.Position_1_6;
+                                        break;
+                                    }
+                                case 7:
+                                    {
+                                        result = BIPLedPositionEnum.Position_1_7;
+                                        break;
+                                    }
+                                case 8:
+                                    {
+                                        result = BIPLedPositionEnum.Position_1_8;
+                                        break;
+                                    }
+                            }
+                            break;
+                        }
+                    case 2:
+                        {
+                            switch (index)
+                            {
+                                case 1:
+                                    {
+                                        result = BIPLedPositionEnum.Position_2_1;
+                                        break;
+                                    }
+                                case 2:
+                                    {
+                                        result = BIPLedPositionEnum.Position_2_2;
+                                        break;
+                                    }
+                                case 3:
+                                    {
+                                        result = BIPLedPositionEnum.Position_2_3;
+                                        break;
+                                    }
+                                case 4:
+                                    {
+                                        result = BIPLedPositionEnum.Position_2_4;
+                                        break;
+                                    }
+                                case 5:
+                                    {
+                                        result = BIPLedPositionEnum.Position_2_5;
+                                        break;
+                                    }
+                                case 6:
+                                    {
+                                        result = BIPLedPositionEnum.Position_2_6;
+                                        break;
+                                    }
+                                case 7:
+                                    {
+                                        result = BIPLedPositionEnum.Position_2_7;
+                                        break;
+                                    }
+                                case 8:
+                                    {
+                                        result = BIPLedPositionEnum.Position_2_8;
+                                        break;
+                                    }
+                            }
+                            break;
+                        }
+                    case 3:
+                        {
+                            switch (index)
+                            {
+                                case 1:
+                                    {
+                                        result = BIPLedPositionEnum.Position_3_1;
+                                        break;
+                                    }
+                                case 2:
+                                    {
+                                        result = BIPLedPositionEnum.Position_3_2;
+                                        break;
+                                    }
+                                case 3:
+                                    {
+                                        result = BIPLedPositionEnum.Position_3_3;
+                                        break;
+                                    }
+                                case 4:
+                                    {
+                                        result = BIPLedPositionEnum.Position_3_4;
+                                        break;
+                                    }
+                                case 5:
+                                    {
+                                        result = BIPLedPositionEnum.Position_3_5;
+                                        break;
+                                    }
+                                case 6:
+                                    {
+                                        result = BIPLedPositionEnum.Position_3_6;
+                                        break;
+                                    }
+                                case 7:
+                                    {
+                                        result = BIPLedPositionEnum.Position_3_7;
+                                        break;
+                                    }
+                                case 8:
+                                    {
+                                        result = BIPLedPositionEnum.Position_3_8;
+                                        break;
+                                    }
+                            }
+                            break;
+                        }
+                }
+            }
+            catch (Exception ex)
+            {
+                Common.ShowErrorMessageBox(ex);
+            }
+            return result;
+        }
     }
 
     [Serializable]
@@ -833,4 +995,5 @@ namespace NonVisuals.Saitek.Panels
         ||_ 
         |_  Rightmost RED when not same bit in Byte #3 set
  */
+
 }

--- a/Source/NonVisuals/Saitek/Panels/BacklitPanelBIP.cs
+++ b/Source/NonVisuals/Saitek/Panels/BacklitPanelBIP.cs
@@ -734,164 +734,49 @@ namespace NonVisuals.Saitek.Panels
 
         public static BIPLedPositionEnum GetLedPosition(string imageName)
         {
-            var result = BIPLedPositionEnum.Position_1_1;
-            //ImagePosition3_4
-            var str = imageName.Remove(0, 14);
-            //3_4
-            var row = int.Parse(str.Substring(0, 1));
-            var index = int.Parse(str.Substring(2, 1));
-            try
+            //ImagePosition_3_4
+            var row = int.Parse(imageName.Substring(14, 1));
+            var index = int.Parse(imageName.Substring(16, 1));
+            return row switch
             {
-                switch (row)
+                1 => index switch
                 {
-                    case 1:
-                        {
-                            switch (index)
-                            {
-                                case 1:
-                                    {
-                                        result = BIPLedPositionEnum.Position_1_1;
-                                        break;
-                                    }
-                                case 2:
-                                    {
-                                        result = BIPLedPositionEnum.Position_1_2;
-                                        break;
-                                    }
-                                case 3:
-                                    {
-                                        result = BIPLedPositionEnum.Position_1_3;
-                                        break;
-                                    }
-                                case 4:
-                                    {
-                                        result = BIPLedPositionEnum.Position_1_4;
-                                        break;
-                                    }
-                                case 5:
-                                    {
-                                        result = BIPLedPositionEnum.Position_1_5;
-                                        break;
-                                    }
-                                case 6:
-                                    {
-                                        result = BIPLedPositionEnum.Position_1_6;
-                                        break;
-                                    }
-                                case 7:
-                                    {
-                                        result = BIPLedPositionEnum.Position_1_7;
-                                        break;
-                                    }
-                                case 8:
-                                    {
-                                        result = BIPLedPositionEnum.Position_1_8;
-                                        break;
-                                    }
-                            }
-                            break;
-                        }
-                    case 2:
-                        {
-                            switch (index)
-                            {
-                                case 1:
-                                    {
-                                        result = BIPLedPositionEnum.Position_2_1;
-                                        break;
-                                    }
-                                case 2:
-                                    {
-                                        result = BIPLedPositionEnum.Position_2_2;
-                                        break;
-                                    }
-                                case 3:
-                                    {
-                                        result = BIPLedPositionEnum.Position_2_3;
-                                        break;
-                                    }
-                                case 4:
-                                    {
-                                        result = BIPLedPositionEnum.Position_2_4;
-                                        break;
-                                    }
-                                case 5:
-                                    {
-                                        result = BIPLedPositionEnum.Position_2_5;
-                                        break;
-                                    }
-                                case 6:
-                                    {
-                                        result = BIPLedPositionEnum.Position_2_6;
-                                        break;
-                                    }
-                                case 7:
-                                    {
-                                        result = BIPLedPositionEnum.Position_2_7;
-                                        break;
-                                    }
-                                case 8:
-                                    {
-                                        result = BIPLedPositionEnum.Position_2_8;
-                                        break;
-                                    }
-                            }
-                            break;
-                        }
-                    case 3:
-                        {
-                            switch (index)
-                            {
-                                case 1:
-                                    {
-                                        result = BIPLedPositionEnum.Position_3_1;
-                                        break;
-                                    }
-                                case 2:
-                                    {
-                                        result = BIPLedPositionEnum.Position_3_2;
-                                        break;
-                                    }
-                                case 3:
-                                    {
-                                        result = BIPLedPositionEnum.Position_3_3;
-                                        break;
-                                    }
-                                case 4:
-                                    {
-                                        result = BIPLedPositionEnum.Position_3_4;
-                                        break;
-                                    }
-                                case 5:
-                                    {
-                                        result = BIPLedPositionEnum.Position_3_5;
-                                        break;
-                                    }
-                                case 6:
-                                    {
-                                        result = BIPLedPositionEnum.Position_3_6;
-                                        break;
-                                    }
-                                case 7:
-                                    {
-                                        result = BIPLedPositionEnum.Position_3_7;
-                                        break;
-                                    }
-                                case 8:
-                                    {
-                                        result = BIPLedPositionEnum.Position_3_8;
-                                        break;
-                                    }
-                            }
-                            break;
-                        }
-                }
-            }
-            catch (Exception ex)
-            {
-                Common.ShowErrorMessageBox(ex);
-            }
-            return result;
+                    1 => BIPLedPositionEnum.Position_1_1,
+                    2 => BIPLedPositionEnum.Position_1_2,
+                    3 => BIPLedPositionEnum.Position_1_3,
+                    4 => BIPLedPositionEnum.Position_1_4,
+                    5 => BIPLedPositionEnum.Position_1_5,
+                    6 => BIPLedPositionEnum.Position_1_6,
+                    7 => BIPLedPositionEnum.Position_1_7,
+                    8 => BIPLedPositionEnum.Position_1_8,
+                    _=> BIPLedPositionEnum.Position_1_1
+                },
+                2 => index switch
+                {
+                    1 => BIPLedPositionEnum.Position_2_1,
+                    2 => BIPLedPositionEnum.Position_2_2,
+                    3 => BIPLedPositionEnum.Position_2_3,
+                    4 => BIPLedPositionEnum.Position_2_4,
+                    5 => BIPLedPositionEnum.Position_2_5,
+                    6 => BIPLedPositionEnum.Position_2_6,
+                    7 => BIPLedPositionEnum.Position_2_7,
+                    8 => BIPLedPositionEnum.Position_2_8,
+                    _ => BIPLedPositionEnum.Position_1_1
+                },
+                3 => index switch
+                {
+                    1 => BIPLedPositionEnum.Position_3_1,
+                    2 => BIPLedPositionEnum.Position_3_2,
+                    3 => BIPLedPositionEnum.Position_3_3,
+                    4 => BIPLedPositionEnum.Position_3_4,
+                    5 => BIPLedPositionEnum.Position_3_5,
+                    6 => BIPLedPositionEnum.Position_3_6,
+                    7 => BIPLedPositionEnum.Position_3_7,
+                    8 => BIPLedPositionEnum.Position_3_8,
+                    _ => BIPLedPositionEnum.Position_1_1
+                },
+                _ => BIPLedPositionEnum.Position_1_1
+            };
         }
     }
 

--- a/Source/NonVisuals/Saitek/Panels/SwitchPanelPZ55.cs
+++ b/Source/NonVisuals/Saitek/Panels/SwitchPanelPZ55.cs
@@ -982,104 +982,34 @@ namespace NonVisuals.Saitek.Panels
 
         public static SwitchPanelPZ55LEDs GetSwitchPanelPZ55LEDColor(SwitchPanelPZ55LEDPosition switchPanelPZ55LEDPosition, PanelLEDColor panelLEDColor)
         {
-            var result = SwitchPanelPZ55LEDs.ALL_DARK;
-
-            switch (switchPanelPZ55LEDPosition)
+            return switchPanelPZ55LEDPosition switch
             {
-                case SwitchPanelPZ55LEDPosition.UP:
-                    {
-                        switch (panelLEDColor)
-                        {
-                            case PanelLEDColor.DARK:
-                                {
-                                    result = SwitchPanelPZ55LEDs.ALL_DARK;
-                                    break;
-                                }
-
-                            case PanelLEDColor.GREEN:
-                                {
-                                    result = SwitchPanelPZ55LEDs.UP_GREEN;
-                                    break;
-                                }
-
-                            case PanelLEDColor.RED:
-                                {
-                                    result = SwitchPanelPZ55LEDs.UP_RED;
-                                    break;
-                                }
-
-                            case PanelLEDColor.YELLOW:
-                                {
-                                    result = SwitchPanelPZ55LEDs.UP_YELLOW;
-                                    break;
-                                }
-                        }
-                        break;
-                    }
-
-                case SwitchPanelPZ55LEDPosition.LEFT:
-                    {
-                        switch (panelLEDColor)
-                        {
-                            case PanelLEDColor.DARK:
-                                {
-                                    result = SwitchPanelPZ55LEDs.ALL_DARK;
-                                    break;
-                                }
-
-                            case PanelLEDColor.GREEN:
-                                {
-                                    result = SwitchPanelPZ55LEDs.LEFT_GREEN;
-                                    break;
-                                }
-
-                            case PanelLEDColor.RED:
-                                {
-                                    result = SwitchPanelPZ55LEDs.LEFT_RED;
-                                    break;
-                                }
-
-                            case PanelLEDColor.YELLOW:
-                                {
-                                    result = SwitchPanelPZ55LEDs.LEFT_YELLOW;
-                                    break;
-                                }
-                        }
-                        break;
-                    }
-
-                case SwitchPanelPZ55LEDPosition.RIGHT:
-                    {
-                        switch (panelLEDColor)
-                        {
-                            case PanelLEDColor.DARK:
-                                {
-                                    result = SwitchPanelPZ55LEDs.ALL_DARK;
-                                    break;
-                                }
-
-                            case PanelLEDColor.GREEN:
-                                {
-                                    result = SwitchPanelPZ55LEDs.RIGHT_GREEN;
-                                    break;
-                                }
-
-                            case PanelLEDColor.RED:
-                                {
-                                    result = SwitchPanelPZ55LEDs.RIGHT_RED;
-                                    break;
-                                }
-
-                            case PanelLEDColor.YELLOW:
-                                {
-                                    result = SwitchPanelPZ55LEDs.RIGHT_YELLOW;
-                                    break;
-                                }
-                        }
-                        break;
-                    }
-            }
-            return result;
+                SwitchPanelPZ55LEDPosition.UP => panelLEDColor switch
+                {
+                    PanelLEDColor.DARK => SwitchPanelPZ55LEDs.ALL_DARK,
+                    PanelLEDColor.GREEN => SwitchPanelPZ55LEDs.UP_GREEN,
+                    PanelLEDColor.RED => SwitchPanelPZ55LEDs.UP_RED,
+                    PanelLEDColor.YELLOW => SwitchPanelPZ55LEDs.UP_YELLOW,
+                    _ => SwitchPanelPZ55LEDs.ALL_DARK
+                },
+                SwitchPanelPZ55LEDPosition.LEFT => panelLEDColor switch
+                {
+                    PanelLEDColor.DARK => SwitchPanelPZ55LEDs.ALL_DARK,
+                    PanelLEDColor.GREEN => SwitchPanelPZ55LEDs.LEFT_GREEN,
+                    PanelLEDColor.RED => SwitchPanelPZ55LEDs.LEFT_RED,
+                    PanelLEDColor.YELLOW => SwitchPanelPZ55LEDs.LEFT_YELLOW,
+                    _ => SwitchPanelPZ55LEDs.ALL_DARK
+                },
+                SwitchPanelPZ55LEDPosition.RIGHT => panelLEDColor switch
+                {
+                    PanelLEDColor.DARK => SwitchPanelPZ55LEDs.ALL_DARK,
+                    PanelLEDColor.GREEN => SwitchPanelPZ55LEDs.RIGHT_GREEN,
+                    PanelLEDColor.RED => SwitchPanelPZ55LEDs.RIGHT_RED,
+                    PanelLEDColor.YELLOW => SwitchPanelPZ55LEDs.RIGHT_YELLOW,
+                    _ => SwitchPanelPZ55LEDs.ALL_DARK
+                },
+                _ => SwitchPanelPZ55LEDs.ALL_DARK
+            };
         }
 
         private void CreateSwitchKeys()

--- a/Source/NonVisuals/Saitek/Panels/SwitchPanelPZ55.cs
+++ b/Source/NonVisuals/Saitek/Panels/SwitchPanelPZ55.cs
@@ -980,7 +980,7 @@ namespace NonVisuals.Saitek.Panels
             }
         }
 
-        private static SwitchPanelPZ55LEDs GetSwitchPanelPZ55LEDColor(SwitchPanelPZ55LEDPosition switchPanelPZ55LEDPosition, PanelLEDColor panelLEDColor)
+        public static SwitchPanelPZ55LEDs GetSwitchPanelPZ55LEDColor(SwitchPanelPZ55LEDPosition switchPanelPZ55LEDPosition, PanelLEDColor panelLEDColor)
         {
             var result = SwitchPanelPZ55LEDs.ALL_DARK;
 

--- a/Source/NonVisuals/StreamDeck/DCSBIOSConverter.cs
+++ b/Source/NonVisuals/StreamDeck/DCSBIOSConverter.cs
@@ -297,101 +297,32 @@ namespace NonVisuals.StreamDeck
             set => _referenceValue2 = value;
         }
 
-        private static string GetOutputAsString(EnumConverterOutputType converterOutputType)
+        public static string GetOutputAsString(EnumConverterOutputType converterOutputType)
         {
-            string result;
-            switch (converterOutputType)
+            return converterOutputType switch
             {
-                case EnumConverterOutputType.NotSet:
-                    {
-                        result = "not set";
-                        break;
-                    }
-
-                case EnumConverterOutputType.Raw:
-                    {
-                        result = "raw";
-                        break;
-                    }
-
-                case EnumConverterOutputType.Image:
-                    {
-                        result = "image";
-                        break;
-                    }
-
-                case EnumConverterOutputType.ImageOverlay:
-                    {
-                        result = "image overlay";
-                        break;
-                    }
-
-                default:
-                    {
-                        result = "unknown?";
-                        break;
-                    }
-            }
-
-            return result;
+                EnumConverterOutputType.NotSet => "not set",
+                EnumConverterOutputType.Raw => "raw",
+                EnumConverterOutputType.Image => "image",
+                EnumConverterOutputType.ImageOverlay => "image overlay",
+                _ => "unknown?"
+            };
         }
 
-        private static string GetComparatorAsString(EnumComparator comparator)
+        public static string GetComparatorAsString(EnumComparator comparator)
         {
-            var result = string.Empty;
-
-            switch (comparator)
+            return comparator switch
             {
-                case EnumComparator.NotSet:
-                    {
-                        result = "NotSet";
-                        break;
-                    }
-
-                case EnumComparator.Equals:
-                    {
-                        result = "==";
-                        break;
-                    }
-
-                case EnumComparator.NotEquals:
-                    {
-                        result = "!=";
-                        break;
-                    }
-
-                case EnumComparator.LessThan:
-                    {
-                        result = "<";
-                        break;
-                    }
-
-                case EnumComparator.LessThanEqual:
-                    {
-                        result = "<=";
-                        break;
-                    }
-
-                case EnumComparator.GreaterThan:
-                    {
-                        result = ">";
-                        break;
-                    }
-
-                case EnumComparator.GreaterThanEqual:
-                    {
-                        result = ">=";
-                        break;
-                    }
-
-                case EnumComparator.Always:
-                    {
-                        result = "Always";
-                        break;
-                    }
-            }
-
-            return result;
+                EnumComparator.NotSet => "NotSet",
+                EnumComparator.Equals => "==",
+                EnumComparator.NotEquals => "!=",
+                EnumComparator.LessThan => "<",
+                EnumComparator.LessThanEqual => "<=",
+                EnumComparator.GreaterThan => ">",
+                EnumComparator.GreaterThanEqual => ">=",
+                EnumComparator.Always => "Always",
+                _ => throw new ArgumentException($"Unexpected EnumComparator value {comparator}")
+            };       
         }
 
         [JsonIgnore]

--- a/Source/Tests/NonVisuals/BackLitPanelTests.cs
+++ b/Source/Tests/NonVisuals/BackLitPanelTests.cs
@@ -1,0 +1,90 @@
+﻿using DCSFlightpanels.PanelUserControls;
+using NonVisuals.Saitek.Panels;
+using System;
+using Xunit;
+
+namespace Tests.NonVisuals
+{
+    public class BackLitPanelTests
+    {
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("a2")]
+        [InlineData("a23")]
+        [InlineData("a234")]
+        [InlineData("a2345")]
+        [InlineData("a23456")]
+        [InlineData("a234567")]
+        [InlineData("a2345678")]
+        [InlineData("a23456789")]
+        [InlineData("a234567890")]
+        [InlineData("a2345678901")]
+        [InlineData("a23456789012")]
+        [InlineData("a234567890123")]
+        [InlineData("12345678901234")]
+        [InlineData("abcdefghijklmn")]
+        public void GetLedPosition_Throws_ArgumentOutOfRange_IfStringSmallerThan15CharsLong(string inputString)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => BacklitPanelBIP.GetLedPosition(inputString));
+        }
+
+        [Theory]
+        [InlineData("12345678901234a")]
+        [InlineData("12345678901234_")]
+        [InlineData("_______________")]
+
+        public void GetLedPosition_Throws_FormatException_If15thCharIsNotInt(string inputString)
+        {
+            Assert.Throws<FormatException>(() => BacklitPanelBIP.GetLedPosition(inputString));
+        }
+
+        [Theory]
+        [InlineData("______________1")]
+        [InlineData("______________12")]
+        [InlineData("______________1a")]
+        public void GetLedPosition_Throws_ArgumentOutOfRange_IfStringSmallerThan17CharsLong(string inputString)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => BacklitPanelBIP.GetLedPosition(inputString));
+        }
+
+        [Theory]
+        [InlineData("______________1aa")]
+        [InlineData("______________1_a")]
+        [InlineData("______________1_b")]
+        [InlineData("______________0_b")]
+        [InlineData("______________9_x")]
+        public void GetLedPosition_Throws_FormatException_If17thCharIsNotInt(string inputString)
+        {
+            Assert.Throws<FormatException>(() => BacklitPanelBIP.GetLedPosition(inputString));
+        }
+
+        [Theory]
+        [InlineData("______________1a1", BIPLedPositionEnum.Position_1_1)]
+        [InlineData("______________1_1", BIPLedPositionEnum.Position_1_1)]
+        [InlineData("aaaaaaaaaaaaaa1b1", BIPLedPositionEnum.Position_1_1)]
+        [InlineData("aaaaaaaaaaaaaa1b2", BIPLedPositionEnum.Position_1_2)]
+        [InlineData("______________1_8", BIPLedPositionEnum.Position_1_8)]
+        [InlineData("______________2_1", BIPLedPositionEnum.Position_2_1)]
+        [InlineData("______________2_8", BIPLedPositionEnum.Position_2_8)]
+        [InlineData("______x_______3_1", BIPLedPositionEnum.Position_3_1)]
+        [InlineData("___________z__3_4", BIPLedPositionEnum.Position_3_4)]
+        [InlineData("__uu__________3x8", BIPLedPositionEnum.Position_3_8)]
+
+        public void GetLedPosition_ShouldReturn_ExpectedEnumValue(string inputString, BIPLedPositionEnum bIPLedPositionEnum)
+        {
+            Assert.Equal(bIPLedPositionEnum, BacklitPanelBIP.GetLedPosition(inputString));
+        }
+
+        [Theory]
+        [InlineData("______________1_9", BIPLedPositionEnum.Position_1_1)]
+        [InlineData("______________1_0", BIPLedPositionEnum.Position_1_1)]
+        [InlineData("______________2_0", BIPLedPositionEnum.Position_1_1)]
+        [InlineData("______________2_9", BIPLedPositionEnum.Position_1_1)]
+        [InlineData("______________9_1", BIPLedPositionEnum.Position_1_1)]
+        public void GetLedPosition_ShouldReturn_Position_1_1_ForUnexpectedValues(string inputString, BIPLedPositionEnum bIPLedPositionEnum)
+        {
+            Assert.Equal(bIPLedPositionEnum, BacklitPanelBIP.GetLedPosition(inputString));
+        }
+    }
+}

--- a/Source/Tests/NonVisuals/BackLitPanelTests.cs
+++ b/Source/Tests/NonVisuals/BackLitPanelTests.cs
@@ -70,7 +70,7 @@ namespace Tests.NonVisuals
         [InlineData("______x_______3_1", BIPLedPositionEnum.Position_3_1)]
         [InlineData("___________z__3_4", BIPLedPositionEnum.Position_3_4)]
         [InlineData("__uu__________3x8", BIPLedPositionEnum.Position_3_8)]
-
+        [InlineData("ImagePosition_3_4", BIPLedPositionEnum.Position_3_4)]
         public void GetLedPosition_ShouldReturn_ExpectedEnumValue(string inputString, BIPLedPositionEnum bIPLedPositionEnum)
         {
             Assert.Equal(bIPLedPositionEnum, BacklitPanelBIP.GetLedPosition(inputString));

--- a/Source/Tests/NonVisuals/DCSBiosConverterTests.cs
+++ b/Source/Tests/NonVisuals/DCSBiosConverterTests.cs
@@ -1,0 +1,41 @@
+﻿
+using NonVisuals.StreamDeck;
+using System;
+using Xunit;
+
+namespace Tests.NonVisuals
+{
+    public class DCSBiosConverterTests
+    {
+        [Theory]
+        [InlineData(EnumComparator.NotSet, "NotSet")]
+        [InlineData(EnumComparator.Equals, "==")]
+        [InlineData(EnumComparator.NotEquals, "!=")]
+        [InlineData(EnumComparator.LessThan, "<")]
+        [InlineData(EnumComparator.LessThanEqual, "<=")]
+        [InlineData(EnumComparator.GreaterThan, ">")]
+        [InlineData(EnumComparator.GreaterThanEqual, ">=")]
+        [InlineData(EnumComparator.Always, "Always")]
+        public void GetComparatorAsString_MustReturnExpectedValue(EnumComparator comparator, string expectedValue)
+        {
+            Assert.Equal(expectedValue, DCSBIOSConverter.GetComparatorAsString(comparator));
+        }
+
+        [Fact]
+        public void GetComparatorAsString_ThrowExeptionForUnexpectedValue()
+        {
+            Assert.Throws<ArgumentException>(() => DCSBIOSConverter.GetComparatorAsString((EnumComparator)int.MaxValue));
+        }
+
+        [Theory]
+        [InlineData(EnumConverterOutputType.NotSet, "not set")]
+        [InlineData(EnumConverterOutputType.Raw, "raw")]
+        [InlineData(EnumConverterOutputType.Image, "image")]
+        [InlineData(EnumConverterOutputType.ImageOverlay, "image overlay")]
+        [InlineData((EnumConverterOutputType)int.MaxValue, "unknown?")]
+        public void GetOutputAsString_MustReturnExpectedValue(EnumConverterOutputType converterOutputType, string expectedValue)
+        {
+            Assert.Equal(expectedValue, DCSBIOSConverter.GetOutputAsString(converterOutputType));
+        }
+    }
+}

--- a/Source/Tests/NonVisuals/RadiosPZ69DisplayBytesTests.cs
+++ b/Source/Tests/NonVisuals/RadiosPZ69DisplayBytesTests.cs
@@ -9,7 +9,6 @@ namespace Tests.NonVisuals
 {
     public class RadiosPZ69DisplayBytesTests
     {
-        private readonly PZ69DisplayBytes _dp = new();
         private const string ZEROES = "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00";
         private const string DEIGHTS = "00-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8-D8";
         private const string VALUES = "00-01-02-03-04-05-06-07-08-09-01-02-03-04-05-06-07-08-09-01-02";
@@ -38,7 +37,7 @@ namespace Tests.NonVisuals
         public void SetPositionBlank_ShouldSet_5_Blank_Chars_At_Position(string expected, string inputArray, PZ69LCDPosition lcdPosition)
         {
             var bytes = StringToBytes(inputArray);
-            _dp.SetPositionBlank(ref bytes, lcdPosition);
+            PZ69DisplayBytes.SetPositionBlank(ref bytes, lcdPosition);
             Assert.Equal(expected, BitConverter.ToString(bytes));
         }
 
@@ -89,7 +88,7 @@ namespace Tests.NonVisuals
         public void UnsignedInteger_ShouldReturn_ExpectedValue(string expected, uint inputUint, string inputArray, PZ69LCDPosition lcdPosition)
         {
             var bytes = StringToBytes(inputArray);
-            _dp.UnsignedInteger(ref bytes, inputUint, lcdPosition);
+            PZ69DisplayBytes.UnsignedInteger(ref bytes, inputUint, lcdPosition);
             Assert.Equal(expected, BitConverter.ToString(bytes));
         }
 
@@ -145,7 +144,7 @@ namespace Tests.NonVisuals
         public void DefaultStringAsIt_ShouldReturn_ExpectedValue(string expected, string inputString, string inputArray, PZ69LCDPosition lcdPosition)
         {
             var bytes = StringToBytes(inputArray);
-            _dp.DefaultStringAsIs(ref bytes, inputString, lcdPosition);
+            PZ69DisplayBytes.DefaultStringAsIs(ref bytes, inputString, lcdPosition);
             Assert.Equal(expected, BitConverter.ToString(bytes));
         }
 
@@ -160,7 +159,7 @@ namespace Tests.NonVisuals
         public void DefaultStringAsIt_InvalidChars_OrCombination_ShouldThrow_FormatException(string inputString)
         {
             var bytes = StringToBytes(DEIGHTS);
-            Assert.Throws<FormatException>(() => _dp.DefaultStringAsIs(ref bytes, inputString, PZ69LCDPosition.UPPER_ACTIVE_LEFT));            
+            Assert.Throws<FormatException>(() => PZ69DisplayBytes.DefaultStringAsIs(ref bytes, inputString, PZ69LCDPosition.UPPER_ACTIVE_LEFT));            
         }
 
         public static IEnumerable<object[]> DoubleWithSpecifiedDecimalsPlacesData()
@@ -219,7 +218,7 @@ namespace Tests.NonVisuals
         public void DoubleWithSpecifiedDecimalsPlaces_ShouldReturn_ExpectedValue(string expected, double digits, int decimals, string inputArray, PZ69LCDPosition lcdPosition)
         {
             var bytes = StringToBytes(inputArray);
-            _dp.DoubleWithSpecifiedDecimalsPlaces(ref bytes, digits, decimals, lcdPosition);
+            PZ69DisplayBytes.DoubleWithSpecifiedDecimalsPlaces(ref bytes, digits, decimals, lcdPosition);
             Assert.Equal(expected, BitConverter.ToString(bytes));
         }
 
@@ -258,7 +257,7 @@ namespace Tests.NonVisuals
         public void Double_ShouldReturn_ExpectedValue(string expected, double digits, string inputArray, PZ69LCDPosition lcdPosition)
         {
             var bytes = StringToBytes(inputArray);
-            _dp.DoubleJustifyLeft(ref bytes, digits, lcdPosition);
+            PZ69DisplayBytes.DoubleJustifyLeft(ref bytes, digits, lcdPosition);
             Assert.Equal(expected, BitConverter.ToString(bytes));
         }
     }

--- a/Source/Tests/NonVisuals/SwitchPanelPZ55Tests.cs
+++ b/Source/Tests/NonVisuals/SwitchPanelPZ55Tests.cs
@@ -1,0 +1,50 @@
+﻿using NonVisuals.Saitek;
+using NonVisuals.Saitek.Panels;
+using NonVisuals.Saitek.Switches;
+using NonVisuals.StreamDeck;
+using Xunit;
+
+namespace Tests.NonVisuals
+{
+    public class SwitchPanelPZ55Tests
+    {
+        private const SwitchPanelPZ55LEDPosition _Invalid_SwitchPanelPZ55LEDPosition = (SwitchPanelPZ55LEDPosition)byte.MaxValue;
+        private const PanelLEDColor _Invalid_PanelLEDColor = (PanelLEDColor)byte.MaxValue;
+
+
+        [Theory]
+        [InlineData(SwitchPanelPZ55LEDPosition.UP, PanelLEDColor.DARK, SwitchPanelPZ55LEDs.ALL_DARK)]
+        [InlineData(SwitchPanelPZ55LEDPosition.UP, PanelLEDColor.GREEN, SwitchPanelPZ55LEDs.UP_GREEN)]
+        [InlineData(SwitchPanelPZ55LEDPosition.UP, PanelLEDColor.RED, SwitchPanelPZ55LEDs.UP_RED)]
+        [InlineData(SwitchPanelPZ55LEDPosition.UP, PanelLEDColor.YELLOW, SwitchPanelPZ55LEDs.UP_YELLOW)]
+
+        [InlineData(SwitchPanelPZ55LEDPosition.LEFT, PanelLEDColor.DARK, SwitchPanelPZ55LEDs.ALL_DARK)]
+        [InlineData(SwitchPanelPZ55LEDPosition.LEFT, PanelLEDColor.GREEN, SwitchPanelPZ55LEDs.LEFT_GREEN)]
+        [InlineData(SwitchPanelPZ55LEDPosition.LEFT, PanelLEDColor.RED, SwitchPanelPZ55LEDs.LEFT_RED)]
+        [InlineData(SwitchPanelPZ55LEDPosition.LEFT, PanelLEDColor.YELLOW, SwitchPanelPZ55LEDs.LEFT_YELLOW)]
+
+        [InlineData(SwitchPanelPZ55LEDPosition.RIGHT, PanelLEDColor.DARK, SwitchPanelPZ55LEDs.ALL_DARK)]
+        [InlineData(SwitchPanelPZ55LEDPosition.RIGHT, PanelLEDColor.GREEN, SwitchPanelPZ55LEDs.RIGHT_GREEN)]
+        [InlineData(SwitchPanelPZ55LEDPosition.RIGHT, PanelLEDColor.RED, SwitchPanelPZ55LEDs.RIGHT_RED)]
+        [InlineData(SwitchPanelPZ55LEDPosition.RIGHT, PanelLEDColor.YELLOW, SwitchPanelPZ55LEDs.RIGHT_YELLOW)]
+        public void GetSwitchPanelPZ55LEDColor_ShouldReturn_ExpectedEnumValue(SwitchPanelPZ55LEDPosition switchPanelPZ55LEDPosition, PanelLEDColor panelLEDColor, SwitchPanelPZ55LEDs expectedEnumValue)
+        {
+            Assert.Equal(expectedEnumValue, SwitchPanelPZ55.GetSwitchPanelPZ55LEDColor(switchPanelPZ55LEDPosition, panelLEDColor));
+        }
+
+        [Theory]
+        [InlineData(_Invalid_SwitchPanelPZ55LEDPosition, PanelLEDColor.DARK, SwitchPanelPZ55LEDs.ALL_DARK)]
+        [InlineData(_Invalid_SwitchPanelPZ55LEDPosition, PanelLEDColor.GREEN, SwitchPanelPZ55LEDs.ALL_DARK)]
+        [InlineData(_Invalid_SwitchPanelPZ55LEDPosition, PanelLEDColor.RED, SwitchPanelPZ55LEDs.ALL_DARK)]
+        [InlineData(_Invalid_SwitchPanelPZ55LEDPosition, PanelLEDColor.YELLOW, SwitchPanelPZ55LEDs.ALL_DARK)]
+
+        [InlineData(SwitchPanelPZ55LEDPosition.UP, _Invalid_PanelLEDColor, SwitchPanelPZ55LEDs.ALL_DARK)]
+        [InlineData(SwitchPanelPZ55LEDPosition.LEFT, _Invalid_PanelLEDColor, SwitchPanelPZ55LEDs.ALL_DARK)]
+        [InlineData(SwitchPanelPZ55LEDPosition.RIGHT, _Invalid_PanelLEDColor, SwitchPanelPZ55LEDs.ALL_DARK)]
+
+        public void GetSwitchPanelPZ55LEDColor_ShouldReturn_ALL_DARK_For_UnExpectedEnumValues(SwitchPanelPZ55LEDPosition switchPanelPZ55LEDPosition, PanelLEDColor panelLEDColor, SwitchPanelPZ55LEDs expectedEnumValue)
+        {
+            Assert.Equal(expectedEnumValue, SwitchPanelPZ55.GetSwitchPanelPZ55LEDColor(switchPanelPZ55LEDPosition, panelLEDColor));
+        }
+    }
+}

--- a/Source/Tests/Tests.csproj
+++ b/Source/Tests/Tests.csproj
@@ -31,6 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\DCSFlightpanels\DCSFlightpanels.csproj" />
     <ProjectReference Include="..\NonVisuals\NonVisuals.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
* Add a bunch of test units on BacklitPanel, SwitchPanelPZ55, DCSBiosconverter
* Refacto some long switches with clearer pattern matching
* Moved some functions from Xaml file to better class (& make them easily testable)
* Removed some unused function in PZ70
* Experimental : Change to `checkout@V3` in codeQl-analysis to try to avoid warning `Node.js 12 actions are deprecated.` in github action report
* Made PZ69DisplayBytes  a static class. The was no need for an instance class.

Note : I don't have a BackLitPanel to test the changes but since I covered the functions with unit tests before refacto, there is nearly 0% chance that something is bad.
