### PR TITLE
[unit tests A10] Code improve and unit tests A10 radios

### DIFF
--- a/Source/DCSFlightpanels/Bills/BillBaseInput.cs
+++ b/Source/DCSFlightpanels/Bills/BillBaseInput.cs
@@ -180,8 +180,13 @@ namespace DCSFlightpanels.Bills
 
             if (content != null)
             {
-                var copyPackage = new CopyPackage { ContentType = copyContentType, Content = content, SourceName = TextBox.Name };
-                copyPackage.Description = description;
+                CopyPackage copyPackage = new()
+                {
+                    ContentType = copyContentType,
+                    Content = content,
+                    SourceName = TextBox.Name,
+                    Description = description
+                };
                 Clipboard.SetDataObject(copyPackage);
             }
         }

--- a/Source/DCSFlightpanels/PanelUserControls/StreamDeck/UserControlStreamDeckUIBase.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/StreamDeck/UserControlStreamDeckUIBase.cs
@@ -423,9 +423,8 @@ namespace DCSFlightpanels.PanelUserControls.StreamDeck
                 buttonImage.Bill = new BillStreamDeckFace
                 {
                     StreamDeckButtonName = (EnumStreamDeckButtonNames)Enum.Parse(typeof(EnumStreamDeckButtonNames), "BUTTON" + buttonImage.Name.Replace("ButtonImage", string.Empty)),
+                    StreamDeckPanelInstance = _streamDeckPanel
                 };
-
-                buttonImage.Bill.StreamDeckPanelInstance = _streamDeckPanel;
                 buttonImage.SetDefaultButtonImage();                
             }
         }

--- a/Source/HidLibrary/HidDevice.cs
+++ b/Source/HidLibrary/HidDevice.cs
@@ -472,7 +472,7 @@ namespace HidLibrary
             var callbackDelegate = (ReadCallback)hidAsyncState.CallbackDelegate;
             var data = callerDelegate.EndInvoke(ar);
 
-            if ((callbackDelegate != null)) callbackDelegate.Invoke(data);
+            if (callbackDelegate != null) callbackDelegate.Invoke(data);
         }
 
         protected static void EndReadReport(IAsyncResult ar)
@@ -482,7 +482,7 @@ namespace HidLibrary
             var callbackDelegate = (ReadReportCallback)hidAsyncState.CallbackDelegate;
             var report = callerDelegate.EndInvoke(ar);
 
-            if ((callbackDelegate != null)) callbackDelegate.Invoke(report);
+            if (callbackDelegate != null) callbackDelegate.Invoke(report);
         }
 
         private static void EndWrite(IAsyncResult ar)
@@ -492,7 +492,7 @@ namespace HidLibrary
             var callbackDelegate = (WriteCallback)hidAsyncState.CallbackDelegate;
             var result = callerDelegate.EndInvoke(ar);
 
-            if ((callbackDelegate != null)) callbackDelegate.Invoke(result);
+            if (callbackDelegate != null) callbackDelegate.Invoke(result);
         }
 
         private static void EndWriteReport(IAsyncResult ar)
@@ -502,7 +502,7 @@ namespace HidLibrary
             var callbackDelegate = (WriteCallback)hidAsyncState.CallbackDelegate;
             var result = callerDelegate.EndInvoke(ar);
 
-            if ((callbackDelegate != null)) callbackDelegate.Invoke(result);
+            if (callbackDelegate != null) callbackDelegate.Invoke(result);
         }
 
         private byte[] CreateInputBuffer()

--- a/Source/NonVisuals/Radios/RadioPanelPZ69A10C.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69A10C.cs
@@ -4079,7 +4079,7 @@ namespace NonVisuals.Radios
             return string.Empty;
         }
 
-        private static string GetILSDialFrequencyForPosition(int dial, uint position)
+        public static string GetILSDialFrequencyForPosition(int dial, uint position)
         {
             // 1 Mhz   "108" "109" "110" "111"
             // 0     1     2     3
@@ -4089,22 +4089,20 @@ namespace NonVisuals.Radios
             {
                 case 1:
                     {
-#pragma warning disable CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).
                         return position switch
                         {
                             0 => "108",
                             1 => "109",
                             2 => "110",
-                            3 => "111"
+                            3 => "111",
+                            _ => throw new ArgumentOutOfRangeException(nameof(position), $"ILSFreqPos Unexpected position switch value {position} for dial value of 1"),
                         };
-#pragma warning restore CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).
                     }
 
                 case 2:
                     {
                         // 2 Khz   "10" "15" "30" "35" "50" "55" "70" "75" "90" "95"
                         // 0    1    2    3    4    5    6    7    8    9
-#pragma warning disable CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).
                         return position switch
                         {
                             0 => "10",
@@ -4116,15 +4114,15 @@ namespace NonVisuals.Radios
                             6 => "70",
                             7 => "75",
                             8 => "90",
-                            9 => "95"
+                            9 => "95",
+                            _ => throw new ArgumentOutOfRangeException(nameof(position), $"ILSFreqPos Unexpected position switch value {position} for dial value of 2"),
                         };
-#pragma warning restore CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).
                     }
             }
             return string.Empty;
         }
 
-        private static int GetILSDialPosForFrequency(int dial, int freq)
+        public static int GetILSDialPosForFrequency(int dial, int freq)
         {
             // 1 Mhz   "108" "109" "110" "111"
             // 0     1     2     3
@@ -4134,22 +4132,20 @@ namespace NonVisuals.Radios
             {
                 case 1:
                     {
-#pragma warning disable CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).
                         return freq switch
                         {
                             108 => 0,
                             109 => 1,
                             110 => 2,
-                            111 => 3
+                            111 => 3,
+                            _ => throw new ArgumentOutOfRangeException(nameof(freq), $"ILSPosFreq Unexpected position switch value {freq} for dial value of 1")
                         };
-#pragma warning restore CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).
                     }
 
                 case 2:
                     {
                         // 2 Khz   "10" "15" "30" "35" "50" "55" "70" "75" "90" "95"
                         // 0    1    2    3    4    5    6    7    8    9
-#pragma warning disable CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).
                         return freq switch
                         {
                             10 => 0,
@@ -4161,9 +4157,9 @@ namespace NonVisuals.Radios
                             70 => 6,
                             75 => 7,
                             90 => 8,
-                            95 => 9
+                            95 => 9,
+                            _ => throw new ArgumentOutOfRangeException(nameof(freq), $"ILSPosFreq Unexpected position switch value {freq} for dial value of 2")
                         };
-#pragma warning restore CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).
                     }
             }
             return 0;

--- a/Source/NonVisuals/Radios/RadioPanelPZ69A10C.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69A10C.cs
@@ -3889,7 +3889,7 @@ namespace NonVisuals.Radios
             SaitekPanelKnobs = RadioPanelKnobA10C.GetRadioPanelKnobs();
         }
 
-        private static string GetVhfAmDialFrequencyForPosition(int dial, uint position)
+        public static string GetVhfAmDialFrequencyForPosition(int dial, uint position)
         {
 
             // Frequency selector 1      VHFAM_FREQ1
@@ -3909,7 +3909,6 @@ namespace NonVisuals.Radios
             {
                 case 1:
                     {
-#pragma warning disable CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).
                         return position switch
                         {
                             0 => "3",
@@ -3924,9 +3923,9 @@ namespace NonVisuals.Radios
                             9 => "12",
                             10 => "13",
                             11 => "14",
-                            12 => "15"
+                            12 => "15",
+                            _ => throw new ArgumentOutOfRangeException(nameof(position),$"Unexpected position switch value {position} for dial value of 1"),
                         };
-#pragma warning restore CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).
                     }
 
                 case 2:
@@ -3943,15 +3942,14 @@ namespace NonVisuals.Radios
                     {
                         // "00" "25" "50" "75", 0 2 5 7 used.
                         // Pos     0    1    2    3
-#pragma warning disable CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).
                         return position switch
                         {
                             0 => "0",
                             1 => "2",
                             2 => "5",
-                            3 => "7"                        
+                            3 => "7",
+                            _ => throw new ArgumentOutOfRangeException(nameof(position), $"Unexpected position switch value {position} for dial value of 4"),
                         };
-#pragma warning restore CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).
                     }
             }
             return string.Empty;

--- a/Source/NonVisuals/Radios/RadioPanelPZ69A10C.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69A10C.cs
@@ -3924,7 +3924,7 @@ namespace NonVisuals.Radios
                             10 => "13",
                             11 => "14",
                             12 => "15",
-                            _ => throw new ArgumentOutOfRangeException(nameof(position),$"Unexpected position switch value {position} for dial value of 1"),
+                            _ => throw new ArgumentOutOfRangeException(nameof(position),$"VhfAm Unexpected position switch value {position} for dial value of 1"),
                         };
                     }
 
@@ -3948,14 +3948,14 @@ namespace NonVisuals.Radios
                             1 => "2",
                             2 => "5",
                             3 => "7",
-                            _ => throw new ArgumentOutOfRangeException(nameof(position), $"Unexpected position switch value {position} for dial value of 4"),
+                            _ => throw new ArgumentOutOfRangeException(nameof(position), $"VhfAm Unexpected position switch value {position} for dial value of 4"),
                         };
                     }
             }
             return string.Empty;
         }
 
-        private static string GetUhfDialFrequencyForPosition(int dial, uint position)
+        public static string GetUhfDialFrequencyForPosition(int dial, uint position)
         {
             // Frequency selector 1     
             // //"2"  "3"  "A"
@@ -3978,14 +3978,13 @@ namespace NonVisuals.Radios
             {
                 case 1:
                     {
-#pragma warning disable CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).
                         return position switch
                         {
                             0 => "2",
                             1 => "3",
-                            2 => "0" // should be "A" // throw new NotImplementedException("check how A should be treated.");
+                            2 => "0", // should be "A" // throw new NotImplementedException("check how A should be treated.");
+                            _ => throw new ArgumentOutOfRangeException(nameof(position), $"Uhf Unexpected position switch value {position} for dial value of 1"),
                         };
-#pragma warning restore CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).
                     }
 
                 case 2:
@@ -3999,15 +3998,14 @@ namespace NonVisuals.Radios
                     {
                         // "00" "25" "50" "75", only "00" and "50" used.
                         // Pos     0    1    2    3
-#pragma warning disable CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).
                         return position switch
                         {
                             0 => "00",
                             1 => "25",
                             2 => "50",
-                            3 => "75"
+                            3 => "75",
+                            _ => throw new ArgumentOutOfRangeException(nameof(position), $"Uhf Unexpected position switch value {position} for dial value of 5"),
                         };
-#pragma warning restore CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).
                     }
             }
 

--- a/Source/NonVisuals/Radios/RadioPanelPZ69A10C.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69A10C.cs
@@ -4012,7 +4012,7 @@ namespace NonVisuals.Radios
             return string.Empty;
         }
 
-        private static string GetVhfFmDialFrequencyForPosition(int dial, uint position)
+        public static string GetVhfFmDialFrequencyForPosition(int dial, uint position)
         {
 
             // Frequency selector 1      VHFFM_FREQ1
@@ -4032,7 +4032,6 @@ namespace NonVisuals.Radios
             {
                 case 1:
                     {
-#pragma warning disable CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).
                         return position switch
                         {
                             0 => "3",
@@ -4047,9 +4046,9 @@ namespace NonVisuals.Radios
                             9 => "12",
                             10 => "13",
                             11 => "14",
-                            12 => "15"
+                            12 => "15",
+                            _ => throw new ArgumentOutOfRangeException(nameof(position), $"VhfFm Unexpected position switch value {position} for dial value of 1"),
                         };                   
-#pragma warning restore CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).
                     }
 
                 case 2:
@@ -4066,15 +4065,14 @@ namespace NonVisuals.Radios
                     {
                         // "00" "25" "50" "75"
                         // Pos     0    1    2    3
-#pragma warning disable CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).
                         return position switch
                         {
                             0 => "00",
                             1 => "25",
                             2 => "50",
-                            3 => "75"
+                            3 => "75",
+                            _ => throw new ArgumentOutOfRangeException(nameof(position), $"VhfFm Unexpected position switch value {position} for dial value of 4"),
                         };
-#pragma warning restore CS8509 // The switch expression does not handle all possible values of its input type (it is not exhaustive).
                     }
             }
 

--- a/Source/Tests/NonVisuals/BackLitPanelTests.cs
+++ b/Source/Tests/NonVisuals/BackLitPanelTests.cs
@@ -1,4 +1,4 @@
-﻿using NonVisuals.Panels.Saitek.Panels;
+using NonVisuals.Panels.Saitek.Panels;
 using System;
 using Xunit;
 

--- a/Source/Tests/NonVisuals/CloneTests.cs
+++ b/Source/Tests/NonVisuals/CloneTests.cs
@@ -22,10 +22,12 @@ namespace Tests.NonVisuals
 
         [Fact]
         public void KeypressInfo_MustBe_Clonable() {
-            KeyPressInfo source = new();
-            source.LengthOfKeyPress = KeyPressLength.SecondAndHalf;
-            source.LengthOfBreak = KeyPressLength.FortySecs;
-            
+            KeyPressInfo source = new()
+            {
+                LengthOfKeyPress = KeyPressLength.SecondAndHalf,
+                LengthOfBreak = KeyPressLength.FortySecs
+            };
+
             KeyPressInfo cloned = source.CloneJson();
             
             Assert.NotNull(cloned);
@@ -35,8 +37,10 @@ namespace Tests.NonVisuals
 
         [Fact]
         public void IKeyPressInfo_SortedList_MustBe_Clonable() {
-            SortedList<int, IKeyPressInfo> source = new();
-            source.Add(1, new KeyPressInfo());
+            SortedList<int, IKeyPressInfo> source = new()
+            {
+                { 1, new KeyPressInfo() }
+            };
 
             SortedList<int, IKeyPressInfo> cloned = source.CloneJson();
 
@@ -46,8 +50,10 @@ namespace Tests.NonVisuals
 
         [Fact]
         public void DCSBIOSInput_List_MustBe_Clonable() {
-            List<DCSBIOSInput> source = new();
-            source.Add(new DCSBIOSInput());
+            List<DCSBIOSInput> source = new()
+            {
+                new DCSBIOSInput()
+            };
 
             List<DCSBIOSInput> cloned = source.CloneJson();
 
@@ -58,10 +64,12 @@ namespace Tests.NonVisuals
         [Fact]        
         public void BIPLink_MustBe_Clonable_UseOf_BIPLinkPZ69() {
             //Note: BIPLink is Absract
-            BIPLinkPZ69 source = new();
-            source.Description = _stringValue1;
-            source.WhenTurnedOn = false;
-            
+            BIPLinkPZ69 source = new()
+            {
+                Description = _stringValue1,
+                WhenTurnedOn = false
+            };
+
             BIPLinkPZ69 cloned = source.CloneJson();
 
             Assert.NotNull(cloned);
@@ -72,10 +80,12 @@ namespace Tests.NonVisuals
         [Fact]
         public void BIPLink_MustBe_Clonable_UseOf_BIPLinkPZ55() {
             //Note: BIPLink is Absract
-            BIPLinkPZ55 source = new();
-            source.Description = _stringValue1;
-            source.WhenTurnedOn = false;
-            
+            BIPLinkPZ55 source = new()
+            {
+                Description = _stringValue1,
+                WhenTurnedOn = false
+            };
+
             BIPLinkPZ55 cloned = source.CloneJson();
 
             Assert.NotNull(cloned);
@@ -85,11 +95,13 @@ namespace Tests.NonVisuals
 
         [Fact]
         public void OSCommand_MustBe_Clonable() {
-            OSCommand source = new();
-            source.Name = _stringValue1;
-            source.Arguments = _stringValue2;
-            source.Command = _stringValue3;
-            
+            OSCommand source = new()
+            {
+                Name = _stringValue1,
+                Arguments = _stringValue2,
+                Command = _stringValue3
+            };
+
             OSCommand cloned = source.CloneJson();
 
             Assert.NotNull(cloned);
@@ -100,11 +112,13 @@ namespace Tests.NonVisuals
 
         [Fact]
         public void DCSBIOSDecoder_MustBe_Clonable() {
-            DCSBIOSDecoder source = new();
-            source.ButtonFinalText = _stringValue1;
-            source.ButtonTextTemplate = _stringValue2;
-            source.FontColor = _colorValue1;
-           
+            DCSBIOSDecoder source = new()
+            {
+                ButtonFinalText = _stringValue1,
+                ButtonTextTemplate = _stringValue2,
+                FontColor = _colorValue1
+            };
+
             DCSBIOSDecoder cloned = source.CloneJson();
 
             Assert.NotNull(cloned);
@@ -115,9 +129,11 @@ namespace Tests.NonVisuals
 
         [Fact]
         public void StreamDeckButton_MustBe_Clonable() {
-            StreamDeckButton source = new();
-            source.StreamDeckButtonName = EnumStreamDeckButtonNames.BUTTON1;
-            source.IsVisible = false;
+            StreamDeckButton source = new()
+            {
+                StreamDeckButtonName = EnumStreamDeckButtonNames.BUTTON1,
+                IsVisible = false
+            };
 
             StreamDeckButton cloned = source.CloneJson();
 
@@ -128,10 +144,12 @@ namespace Tests.NonVisuals
 
         [Fact]
         public void DCSBIOSInput_MustBe_Clonable() {
-            DCSBIOSInput source = new();
-            source.ControlId = _stringValue1;
-            source.Delay = _intValue1;
-            source.ControlDescription = _stringValue2;
+            DCSBIOSInput source = new()
+            {
+                ControlId = _stringValue1,
+                Delay = _intValue1,
+                ControlDescription = _stringValue2
+            };
 
             DCSBIOSInput cloned = source.CloneJson();
 
@@ -146,10 +164,12 @@ namespace Tests.NonVisuals
             var gamingPanelSkeleton =
                new GamingPanelSkeleton(GamingPanelVendorEnum.Saitek, GamingPanelEnum.PZ70MultiPanel);
             StreamDeckPanel streamdeckPanel = new(GamingPanelEnum.StreamDeck, new HIDSkeleton(gamingPanelSkeleton, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"), true);
-            DCSBIOSConverter source = new(streamdeckPanel);
-            source.ConverterOutputType = EnumConverterOutputType.Image;
-            source.BackgroundColor = _colorValue1;
-            source.OffsetX = _intValue1;
+            DCSBIOSConverter source = new(streamdeckPanel)
+            {
+                ConverterOutputType = EnumConverterOutputType.Image,
+                BackgroundColor = _colorValue1,
+                OffsetX = _intValue1
+            };
 
             DCSBIOSConverter cloned = source.CloneJson();
 

--- a/Source/Tests/NonVisuals/CloneTests.cs
+++ b/Source/Tests/NonVisuals/CloneTests.cs
@@ -18,7 +18,7 @@ namespace Tests.NonVisuals
         private const string _stringValue2 = "Some string value 2";
         private const string _stringValue3 = "Some string value 3";
         private const int _intValue1 = 456;
-        private Color _colorValue1 = Color.Aquamarine;
+        private readonly Color _colorValue1 = Color.Aquamarine;
 
         [Fact]
         public void KeypressInfo_MustBe_Clonable() {

--- a/Source/Tests/NonVisuals/RadioPanelPZ69A10CTests.cs
+++ b/Source/Tests/NonVisuals/RadioPanelPZ69A10CTests.cs
@@ -69,12 +69,13 @@ namespace Tests.NonVisuals
 
         [Theory]
         [InlineData(1, 13)]
+        [InlineData(1, 555)]
         [InlineData(4, 4)]
         [InlineData(4, 666)]
         ///previous Non-exhaustive switches that throwed exception is replaced by default handling in switches that also throws a better exception
         public void GetVhfAmDialFrequencyForPosition_ThrowsException_For_UnexpectedPositionValue_For_DialValue1And4(int dial, uint position)
         {
-            Assert.Throws<ArgumentOutOfRangeException>(()=> RadioPanelPZ69A10C.GetVhfAmDialFrequencyForPosition(dial, position));
+            Assert.Throws<ArgumentOutOfRangeException>(() => RadioPanelPZ69A10C.GetVhfAmDialFrequencyForPosition(dial, position));
         }
 
 
@@ -100,7 +101,8 @@ namespace Tests.NonVisuals
         [InlineData(5, 2, "50")]
         [InlineData(5, 3, "75")]
 
-        public void GetUhfDialFrequencyForPosition_ShouldReturn_ExpectedValues(int dial, uint position, string expectedValue) {
+        public void GetUhfDialFrequencyForPosition_ShouldReturn_ExpectedValues(int dial, uint position, string expectedValue)
+        {
             Assert.Equal(expectedValue, RadioPanelPZ69A10C.GetUhfDialFrequencyForPosition(dial, position));
         }
 
@@ -113,6 +115,77 @@ namespace Tests.NonVisuals
         public void GetUhfDialFrequencyForPosition_ThrowsException_For_UnexpectedPositionValue_For_DialValue1And5(int dial, uint position)
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => RadioPanelPZ69A10C.GetUhfDialFrequencyForPosition(dial, position));
+        }
+
+        [Theory]
+        [InlineData(0, 0, "")]
+        [InlineData(0, 555, "")]
+
+        [InlineData(1, 0, "3")]
+        [InlineData(1, 1, "4")]
+        [InlineData(1, 2, "5")]
+        [InlineData(1, 3, "6")]
+        [InlineData(1, 4, "7")]
+        [InlineData(1, 5, "8")]
+        [InlineData(1, 6, "9")]
+        [InlineData(1, 7, "10")]
+        [InlineData(1, 8, "11")]
+        [InlineData(1, 9, "12")]
+        [InlineData(1, 10, "13")]
+        [InlineData(1, 11, "14")]
+        [InlineData(1, 12, "15")]
+
+        [InlineData(2, 0, "0")]
+        [InlineData(2, 1, "1")]
+        [InlineData(2, 2, "2")]
+        [InlineData(2, 3, "3")]
+        [InlineData(2, 4, "4")]
+        [InlineData(2, 5, "5")]
+        [InlineData(2, 6, "6")]
+        [InlineData(2, 7, "7")]
+        [InlineData(2, 8, "8")]
+        [InlineData(2, 9, "9")]
+        [InlineData(2, 10, "10")]
+        [InlineData(2, 11, "11")]
+        [InlineData(2, 12, "12")]
+        [InlineData(2, 13, "13")]
+
+        [InlineData(3, 0, "0")]
+        [InlineData(3, 1, "1")]
+        [InlineData(3, 2, "2")]
+        [InlineData(3, 3, "3")]
+        [InlineData(3, 4, "4")]
+        [InlineData(3, 5, "5")]
+        [InlineData(3, 6, "6")]
+        [InlineData(3, 7, "7")]
+        [InlineData(3, 8, "8")]
+        [InlineData(3, 9, "9")]
+        [InlineData(3, 10, "10")]
+        [InlineData(3, 11, "11")]
+        [InlineData(3, 12, "12")]
+        [InlineData(3, 13, "13")]
+
+        [InlineData(4, 0, "00")]
+        [InlineData(4, 1, "25")]
+        [InlineData(4, 2, "50")]
+        [InlineData(4, 3, "75")]
+
+        [InlineData(5, 0, "")]
+        [InlineData(6, 666, "")]
+        public void GetVhfFmDialFrequencyForPosition_ShouldReturn_ExpectedValues(int dial, uint position, string expectedValue)
+        {
+            Assert.Equal(expectedValue, RadioPanelPZ69A10C.GetVhfFmDialFrequencyForPosition(dial, position));
+        }
+
+        [Theory]
+        [InlineData(1, 13)]
+        [InlineData(1, 555)]
+        [InlineData(4, 4)]
+        [InlineData(4, 666)]
+        ///previous Non-exhaustive switches that throwed exception is replaced by default handling in switches that also throws a better exception
+        public void GetVhfFmDialFrequencyForPosition_ThrowsException_For_UnexpectedPositionValue_For_DialValue1And4(int dial, uint position)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => RadioPanelPZ69A10C.GetVhfFmDialFrequencyForPosition(dial, position));
         }
     }
 }

--- a/Source/Tests/NonVisuals/RadioPanelPZ69A10CTests.cs
+++ b/Source/Tests/NonVisuals/RadioPanelPZ69A10CTests.cs
@@ -1,0 +1,80 @@
+﻿using NonVisuals.Radios;
+using System;
+using Xunit;
+
+namespace Tests.NonVisuals
+{
+    public class RadioPanelPZ69A10CTests
+    {
+
+        [Theory]
+        [InlineData(0, 0, "")]
+        [InlineData(0, 555, "")]
+
+        [InlineData(1, 0, "3")]
+        [InlineData(1, 1, "4")]
+        [InlineData(1, 2, "5")]
+        [InlineData(1, 3, "6")]
+        [InlineData(1, 4, "7")]
+        [InlineData(1, 5, "8")]
+        [InlineData(1, 6, "9")]
+        [InlineData(1, 7, "10")]
+        [InlineData(1, 8, "11")]
+        [InlineData(1, 9, "12")]
+        [InlineData(1, 10, "13")]
+        [InlineData(1, 11, "14")]
+        [InlineData(1, 12, "15")]
+
+        [InlineData(2, 0, "0")]
+        [InlineData(2, 1, "1")]
+        [InlineData(2, 2, "2")]
+        [InlineData(2, 3, "3")]
+        [InlineData(2, 4, "4")]
+        [InlineData(2, 5, "5")]
+        [InlineData(2, 6, "6")]
+        [InlineData(2, 7, "7")]
+        [InlineData(2, 8, "8")]
+        [InlineData(2, 9, "9")]
+        [InlineData(2, 10, "10")]
+        [InlineData(2, 11, "11")]
+        [InlineData(2, 12, "12")]
+        [InlineData(2, 13, "13")]
+
+        [InlineData(3, 0, "0")]
+        [InlineData(3, 1, "1")]
+        [InlineData(3, 2, "2")]
+        [InlineData(3, 3, "3")]
+        [InlineData(3, 4, "4")]
+        [InlineData(3, 5, "5")]
+        [InlineData(3, 6, "6")]
+        [InlineData(3, 7, "7")]
+        [InlineData(3, 8, "8")]
+        [InlineData(3, 9, "9")]
+        [InlineData(3, 10, "10")]
+        [InlineData(3, 11, "11")]
+        [InlineData(3, 12, "12")]
+        [InlineData(3, 13, "13")]
+
+        [InlineData(4, 0, "0")]
+        [InlineData(4, 1, "2")]
+        [InlineData(4, 2, "5")]
+        [InlineData(4, 3, "7")]
+
+        [InlineData(5, 0, "")]
+        [InlineData(6, 666, "")]
+        public void GetVhfAmDialFrequencyForPosition_ShouldReturn_ExpectedValues(int dial, uint position, string expectedValue)
+        {
+            Assert.Equal(expectedValue, RadioPanelPZ69A10C.GetVhfAmDialFrequencyForPosition(dial, position));
+        }
+
+        [Theory]
+        [InlineData(1, 13)]
+        [InlineData(4, 4)]
+        [InlineData(4, 666)]
+        ///previous Non-exhaustive switches that throwed exception is replaced by default handling in switches that also throws a better exception
+        public void GetVhfAmDialFrequencyForPosition_ThrowsException_For_UnexpectedPositionValue_For_DialValue1And4(int dial, uint position)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(()=> RadioPanelPZ69A10C.GetVhfAmDialFrequencyForPosition(dial, position));
+        }
+    }
+}

--- a/Source/Tests/NonVisuals/RadioPanelPZ69A10CTests.cs
+++ b/Source/Tests/NonVisuals/RadioPanelPZ69A10CTests.cs
@@ -76,5 +76,43 @@ namespace Tests.NonVisuals
         {
             Assert.Throws<ArgumentOutOfRangeException>(()=> RadioPanelPZ69A10C.GetVhfAmDialFrequencyForPosition(dial, position));
         }
+
+
+        [Theory]
+        [InlineData(1, 0, "2")]
+        [InlineData(1, 1, "3")]
+        [InlineData(1, 2, "0")]
+
+        [InlineData(2, 0, "0")]
+        [InlineData(2, 1, "1")]
+        [InlineData(2, 5551, "5551")]
+
+        [InlineData(3, 0, "0")]
+        [InlineData(3, 1, "1")]
+        [InlineData(3, 6662, "6662")]
+
+        [InlineData(4, 0, "0")]
+        [InlineData(4, 1, "1")]
+        [InlineData(4, 7773, "7773")]
+
+        [InlineData(5, 0, "00")]
+        [InlineData(5, 1, "25")]
+        [InlineData(5, 2, "50")]
+        [InlineData(5, 3, "75")]
+
+        public void GetUhfDialFrequencyForPosition_ShouldReturn_ExpectedValues(int dial, uint position, string expectedValue) {
+            Assert.Equal(expectedValue, RadioPanelPZ69A10C.GetUhfDialFrequencyForPosition(dial, position));
+        }
+
+        [Theory]
+        [InlineData(1, 3)]
+        [InlineData(1, 555)]
+        [InlineData(5, 4)]
+        [InlineData(5, 666)]
+        ///previous Non-exhaustive switches that throwed exception is replaced by default handling in switches that also throws a better exception
+        public void GetUhfDialFrequencyForPosition_ThrowsException_For_UnexpectedPositionValue_For_DialValue1And5(int dial, uint position)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => RadioPanelPZ69A10C.GetUhfDialFrequencyForPosition(dial, position));
+        }
     }
 }

--- a/Source/Tests/NonVisuals/RadioPanelPZ69A10CTests.cs
+++ b/Source/Tests/NonVisuals/RadioPanelPZ69A10CTests.cs
@@ -187,5 +187,75 @@ namespace Tests.NonVisuals
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => RadioPanelPZ69A10C.GetVhfFmDialFrequencyForPosition(dial, position));
         }
+
+        [Theory]
+        [InlineData(1, 0, "108")]
+        [InlineData(1, 1, "109")]
+        [InlineData(1, 2, "110")]
+        [InlineData(1, 3, "111")]
+
+        [InlineData(2, 0, "10")]
+        [InlineData(2, 1, "15")]
+        [InlineData(2, 2, "30")]
+        [InlineData(2, 3, "35")]
+        [InlineData(2, 4, "50")]
+        [InlineData(2, 5, "55")]
+        [InlineData(2, 6, "70")]
+        [InlineData(2, 7, "75")]
+        [InlineData(2, 8, "90")]
+        [InlineData(2, 9, "95")]
+
+        public void GetILSDialFrequencyForPosition_ShouldReturn_ExpectedValues(int dial, uint position, string expectedValue)
+        {
+            Assert.Equal(expectedValue, RadioPanelPZ69A10C.GetILSDialFrequencyForPosition(dial, position));
+        }
+
+        [Theory]
+        [InlineData(1, 4)]
+        [InlineData(1, 555)]
+        [InlineData(2, 10)]
+        [InlineData(2, 666)]
+        ///previous Non-exhaustive switches that throwed exception is replaced by default handling in switches that also throws a better exception
+        public void GetILSDialFrequencyForPosition_ThrowsException_For_UnexpectedPositionValue_For_DialValue1And4(int dial, uint position)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => RadioPanelPZ69A10C.GetILSDialFrequencyForPosition(dial, position));
+        }
+
+        [Theory]
+        [InlineData(1, 108, 0)]
+        [InlineData(1, 109, 1)]
+        [InlineData(1, 110, 2)]
+        [InlineData(1, 111, 3)]
+
+        [InlineData(2, 10, 0)]
+        [InlineData(2, 15, 1)]
+        [InlineData(2, 30, 2)]
+        [InlineData(2, 35, 3)]
+        [InlineData(2, 50, 4)]
+        [InlineData(2, 55, 5)]
+        [InlineData(2, 70, 6)]
+        [InlineData(2, 75, 7)]
+        [InlineData(2, 90, 8)]
+        [InlineData(2, 95, 9)]
+        public void GetILSDialPosForFrequency_ShouldReturn_ExpectedValues(int dial, int frequency, int expectedValue)
+        {
+            Assert.Equal(expectedValue, RadioPanelPZ69A10C.GetILSDialPosForFrequency(dial, frequency));
+        }
+
+        [Theory]
+        [InlineData(1, -1)]
+        [InlineData(1, 107)]
+        [InlineData(1, 112)]
+        [InlineData(1, 5551)]
+
+        [InlineData(2, -1)]
+        [InlineData(2, 9)]
+        [InlineData(2, 96)]
+        [InlineData(2, 6661)]
+        ///previous Non-exhaustive switches that throwed exception is replaced by default handling in switches that also throws a better exception
+        public void GetILSDialPosForFrequency_ThrowsException_For_UnexpectedPositionValue_For_DialValue1And4(int dial, int frequency)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => RadioPanelPZ69A10C.GetILSDialPosForFrequency(dial, frequency));
+        }
     }
 }

--- a/Source/Tests/NonVisuals/SwitchPanelPZ55Tests.cs
+++ b/Source/Tests/NonVisuals/SwitchPanelPZ55Tests.cs
@@ -1,4 +1,4 @@
-﻿using NonVisuals.Panels.Saitek;
+using NonVisuals.Panels.Saitek;
 using NonVisuals.Panels.Saitek.Panels;
 using NonVisuals.Panels.Saitek.Switches;
 using Xunit;


### PR DESCRIPTION
- Add small changes to improve code and reduce suggestions
- Add a bunch of unit test for A10 radios. First step of refactoring a little some huge switches and removing previous pragma directives about non exhaustive switches. Tested with A10 and working OK.
- Add some unit tests of BacklitPanel & PZ55

