### PR TITLE
[SRS] Re-Addind SRS to DCSFP

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ aircraft in the Multipanel & Backlit Panel.
 Using DCSFlightpanels as a key emulator it can be used in almost any game like
 Elite Dangerous, War Thunder, Flaming Cliff Series, IL-2.
 You can use multiple panels of each type and configure them separately.
+DCSFlightpanels supports [Simple Radio Standalone](https://github.com/ciribob/DCS-SimpleRadioStandalone) (PZ69 Radio Panel).
 
 
 <br/><br/>

--- a/Source/ClassLibraryCommon/Common.cs
+++ b/Source/ClassLibraryCommon/Common.cs
@@ -15,6 +15,7 @@
         DCSBIOSInputEnabled = 1,
         DCSBIOSOutputEnabled = 2,
         KeyboardEmulationOnly = 4,
+        SRSEnabled = 8,
         NS430Enabled = 16
     }
     

--- a/Source/ClassLibraryCommon/DCSAircraft.cs
+++ b/Source/ClassLibraryCommon/DCSAircraft.cs
@@ -77,6 +77,11 @@
                     var module = new DCSAircraft(2, "Key Emulation", "KEYEMULATOR");
                     ModulesList.Add(module);
                 }
+  				if (!ModulesList.Exists(o => o.ID == 3))
+            	{
+                	var module = new DCSFPProfile(3, "Key Emulation with SRS support", "KEYEMULATOR_SRS");
+                	ModulesList.Add(module);
+            	}
             }
         }
 
@@ -165,6 +170,16 @@
             }
             return module;
         }
+        
+        public static DCSFPProfile GetKeyEmulatorSRS()
+        {
+            var module = Modules.FirstOrDefault(x => IsKeyEmulatorSRS(x));
+            if (module == null)
+            {
+                LogErrorAndThrowException($"DCSFPProfile : Failed to find internal module KeyEmulatorSRS. Modules loaded : {Modules.Count}");
+            }
+            return module;
+        }
 
         public static bool HasNS430()
         {
@@ -191,7 +206,12 @@
             return dcsfpModule.ID == 2;
         }
 
-        public static bool IsFlamingCliff(DCSAircraft dcsfpModule)
+        public static bool IsKeyEmulatorSRS(DCSFPProfile dcsfpModule)
+        {
+            return dcsfpModule.ID == 3;
+        }
+
+        public static bool IsFlamingCliff(DCSFPProfile dcsfpModule)
         {
             return dcsfpModule.ID == 4;
         }
@@ -386,6 +406,7 @@
             int? moduleNumber = oldEnumValue switch
             {
                 "KEYEMULATOR" => 2,
+                "KEYEMULATOR_SRS" => 3,
                 "A4E" => 6,
                 "A10C" => 5,
                 "AH6J" => 7,

--- a/Source/ClassLibraryCommon/DCSAircraft.cs
+++ b/Source/ClassLibraryCommon/DCSAircraft.cs
@@ -79,7 +79,7 @@
                 }
   				if (!ModulesList.Exists(o => o.ID == 3))
             	{
-                	var module = new DCSFPProfile(3, "Key Emulation with SRS support", "KEYEMULATOR_SRS");
+                	var module = new DCSAircraft(3, "Key Emulation with SRS support", "KEYEMULATOR_SRS");
                 	ModulesList.Add(module);
             	}
             }
@@ -171,7 +171,7 @@
             return module;
         }
         
-        public static DCSFPProfile GetKeyEmulatorSRS()
+        public static DCSAircraft GetKeyEmulatorSRS()
         {
             var module = Modules.FirstOrDefault(x => IsKeyEmulatorSRS(x));
             if (module == null)
@@ -206,12 +206,12 @@
             return dcsfpModule.ID == 2;
         }
 
-        public static bool IsKeyEmulatorSRS(DCSFPProfile dcsfpModule)
+        public static bool IsKeyEmulatorSRS(DCSAircraft dcsfpModule)
         {
             return dcsfpModule.ID == 3;
         }
 
-        public static bool IsFlamingCliff(DCSFPProfile dcsfpModule)
+        public static bool IsFlamingCliff(DCSAircraft dcsfpModule)
         {
             return dcsfpModule.ID == 4;
         }

--- a/Source/DCSFlightpanels.sln.DotSettings
+++ b/Source/DCSFlightpanels.sln.DotSettings
@@ -49,6 +49,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=RED/@EntryIndexedValue">RED</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SA/@EntryIndexedValue">SA</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SD/@EntryIndexedValue">SD</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SRS/@EntryIndexedValue">SRS</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=TACAN/@EntryIndexedValue">TACAN</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=TPM/@EntryIndexedValue">TPM</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=UFD/@EntryIndexedValue">UFD</s:String>

--- a/Source/DCSFlightpanels.sln.DotSettings
+++ b/Source/DCSFlightpanels.sln.DotSettings
@@ -105,6 +105,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Leds/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Logitech/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=lue_000D_000A_0020_0020_0020_0020_0020/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=millisec/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Multipanel/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=negator/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Negators/@EntryIndexedValue">True</s:Boolean>

--- a/Source/DCSFlightpanels/Bills/BillBaseInput.cs
+++ b/Source/DCSFlightpanels/Bills/BillBaseInput.cs
@@ -8,8 +8,6 @@ namespace DCSFlightpanels.Bills
     using System.Collections.Generic;
     using System.Windows;
     using System.Windows.Controls;
-    using System.Windows.Media;
-
     using ClassLibraryCommon;
 
     using DCS_BIOS;

--- a/Source/DCSFlightpanels/CustomControls/CDU737UserControl.xaml.cs
+++ b/Source/DCSFlightpanels/CustomControls/CDU737UserControl.xaml.cs
@@ -1,6 +1,4 @@
-﻿using System.Windows.Controls;
-
-namespace DCSFlightpanels.CustomControls
+﻿namespace DCSFlightpanels.CustomControls
 {
     /// <summary>
     /// Logique d'interaction pour CDU737UserControl.xaml

--- a/Source/DCSFlightpanels/DCSFlightpanels.csproj
+++ b/Source/DCSFlightpanels/DCSFlightpanels.csproj
@@ -28,7 +28,7 @@
     </Authors>
     <PackageId>DCSFlightpanels (DCSFP)</PackageId>
     <Version>1.0.0</Version>
-    <AssemblyVersion>4.6.8420.1</AssemblyVersion>
+    <AssemblyVersion>4.6.8427.1</AssemblyVersion>
     <FileVersion>
     </FileVersion>
     <ApplicationIcon>flightpanels02_8Rc_icon.ico</ApplicationIcon>

--- a/Source/DCSFlightpanels/DarkMode.cs
+++ b/Source/DCSFlightpanels/DarkMode.cs
@@ -1,6 +1,4 @@
-﻿using System.Windows.Controls;
-using System.Windows;
-using System.Windows.Controls.Primitives;
+﻿using System.Windows;
 using System.Windows.Media;
 
 using System;

--- a/Source/DCSFlightpanels/MainWindow.xaml.cs
+++ b/Source/DCSFlightpanels/MainWindow.xaml.cs
@@ -42,7 +42,6 @@
     using Octokit;
     using NonVisuals.Panels;
     using NonVisuals.HID;
-    using Theraot.Collections;
 
     public partial class MainWindow : IGamingPanelListener, IDcsBiosConnectionListener, ISettingsModifiedListener, IProfileHandlerListener, IDisposable, IHardwareConflictResolver, IPanelEventListener, IForwardPanelEventListener
     {

--- a/Source/DCSFlightpanels/MainWindow.xaml.cs
+++ b/Source/DCSFlightpanels/MainWindow.xaml.cs
@@ -499,7 +499,7 @@
 
                                 AppEventHandler.PanelEvent(this, hidSkeleton.HIDInstance, hidSkeleton, PanelEventType.Created);
                             }
-                            else if (Common.IsEmulationModesFlagSet(EmulationMode.SRSEnabled) || DCSFPProfile.IsFlamingCliff(_profileHandler.Profile))
+                            else if (Common.IsEmulationModesFlagSet(EmulationMode.SRSEnabled) || DCSAircraft.IsFlamingCliff(_profileHandler.DCSAircraft))
                             {
                                 var radioPanelPZ69UserControl = new RadioPanelPZ69UserControlSRS(hidSkeleton);
                                 _panelUserControls.Add(radioPanelPZ69UserControl);
@@ -507,7 +507,7 @@
                                 TabControlPanels.Items.Add(tabItem);
                                 _profileFileHIDInstances.Add(new KeyValuePair<string, GamingPanelEnum>(hidSkeleton.HIDReadDevice.DevicePath, hidSkeleton.PanelInfo.GamingPanelType));
                             }
-                            else if (DCSFPProfile.IsA10C(_profileHandler.Profile) && !_profileHandler.Profile.UseGenericRadio)
+                            else if (DCSAircraft.IsA10C(_profileHandler.DCSAircraft) && !_profileHandler.DCSAircraft.UseGenericRadio)
                             {
                                 var radioPanelPZ69UserControl = new RadioPanelPZ69UserControlA10C(hidSkeleton);
                                 _panelUserControls.Add(radioPanelPZ69UserControl);

--- a/Source/DCSFlightpanels/MainWindow.xaml.cs
+++ b/Source/DCSFlightpanels/MainWindow.xaml.cs
@@ -506,6 +506,7 @@
                                 tabItem.Content = radioPanelPZ69UserControl;
                                 TabControlPanels.Items.Add(tabItem);
                                 _profileFileHIDInstances.Add(new KeyValuePair<string, GamingPanelEnum>(hidSkeleton.HIDReadDevice.DevicePath, hidSkeleton.PanelInfo.GamingPanelType));
+                                AppEventHandler.PanelEvent(this, hidSkeleton.HIDInstance, hidSkeleton, PanelEventType.Created);
                             }
                             else if (DCSAircraft.IsA10C(_profileHandler.DCSAircraft) && !_profileHandler.DCSAircraft.UseGenericRadio)
                             {

--- a/Source/DCSFlightpanels/MainWindow.xaml.cs
+++ b/Source/DCSFlightpanels/MainWindow.xaml.cs
@@ -37,6 +37,7 @@
     using NonVisuals.EventArgs;
     using NonVisuals.Interfaces;
     using NonVisuals.Plugin;
+    using NonVisuals.Radios.SRS;
 
     using Octokit;
     using NonVisuals.Panels;
@@ -499,7 +500,15 @@
 
                                 AppEventHandler.PanelEvent(this, hidSkeleton.HIDInstance, hidSkeleton, PanelEventType.Created);
                             }
-                            else if (DCSAircraft.IsA10C(_profileHandler.DCSAircraft) && !_profileHandler.DCSAircraft.UseGenericRadio)
+                            else if (Common.IsEmulationModesFlagSet(EmulationMode.SRSEnabled) || DCSFPProfile.IsFlamingCliff(_profileHandler.Profile))
+                            {
+                                var radioPanelPZ69UserControl = new RadioPanelPZ69UserControlSRS(hidSkeleton);
+                                _panelUserControls.Add(radioPanelPZ69UserControl);
+                                tabItem.Content = radioPanelPZ69UserControl;
+                                TabControlPanels.Items.Add(tabItem);
+                                _profileFileHIDInstances.Add(new KeyValuePair<string, GamingPanelEnum>(hidSkeleton.HIDReadDevice.DevicePath, hidSkeleton.PanelInfo.GamingPanelType));
+                            }
+                            else if (DCSFPProfile.IsA10C(_profileHandler.Profile) && !_profileHandler.Profile.UseGenericRadio)
                             {
                                 var radioPanelPZ69UserControl = new RadioPanelPZ69UserControlA10C(hidSkeleton);
                                 _panelUserControls.Add(radioPanelPZ69UserControl);
@@ -1603,7 +1612,11 @@
                 {
                     LoadProcessPriority();
                 }
-
+                if (settingsWindow.SRSChanged)
+                {
+                    SRSListenerFactory.SetParams(Settings.Default.SRSPortFrom, Settings.Default.SRSIpTo, Settings.Default.SRSPortTo);
+                    SRSListenerFactory.ReStart();
+                }
                 ConfigurePlugins();
             }
         }

--- a/Source/DCSFlightpanels/MainWindow.xaml.cs
+++ b/Source/DCSFlightpanels/MainWindow.xaml.cs
@@ -1614,8 +1614,8 @@
                 }
                 if (settingsWindow.SRSChanged)
                 {
-                    SRSListenerFactory.SetParams(Settings.Default.SRSPortFrom, Settings.Default.SRSIpTo, Settings.Default.SRSPortTo);
-                    SRSListenerFactory.ReStart();
+                    SRSRadioFactory.SetParams(Settings.Default.SRSPortFrom, Settings.Default.SRSIpTo, Settings.Default.SRSPortTo);
+                    SRSRadioFactory.ReStart();
                 }
                 ConfigurePlugins();
             }

--- a/Source/DCSFlightpanels/PanelUserControls/FarmingPanelUserControl.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/FarmingPanelUserControl.xaml.cs
@@ -19,7 +19,6 @@
     using NonVisuals.Interfaces;
 
     using Brush = System.Windows.Media.Brush;
-    using Brushes = System.Windows.Media.Brushes;
     using NonVisuals.Panels.Saitek.Panels;
     using NonVisuals.Panels.Saitek.Switches;
     using NonVisuals.Panels.Saitek;

--- a/Source/DCSFlightpanels/PanelUserControls/PreProgrammed/Cdu737UserControlA10C.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/PreProgrammed/Cdu737UserControlA10C.xaml.cs
@@ -1,7 +1,6 @@
 ﻿namespace DCSFlightpanels.PanelUserControls.PreProgrammed
 {
     using System.Windows;
-    using System.Windows.Controls;
     using NonVisuals.EventArgs;
     using NonVisuals.Interfaces;
 

--- a/Source/DCSFlightpanels/PanelUserControls/PreProgrammed/Cdu737UserControlAH64D.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/PreProgrammed/Cdu737UserControlAH64D.xaml.cs
@@ -3,7 +3,6 @@ namespace DCSFlightpanels.PanelUserControls.PreProgrammed
 {
 
     using System.Windows;
-    using System.Windows.Controls;
     using NonVisuals.EventArgs;
     using NonVisuals.Interfaces;
 

--- a/Source/DCSFlightpanels/PanelUserControls/PreProgrammed/Cdu737UserControlF14.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/PreProgrammed/Cdu737UserControlF14.xaml.cs
@@ -1,7 +1,6 @@
 ﻿namespace DCSFlightpanels.PanelUserControls.PreProgrammed
 {
     using System.Windows;
-    using System.Windows.Controls;
     using NonVisuals.EventArgs;
     using NonVisuals.Interfaces;
 

--- a/Source/DCSFlightpanels/PanelUserControls/PreProgrammed/Cdu737UserControlFA18C.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/PreProgrammed/Cdu737UserControlFA18C.xaml.cs
@@ -1,7 +1,6 @@
 ﻿namespace DCSFlightpanels.PanelUserControls.PreProgrammed
 {
     using System.Windows;
-    using System.Windows.Controls;
     using NonVisuals.EventArgs;
     using NonVisuals.Interfaces;
 

--- a/Source/DCSFlightpanels/PanelUserControls/PreProgrammed/Cdu737UserControlM2000C.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/PreProgrammed/Cdu737UserControlM2000C.xaml.cs
@@ -1,7 +1,6 @@
 ﻿namespace DCSFlightpanels.PanelUserControls.PreProgrammed
 {
     using System.Windows;
-    using System.Windows.Controls;
     using NonVisuals.EventArgs;
     using NonVisuals.Interfaces;
 

--- a/Source/DCSFlightpanels/PanelUserControls/PreProgrammed/Cdu737UserControlSA342.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/PreProgrammed/Cdu737UserControlSA342.xaml.cs
@@ -3,7 +3,6 @@ namespace DCSFlightpanels.PanelUserControls.PreProgrammed
 {
 
     using System.Windows;
-    using System.Windows.Controls;
     using NonVisuals.EventArgs;
     using NonVisuals.Interfaces;
 

--- a/Source/DCSFlightpanels/PanelUserControls/StreamDeck/UserControlStreamDeckUIBase.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/StreamDeck/UserControlStreamDeckUIBase.cs
@@ -1,6 +1,4 @@
-﻿using NonVisuals;
-
-namespace DCSFlightpanels.PanelUserControls.StreamDeck
+﻿namespace DCSFlightpanels.PanelUserControls.StreamDeck
 {
     using System;
     using System.Collections.Generic;

--- a/Source/DCSFlightpanels/PanelUserControls/SwitchPanelPZ55UserControl.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/SwitchPanelPZ55UserControl.xaml.cs
@@ -19,7 +19,6 @@ namespace DCSFlightpanels.PanelUserControls
     using NonVisuals.Interfaces;
 
     using Brush = System.Windows.Media.Brush;
-    using Brushes = System.Windows.Media.Brushes;
     using Image = System.Windows.Controls.Image;
     using SwitchPanelPZ55Keys = MEF.SwitchPanelPZ55Keys;
     using NonVisuals.Panels.Saitek.Panels;

--- a/Source/DCSFlightpanels/PanelUserControls/TPMPanelUserControl.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/TPMPanelUserControl.xaml.cs
@@ -6,8 +6,6 @@
     using System.Windows;
     using System.Windows.Controls;
     using System.Windows.Input;
-    using System.Windows.Media;
-
     using ClassLibraryCommon;
 
     using Bills;

--- a/Source/DCSFlightpanels/ProfileHandler.cs
+++ b/Source/DCSFlightpanels/ProfileHandler.cs
@@ -485,12 +485,12 @@ namespace DCSFlightpanels
             {
                 Common.SetEmulationModes(EmulationMode.KeyboardEmulationOnly);
             }
-			else if (DCSFPProfile.IsKeyEmulatorSRS(Profile))
+			else if (DCSAircraft.IsKeyEmulatorSRS(DCSAircraft))
             {
                 Common.SetEmulationModes(EmulationMode.KeyboardEmulationOnly);
                 Common.SetEmulationModes(EmulationMode.SRSEnabled);
             }			
-            else if (DCSFPProfile.IsFlamingCliff(Profile))
+            else if (DCSAircraft.IsFlamingCliff(DCSAircraft))
             {
 				Common.SetEmulationModes(EmulationMode.SRSEnabled); //???
                 Common.SetEmulationModes(EmulationMode.DCSBIOSOutputEnabled);

--- a/Source/DCSFlightpanels/ProfileHandler.cs
+++ b/Source/DCSFlightpanels/ProfileHandler.cs
@@ -485,8 +485,14 @@ namespace DCSFlightpanels
             {
                 Common.SetEmulationModes(EmulationMode.KeyboardEmulationOnly);
             }
-            else if (DCSAircraft.IsFlamingCliff(DCSAircraft))
+			else if (DCSFPProfile.IsKeyEmulatorSRS(Profile))
             {
+                Common.SetEmulationModes(EmulationMode.KeyboardEmulationOnly);
+                Common.SetEmulationModes(EmulationMode.SRSEnabled);
+            }			
+            else if (DCSFPProfile.IsFlamingCliff(Profile))
+            {
+				Common.SetEmulationModes(EmulationMode.SRSEnabled); //???
                 Common.SetEmulationModes(EmulationMode.DCSBIOSOutputEnabled);
             }
             else

--- a/Source/DCSFlightpanels/Properties/Settings.Designer.cs
+++ b/Source/DCSFlightpanels/Properties/Settings.Designer.cs
@@ -229,6 +229,54 @@ namespace DCSFlightpanels.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("127.0.0.1")]
+        public string SRSIpFrom {
+            get {
+                return ((string)(this["SRSIpFrom"]));
+            }
+            set {
+                this["SRSIpFrom"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("127.0.0.1")]
+        public string SRSIpTo {
+            get {
+                return ((string)(this["SRSIpTo"]));
+            }
+            set {
+                this["SRSIpTo"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("7082")]
+        public int SRSPortFrom {
+            get {
+                return ((int)(this["SRSPortFrom"]));
+            }
+            set {
+                this["SRSPortFrom"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("9040")]
+        public int SRSPortTo {
+            get {
+                return ((int)(this["SRSPortTo"]));
+            }
+            set {
+                this["SRSPortTo"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("2018-01-01")]
         public global::System.DateTime LastGitHubCheck {
             get {

--- a/Source/DCSFlightpanels/Properties/Settings.settings
+++ b/Source/DCSFlightpanels/Properties/Settings.settings
@@ -53,6 +53,18 @@
     <Setting Name="RunMinimized" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="SRSIpFrom" Type="System.String" Scope="User">
+      <Value Profile="(Default)">127.0.0.1</Value>
+    </Setting>
+    <Setting Name="SRSIpTo" Type="System.String" Scope="User">
+      <Value Profile="(Default)">127.0.0.1</Value>
+    </Setting>
+    <Setting Name="SRSPortFrom" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">7082</Value>
+    </Setting>
+    <Setting Name="SRSPortTo" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">9040</Value>
+    </Setting>
     <Setting Name="LastGitHubCheck" Type="System.DateTime" Scope="User">
       <Value Profile="(Default)">2018-01-01</Value>
     </Setting>

--- a/Source/DCSFlightpanels/Radios/Emulators/RadioPanelPZ69UserControlEmulator.xaml.cs
+++ b/Source/DCSFlightpanels/Radios/Emulators/RadioPanelPZ69UserControlEmulator.xaml.cs
@@ -7,14 +7,11 @@
     using System.Windows;
     using System.Windows.Controls;
     using System.Windows.Input;
-    using System.Windows.Media;
-
     using ClassLibraryCommon;
 
     using Bills;
     using CustomControls;
     using Interfaces;
-    using PanelUserControls;
     using Properties;
 
     using MEF;

--- a/Source/DCSFlightpanels/Radios/Emulators/RadioPanelPZ69UserControlGeneric.xaml.cs
+++ b/Source/DCSFlightpanels/Radios/Emulators/RadioPanelPZ69UserControlGeneric.xaml.cs
@@ -13,7 +13,6 @@
     using Bills;
     using CustomControls;
     using Interfaces;
-    using PanelUserControls;
     using Properties;
     using Windows;
 

--- a/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlA10C.xaml.cs
+++ b/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlA10C.xaml.cs
@@ -8,7 +8,6 @@
     using ClassLibraryCommon;
 
     using Interfaces;
-    using PanelUserControls;
     using Properties;
     using NonVisuals.EventArgs;
     using NonVisuals.Interfaces;

--- a/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlAJS37.xaml.cs
+++ b/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlAJS37.xaml.cs
@@ -8,7 +8,6 @@
     using ClassLibraryCommon;
 
     using Interfaces;
-    using PanelUserControls;
     using Properties;
     using NonVisuals.EventArgs;
     using NonVisuals.Interfaces;

--- a/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlAV8BNA.xaml.cs
+++ b/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlAV8BNA.xaml.cs
@@ -8,7 +8,6 @@
     using ClassLibraryCommon;
 
     using Interfaces;
-    using PanelUserControls;
     using Properties;
     using NonVisuals.EventArgs;
     using NonVisuals.Interfaces;

--- a/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlBf109.xaml.cs
+++ b/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlBf109.xaml.cs
@@ -8,7 +8,6 @@
     using ClassLibraryCommon;
 
     using Interfaces;
-    using PanelUserControls;
     using Properties;
     using NonVisuals.EventArgs;
     using NonVisuals.Interfaces;

--- a/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlF14B.xaml.cs
+++ b/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlF14B.xaml.cs
@@ -8,7 +8,6 @@
     using ClassLibraryCommon;
 
     using Interfaces;
-    using PanelUserControls;
     using Properties;
     using NonVisuals.EventArgs;
     using NonVisuals.Interfaces;

--- a/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlF5E.xaml.cs
+++ b/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlF5E.xaml.cs
@@ -8,7 +8,6 @@
     using ClassLibraryCommon;
 
     using Interfaces;
-    using PanelUserControls;
     using Properties;
     using NonVisuals.EventArgs;
     using NonVisuals.Interfaces;

--- a/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlF86F.xaml.cs
+++ b/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlF86F.xaml.cs
@@ -8,7 +8,6 @@
     using ClassLibraryCommon;
 
     using Interfaces;
-    using PanelUserControls;
     using Properties;
     using NonVisuals.EventArgs;
     using NonVisuals.Interfaces;

--- a/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlFA18C.xaml.cs
+++ b/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlFA18C.xaml.cs
@@ -8,7 +8,6 @@
     using ClassLibraryCommon;
 
     using Interfaces;
-    using PanelUserControls;
     using Properties;
     using NonVisuals.EventArgs;
     using NonVisuals.Interfaces;

--- a/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlFw190.xaml.cs
+++ b/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlFw190.xaml.cs
@@ -8,7 +8,6 @@
     using ClassLibraryCommon;
 
     using Interfaces;
-    using PanelUserControls;
     using Properties;
     using NonVisuals.EventArgs;
     using NonVisuals.Interfaces;

--- a/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlKa50.xaml.cs
+++ b/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlKa50.xaml.cs
@@ -8,7 +8,6 @@
     using ClassLibraryCommon;
 
     using Interfaces;
-    using PanelUserControls;
     using Properties;
     using NonVisuals.EventArgs;
     using NonVisuals.Interfaces;

--- a/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlM2000C.xaml.cs
+++ b/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlM2000C.xaml.cs
@@ -8,7 +8,6 @@
     using ClassLibraryCommon;
 
     using Interfaces;
-    using PanelUserControls;
     using Properties;
     using NonVisuals.EventArgs;
     using NonVisuals.Interfaces;

--- a/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlMi24P.xaml.cs
+++ b/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlMi24P.xaml.cs
@@ -8,7 +8,6 @@
     using ClassLibraryCommon;
 
     using Interfaces;
-    using PanelUserControls;
     using Properties;
     using NonVisuals.EventArgs;
     using NonVisuals.Interfaces;

--- a/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlMi8.xaml.cs
+++ b/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlMi8.xaml.cs
@@ -8,7 +8,6 @@
     using ClassLibraryCommon;
 
     using Interfaces;
-    using PanelUserControls;
     using Properties;
     using NonVisuals.EventArgs;
     using NonVisuals.Interfaces;

--- a/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlMiG21bis.xaml.cs
+++ b/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlMiG21bis.xaml.cs
@@ -8,7 +8,6 @@
     using ClassLibraryCommon;
 
     using Interfaces;
-    using PanelUserControls;
     using Properties;
     using NonVisuals.EventArgs;
     using NonVisuals.Interfaces;

--- a/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlP47D.xaml.cs
+++ b/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlP47D.xaml.cs
@@ -8,7 +8,6 @@
     using ClassLibraryCommon;
 
     using Interfaces;
-    using PanelUserControls;
     using Properties;
     using NonVisuals.EventArgs;
     using NonVisuals.Interfaces;

--- a/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlP51D.xaml.cs
+++ b/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlP51D.xaml.cs
@@ -8,7 +8,6 @@
     using ClassLibraryCommon;
 
     using Interfaces;
-    using PanelUserControls;
     using Properties;
     using NonVisuals.EventArgs;
     using NonVisuals.Interfaces;

--- a/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlSA342.xaml.cs
+++ b/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlSA342.xaml.cs
@@ -8,7 +8,6 @@
     using ClassLibraryCommon;
 
     using Interfaces;
-    using PanelUserControls;
     using Properties;
     using NonVisuals.EventArgs;
     using NonVisuals.Interfaces;

--- a/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlSRS.xaml
+++ b/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlSRS.xaml
@@ -1,0 +1,111 @@
+﻿<panelUserControls:UserControlBase x:Class="DCSFlightpanels.Radios.PreProgrammed.RadioPanelPZ69UserControlSRS"
+                 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+                 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                 xmlns:panelUserControls="clr-namespace:DCSFlightpanels.PanelUserControls"
+                 mc:Ignorable="d" 
+                 d:DesignHeight="750" d:DesignWidth="1000" Loaded="RadioPanelPZ69UserControlSRS_OnLoaded">
+    <Grid Name="PZ69Grid" >
+        <Grid.RowDefinitions>
+            <RowDefinition Height="240" />
+            <RowDefinition Height="1*" />
+            <RowDefinition Height="1*" />
+            <RowDefinition Height="1*" />
+            <RowDefinition Height="1*" />
+            <RowDefinition Height="1*" />
+            <RowDefinition Height="1*" />
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="80*" />
+            <ColumnDefinition Width="80"/>
+            <ColumnDefinition Width="80*" />
+            <ColumnDefinition Width="80*"/>
+            <ColumnDefinition Width="80*"/>
+            <ColumnDefinition Width="97*" />
+            <ColumnDefinition Width="301*" />
+        </Grid.ColumnDefinitions>
+        <Canvas HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="5">
+            <Image Height="226" Name="ImagePZ69RadioPanel" Stretch="None" Source="/dcsfp;component/Images/PZ69_Radiopanel.jpg" />
+
+            <!-- UPPER LEFT SELECTOR -->
+            <Image Height="76" Name="TopLeftCom1" Source="/dcsfp;component/Images/dot.jpg" Stretch="None" Canvas.Left="65" Canvas.Top="34" />
+            <Image Height="76" Name="TopLeftCom2" Source="/dcsfp;component/Images/dot.jpg" Stretch="None" Canvas.Left="54" Canvas.Top="36" />
+            <Image Height="76" Name="TopLeftNav1" Source="/dcsfp;component/Images/dot.jpg" Stretch="None" Canvas.Left="46" Canvas.Top="45" />
+            <Image Height="76" Name="TopLeftNav2" Source="/dcsfp;component/Images/dot.jpg" Stretch="None" Canvas.Left="43" Canvas.Top="57" />
+            <Image Height="76" Name="TopLeftADF" Source="/dcsfp;component/Images/dot.jpg" Stretch="None" Canvas.Left="46" Canvas.Top="69"  />
+            <Image Height="76" Name="TopLeftDME" Source="/dcsfp;component/Images/dot.jpg" Stretch="None" Canvas.Left="56" Canvas.Top="77" />
+            <Image Height="76" Name="TopLeftXPDR" Source="/dcsfp;component/Images/dot.jpg" Stretch="None" Canvas.Left="66" Canvas.Top="81" />
+
+            <!-- LOWER LEFT SELECTOR -->
+            <Image Height="76" Name="LowerLeftCom1" Source="/dcsfp;component/Images/dot.jpg" Stretch="None" Canvas.Left="65" Canvas.Top="112" />
+            <Image Height="76" Name="LowerLeftCom2" Source="/dcsfp;component/Images/dot.jpg" Stretch="None" Canvas.Left="54" Canvas.Top="114" />
+            <Image Height="76" Name="LowerLeftNav1" Source="/dcsfp;component/Images/dot.jpg" Stretch="None" Canvas.Left="45" Canvas.Top="122" />
+            <Image Height="76" Name="LowerLeftNav2" Source="/dcsfp;component/Images/dot.jpg" Stretch="None" Canvas.Left="43" Canvas.Top="134" />
+            <Image Height="76" Name="LowerLeftADF" Source="/dcsfp;component/Images/dot.jpg" Stretch="None" Canvas.Left="46" Canvas.Top="147"  />
+            <Image Height="76" Name="LowerLeftDME" Source="/dcsfp;component/Images/dot.jpg" Stretch="None" Canvas.Left="56" Canvas.Top="156" />
+            <Image Height="76" Name="LowerLeftXPDR" Source="/dcsfp;component/Images/dot.jpg" Stretch="None" Canvas.Left="66" Canvas.Top="159" />
+
+            <!-- UPPER LCD KNOB -->
+            <Image Height="76" Name="UpperSmallerLCDKnobInc" Source="/dcsfp;component/Images/dot.jpg" Stretch="None" Canvas.Left="484" Canvas.Top="60" />
+            <Image Height="76" Name="UpperSmallerLCDKnobDec" Source="/dcsfp;component/Images/dot.jpg" Stretch="None" Canvas.Left="469" Canvas.Top="60" />
+            <Image Height="76" Name="UpperLargerLCDKnobInc" Source="/dcsfp;component/Images/dot.jpg" Stretch="None" Canvas.Left="498" Canvas.Top="60" />
+            <Image Height="76" Name="UpperLargerLCDKnobDec" Source="/dcsfp;component/Images/dot.jpg" Stretch="None" Canvas.Left="447" Canvas.Top="60" />
+
+            <!-- LOWER LCD KNOB -->
+            <Image Height="76" Name="LowerSmallerLCDKnobInc" Source="/dcsfp;component/Images/dot.jpg" Stretch="None" Canvas.Left="484" Canvas.Top="136" />
+            <Image Height="76" Name="LowerSmallerLCDKnobDec" Source="/dcsfp;component/Images/dot.jpg" Stretch="None" Canvas.Left="469" Canvas.Top="136" />
+            <Image Height="76" Name="LowerLargerLCDKnobInc" Source="/dcsfp;component/Images/dot.jpg" Stretch="None" Canvas.Left="498" Canvas.Top="136" />
+            <Image Height="76" Name="LowerLargerLCDKnobDec" Source="/dcsfp;component/Images/dot.jpg" Stretch="None" Canvas.Left="447" Canvas.Top="136" />
+
+            <!-- Right Switches -->
+            <Image Height="76" Name="UpperRightSwitch" Source="/dcsfp;component/Images/dot.jpg" Stretch="None" Canvas.Left="562" Canvas.Top="58" />
+            <Image Height="76" Name="LowerRightSwitch" Source="/dcsfp;component/Images/dot.jpg" Stretch="None" Canvas.Left="562" Canvas.Top="131" />
+
+            <Button Name="ButtonGetIdentify" Content="Identify" HorizontalAlignment="Left" VerticalAlignment="Top" Width="76"   Canvas.Left="430" Canvas.Top="12" Click="ButtonGetIdentify_OnClick"/>
+            <Button Name="ButtonGetId" Content="ID" HorizontalAlignment="Left" VerticalAlignment="Top" Width="76"   Canvas.Left="520" Canvas.Top="12" Click="ButtonGetId_OnClick"/>
+        </Canvas>
+        <GroupBox Header="Selector Knobs" Name="GroupUpperSelectorKnob" FontSize="14" FontWeight="Bold" Grid.Column="0" Grid.Row="1" Grid.RowSpan="2" Grid.ColumnSpan="3" >
+            <StackPanel >
+                <TextBlock FontSize="10" FontWeight="Bold">
+                    COM 1  = Radio 1<LineBreak/>
+                    COM 2  = Radio 2 <LineBreak/>
+                    NAV 1  = Radio 3 <LineBreak/>
+                    NAV 2  = Radio 4 <LineBreak/>
+                    ADF    = Radio 5 <LineBreak/>
+                    DME    = Radio 6 <LineBreak/>
+                    XPDR   = Radio 7 <LineBreak/>
+                    ACT/STBY = Toggle Guard Frequency
+                </TextBlock>
+            </StackPanel>
+        </GroupBox>
+
+        <GroupBox Header="Settings" FontSize="10" FontWeight="Bold" Grid.Column="0" Grid.Row="3"  Grid.ColumnSpan="3" Grid.RowSpan="2" >
+            <StackPanel >
+                <Label Content="Frequency Knobs sensitivity"></Label>
+                <ComboBox Name="ComboBoxFreqKnobSensitivity" Width="100" HorizontalAlignment="Left" Margin="5,5,0,0" SelectedIndex="0" SelectedValuePath="Content" IsReadOnly="True" SelectionChanged="ComboBoxFreqKnobSensitivity_OnSelectionChanged">
+                    <ComboBoxItem >0</ComboBoxItem>
+                    <ComboBoxItem >-1</ComboBoxItem>
+                    <ComboBoxItem >-2</ComboBoxItem>
+                </ComboBox>
+                <Label Content="Small Frequency Knob Stepping"></Label>
+                <ComboBox Name="ComboBoxSmallFreqStepping" Width="100" HorizontalAlignment="Left" Margin="5,5,0,0" SelectedIndex="0" SelectedValuePath="Content" IsReadOnly="True" SelectionChanged="ComboBoxSmallFreqStepping_OnSelectionChanged">
+                    <ComboBoxItem >0.001</ComboBoxItem>
+                    <ComboBoxItem >0.005</ComboBoxItem>
+                    <ComboBoxItem >0.010</ComboBoxItem>
+                    <ComboBoxItem >0.050</ComboBoxItem>
+                </ComboBox>
+            </StackPanel>
+        </GroupBox>
+
+        <StackPanel Grid.Column="3" Grid.Row="1" Grid.ColumnSpan="2" Grid.RowSpan="6"/>
+        <StackPanel Grid.Column="6" Grid.Row="0" Grid.ColumnSpan="1" Grid.RowSpan="4">
+            <Label Name="LabelAirframe" Content="Simple Radio Standalone" FontSize="30" FontWeight="Bold" Grid.Column="6" Grid.Row="0"/>
+        </StackPanel>
+        <DockPanel Grid.Column="6" Grid.Row="4" Grid.RowSpan="3" >
+            <GroupBox DockPanel.Dock="Bottom" Header="Log"  FontSize="10"  Margin="0,0.5,0,-1">
+                <TextBox x:Name="TextBoxLogPZ69" VerticalScrollBarVisibility="Visible" VerticalAlignment="Stretch" TextWrapping="Wrap" HorizontalAlignment="Stretch" Height="140" />
+            </GroupBox>
+        </DockPanel>
+    </Grid>
+</panelUserControls:UserControlBase>

--- a/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlSRS.xaml.cs
+++ b/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlSRS.xaml.cs
@@ -11,10 +11,6 @@
     using DCSFlightpanels.Interfaces;
     using DCSFlightpanels.PanelUserControls;
     using DCSFlightpanels.Properties;
-
-    using MEF;
-
-    using NonVisuals;
     using NonVisuals.EventArgs;
     using NonVisuals.HID;
     using NonVisuals.Interfaces;

--- a/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlSRS.xaml.cs
+++ b/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlSRS.xaml.cs
@@ -1,0 +1,488 @@
+﻿namespace DCSFlightpanels.Radios.PreProgrammed
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Windows;
+    using System.Windows.Controls;
+
+    using ClassLibraryCommon;
+
+    using DCSFlightpanels.Interfaces;
+    using DCSFlightpanels.PanelUserControls;
+    using DCSFlightpanels.Properties;
+
+    using MEF;
+
+    using NonVisuals;
+    using NonVisuals.EventArgs;
+    using NonVisuals.HID;
+    using NonVisuals.Interfaces;
+    using NonVisuals.Panels;
+    using NonVisuals.Radios;
+    using NonVisuals.Radios.Knobs;
+
+    /// <summary>
+    /// Interaction logic for RadioPanelPZ69UserControlSRS.xaml
+    /// </summary>
+    public partial class RadioPanelPZ69UserControlSRS : UserControlBase, IGamingPanelListener, IProfileHandlerListener, IGamingPanelUserControl
+    {
+        private readonly RadioPanelPZ69SRS _radioPanelPZ69SRS;
+
+        public RadioPanelPZ69UserControlSRS(HIDSkeleton hidSkeleton)
+        {
+            InitializeComponent();
+
+            HideAllImages();
+
+            _radioPanelPZ69SRS = new RadioPanelPZ69SRS(Settings.Default.SRSPortFrom, Settings.Default.SRSIpTo,
+                Settings.Default.SRSPortTo, hidSkeleton)
+            {
+                FrequencyKnobSensitivity = Settings.Default.RadioFrequencyKnobSensitivity,
+                SmallFreqStepping = Settings.Default.SRSSmallFreqStepping
+            };
+
+            AppEventHandler.AttachGamingPanelListener(this);
+        }
+
+        private bool _disposed;
+        // Protected implementation of Dispose pattern.
+        protected override void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    _radioPanelPZ69SRS.Dispose();
+                    AppEventHandler.DetachGamingPanelListener(this);
+                }
+
+                _disposed = true;
+            }
+
+            // Call base class implementation.
+            base.Dispose(disposing);
+        }
+        
+        public override GamingPanel GetGamingPanel()
+        {
+            return _radioPanelPZ69SRS;
+        }
+
+        public override GamingPanelEnum GetPanelType()
+        {
+            return GamingPanelEnum.PZ69RadioPanel;
+        }
+
+        public string GetName()
+        {
+            return GetType().Name;
+        }
+
+        public void UpdatesHasBeenMissed(object sender, DCSBIOSUpdatesMissedEventArgs e) { }
+
+
+        public void SwitchesChanged(object sender, SwitchesChangedEventArgs e)
+        {
+            try
+            {
+                if (e.PanelType == GamingPanelEnum.PZ69RadioPanel && e.HidInstance.Equals(_radioPanelPZ69SRS.HIDInstance))
+                {
+                    SetGraphicsState(e.Switches);
+                }
+            }
+            catch (Exception ex)
+            {
+                Common.ShowErrorMessageBox( ex);
+            }
+        }
+
+        public void ProfileEvent(object sender, ProfileEventArgs e) { }
+
+        public void SettingsApplied(object sender, PanelInfoArgs e) { }
+
+        public void SettingsModified(object sender, PanelInfoArgs e) { }
+
+
+        private void SetGraphicsState(HashSet<object> knobs)
+        {
+            try
+            {
+                foreach (var radioKnobO in knobs)
+                {
+                    var radioKnob = (RadioPanelKnobSRS)radioKnobO;
+                    Dispatcher?.BeginInvoke((Action)delegate
+                   {
+                        /*if (radioKnob.IsOn)
+                        {
+                            SetGroupboxVisibility(radioKnob.RadioPanelPZ69Knob);
+                        }*/
+                   });
+                    switch (radioKnob.RadioPanelPZ69Knob)
+                    {
+                        case RadioPanelPZ69KnobsSRS.UPPER_COM1:
+                            {
+                                var key = radioKnob;
+                                Dispatcher?.BeginInvoke(
+                                    (Action)delegate
+                                    {
+                                        TopLeftCom1.Visibility = key.IsOn ? Visibility.Visible : Visibility.Collapsed;
+                                    });
+                                break;
+                            }
+                        case RadioPanelPZ69KnobsSRS.UPPER_COM2:
+                            {
+                                var key = radioKnob;
+                                Dispatcher?.BeginInvoke(
+                                    (Action)delegate
+                                    {
+                                        TopLeftCom2.Visibility = key.IsOn ? Visibility.Visible : Visibility.Collapsed;
+                                    });
+                                break;
+                            }
+                        case RadioPanelPZ69KnobsSRS.UPPER_NAV1:
+                            {
+                                var key = radioKnob;
+                                Dispatcher?.BeginInvoke(
+                                    (Action)delegate
+                                    {
+                                        TopLeftNav1.Visibility = key.IsOn ? Visibility.Visible : Visibility.Collapsed;
+                                    });
+                                break;
+                            }
+                        case RadioPanelPZ69KnobsSRS.UPPER_NAV2:
+                            {
+                                var key = radioKnob;
+                                Dispatcher?.BeginInvoke(
+                                    (Action)delegate
+                                    {
+                                        TopLeftNav2.Visibility = key.IsOn ? Visibility.Visible : Visibility.Collapsed;
+                                    });
+                                break;
+                            }
+                        case RadioPanelPZ69KnobsSRS.UPPER_ADF:
+                            {
+                                var key = radioKnob;
+                                Dispatcher?.BeginInvoke(
+                                    (Action)delegate
+                                    {
+                                        TopLeftADF.Visibility = key.IsOn ? Visibility.Visible : Visibility.Collapsed;
+                                    });
+                                break;
+                            }
+                        case RadioPanelPZ69KnobsSRS.UPPER_DME:
+                            {
+                                var key = radioKnob;
+                                Dispatcher?.BeginInvoke(
+                                    (Action)delegate
+                                    {
+                                        TopLeftDME.Visibility = key.IsOn ? Visibility.Visible : Visibility.Collapsed;
+                                    });
+                                break;
+                            }
+                        case RadioPanelPZ69KnobsSRS.UPPER_XPDR:
+                            {
+                                var key = radioKnob;
+                                Dispatcher?.BeginInvoke(
+                                    (Action)delegate
+                                    {
+                                        TopLeftXPDR.Visibility = key.IsOn ? Visibility.Visible : Visibility.Collapsed;
+                                    });
+                                break;
+                            }
+                        case RadioPanelPZ69KnobsSRS.LOWER_COM1:
+                            {
+                                var key = radioKnob;
+                                Dispatcher?.BeginInvoke(
+                                    (Action)delegate
+                                    {
+                                        LowerLeftCom1.Visibility = key.IsOn ? Visibility.Visible : Visibility.Collapsed;
+                                    });
+                                break;
+                            }
+                        case RadioPanelPZ69KnobsSRS.LOWER_COM2:
+                            {
+                                var key = radioKnob;
+                                Dispatcher?.BeginInvoke(
+                                    (Action)delegate
+                                    {
+                                        LowerLeftCom2.Visibility = key.IsOn ? Visibility.Visible : Visibility.Collapsed;
+                                    });
+                                break;
+                            }
+                        case RadioPanelPZ69KnobsSRS.LOWER_NAV1:
+                            {
+                                var key = radioKnob;
+                                Dispatcher?.BeginInvoke(
+                                    (Action)delegate
+                                    {
+                                        LowerLeftNav1.Visibility = key.IsOn ? Visibility.Visible : Visibility.Collapsed;
+                                    });
+                                break;
+                            }
+                        case RadioPanelPZ69KnobsSRS.LOWER_NAV2:
+                            {
+                                var key = radioKnob;
+                                Dispatcher?.BeginInvoke(
+                                    (Action)delegate
+                                    {
+                                        LowerLeftNav2.Visibility = key.IsOn ? Visibility.Visible : Visibility.Collapsed;
+                                    });
+                                break;
+                            }
+                        case RadioPanelPZ69KnobsSRS.LOWER_ADF:
+                            {
+                                var key = radioKnob;
+                                Dispatcher?.BeginInvoke(
+                                    (Action)delegate
+                                    {
+                                        LowerLeftADF.Visibility = key.IsOn ? Visibility.Visible : Visibility.Collapsed;
+                                    });
+                                break;
+                            }
+                        case RadioPanelPZ69KnobsSRS.LOWER_DME:
+                            {
+                                var key = radioKnob;
+                                Dispatcher?.BeginInvoke(
+                                    (Action)delegate
+                                    {
+                                        LowerLeftDME.Visibility = key.IsOn ? Visibility.Visible : Visibility.Collapsed;
+                                    });
+                                break;
+                            }
+                        case RadioPanelPZ69KnobsSRS.LOWER_XPDR:
+                            {
+                                var key = radioKnob;
+                                Dispatcher?.BeginInvoke(
+                                    (Action)delegate
+                                    {
+                                        LowerLeftXPDR.Visibility = key.IsOn ? Visibility.Visible : Visibility.Collapsed;
+                                    });
+                                break;
+                            }
+                        case RadioPanelPZ69KnobsSRS.UPPER_SMALL_FREQ_WHEEL_INC:
+                            {
+                                var key = radioKnob;
+                                Dispatcher?.BeginInvoke(
+                                    (Action)delegate
+                                    {
+                                        UpperSmallerLCDKnobInc.Visibility = key.IsOn ? Visibility.Visible : Visibility.Collapsed;
+                                    });
+                                break;
+                            }
+                        case RadioPanelPZ69KnobsSRS.UPPER_SMALL_FREQ_WHEEL_DEC:
+                            {
+                                var key = radioKnob;
+                                Dispatcher?.BeginInvoke(
+                                    (Action)delegate
+                                    {
+                                        UpperSmallerLCDKnobDec.Visibility = key.IsOn ? Visibility.Visible : Visibility.Collapsed;
+                                    });
+                                break;
+                            }
+                        case RadioPanelPZ69KnobsSRS.UPPER_LARGE_FREQ_WHEEL_INC:
+                            {
+                                var key = radioKnob;
+                                Dispatcher?.BeginInvoke(
+                                    (Action)delegate
+                                    {
+                                        UpperLargerLCDKnobInc.Visibility = key.IsOn ? Visibility.Visible : Visibility.Collapsed;
+                                    });
+                                break;
+                            }
+                        case RadioPanelPZ69KnobsSRS.UPPER_LARGE_FREQ_WHEEL_DEC:
+                            {
+                                var key = radioKnob;
+                                Dispatcher?.BeginInvoke(
+                                    (Action)delegate
+                                    {
+                                        UpperLargerLCDKnobDec.Visibility = key.IsOn ? Visibility.Visible : Visibility.Collapsed;
+                                    });
+                                break;
+                            }
+                        case RadioPanelPZ69KnobsSRS.LOWER_SMALL_FREQ_WHEEL_INC:
+                            {
+                                var key = radioKnob;
+                                Dispatcher?.BeginInvoke(
+                                    (Action)delegate
+                                    {
+                                        LowerSmallerLCDKnobInc.Visibility = key.IsOn ? Visibility.Visible : Visibility.Collapsed;
+                                    });
+                                break;
+                            }
+                        case RadioPanelPZ69KnobsSRS.LOWER_SMALL_FREQ_WHEEL_DEC:
+                            {
+                                var key = radioKnob;
+                                Dispatcher?.BeginInvoke(
+                                    (Action)delegate
+                                    {
+                                        LowerSmallerLCDKnobDec.Visibility = key.IsOn ? Visibility.Visible : Visibility.Collapsed;
+                                    });
+                                break;
+                            }
+                        case RadioPanelPZ69KnobsSRS.LOWER_LARGE_FREQ_WHEEL_INC:
+                            {
+                                var key = radioKnob;
+                                Dispatcher?.BeginInvoke(
+                                    (Action)delegate
+                                    {
+                                        LowerLargerLCDKnobInc.Visibility = key.IsOn ? Visibility.Visible : Visibility.Collapsed;
+                                    });
+                                break;
+                            }
+                        case RadioPanelPZ69KnobsSRS.LOWER_LARGE_FREQ_WHEEL_DEC:
+                            {
+                                var key = radioKnob;
+                                Dispatcher?.BeginInvoke(
+                                    (Action)delegate
+                                    {
+                                        LowerLargerLCDKnobDec.Visibility = key.IsOn ? Visibility.Visible : Visibility.Collapsed;
+                                    });
+                                break;
+                            }
+                        case RadioPanelPZ69KnobsSRS.UPPER_FREQ_SWITCH:
+                            {
+                                var key = radioKnob;
+                                Dispatcher?.BeginInvoke(
+                                    (Action)delegate
+                                    {
+                                        UpperRightSwitch.Visibility = key.IsOn ? Visibility.Visible : Visibility.Collapsed;
+                                    });
+                                break;
+                            }
+                        case RadioPanelPZ69KnobsSRS.LOWER_FREQ_SWITCH:
+                            {
+                                var key = radioKnob;
+                                Dispatcher?.BeginInvoke(
+                                    (Action)delegate
+                                    {
+                                        LowerRightSwitch.Visibility = key.IsOn ? Visibility.Visible : Visibility.Collapsed;
+                                    });
+                                break;
+                            }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Common.ShowErrorMessageBox( ex);
+            }
+        }
+        
+        private void HideAllImages()
+        {
+            TopLeftCom1.Visibility = Visibility.Collapsed;
+            TopLeftCom2.Visibility = Visibility.Collapsed;
+            TopLeftNav1.Visibility = Visibility.Collapsed;
+            TopLeftNav2.Visibility = Visibility.Collapsed;
+            TopLeftADF.Visibility = Visibility.Collapsed;
+            TopLeftDME.Visibility = Visibility.Collapsed;
+            TopLeftXPDR.Visibility = Visibility.Collapsed;
+            LowerLeftCom1.Visibility = Visibility.Collapsed;
+            LowerLeftCom2.Visibility = Visibility.Collapsed;
+            LowerLeftNav1.Visibility = Visibility.Collapsed;
+            LowerLeftNav2.Visibility = Visibility.Collapsed;
+            LowerLeftADF.Visibility = Visibility.Collapsed;
+            LowerLeftDME.Visibility = Visibility.Collapsed;
+            LowerLeftXPDR.Visibility = Visibility.Collapsed;
+            LowerLargerLCDKnobDec.Visibility = Visibility.Collapsed;
+            UpperLargerLCDKnobInc.Visibility = Visibility.Collapsed;
+            UpperRightSwitch.Visibility = Visibility.Collapsed;
+            UpperSmallerLCDKnobDec.Visibility = Visibility.Collapsed;
+            UpperSmallerLCDKnobInc.Visibility = Visibility.Collapsed;
+            UpperLargerLCDKnobDec.Visibility = Visibility.Collapsed;
+            LowerLargerLCDKnobInc.Visibility = Visibility.Collapsed;
+            LowerRightSwitch.Visibility = Visibility.Collapsed;
+            LowerSmallerLCDKnobDec.Visibility = Visibility.Collapsed;
+            LowerSmallerLCDKnobInc.Visibility = Visibility.Collapsed;
+        }
+
+        
+
+
+        private void ButtonGetId_OnClick(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (_radioPanelPZ69SRS != null)
+                {
+                    TextBoxLogPZ69.Text = string.Empty;
+                    TextBoxLogPZ69.Text = _radioPanelPZ69SRS.HIDInstance;
+                    Clipboard.SetText(_radioPanelPZ69SRS.HIDInstance);
+                    MessageBox.Show("The Instance Id for the panel has been copied to the Clipboard.");
+                }
+            }
+            catch (Exception ex)
+            {
+                Common.ShowErrorMessageBox( ex);
+            }
+        }
+
+        private void ComboBoxFreqKnobSensitivity_OnSelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            try
+            {
+                if (UserControlLoaded)
+                {
+                    Settings.Default.RadioFrequencyKnobSensitivity = int.Parse(ComboBoxFreqKnobSensitivity.SelectedValue.ToString());
+                    _radioPanelPZ69SRS.FrequencyKnobSensitivity = int.Parse(ComboBoxFreqKnobSensitivity.SelectedValue.ToString());
+                    Settings.Default.Save();
+                }
+            }
+            catch (Exception ex)
+            {
+                Common.ShowErrorMessageBox( ex);
+            }
+        }
+
+        private void ComboBoxSmallFreqStepping_OnSelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            try
+            {
+                if (UserControlLoaded)
+                {
+                    var numberFormat = new NumberFormatInfo
+                    {
+                        NumberDecimalSeparator = ".",
+                        NumberDecimalDigits = 3,
+                        NumberGroupSeparator = string.Empty
+                    };
+                    Settings.Default.SRSSmallFreqStepping = double.Parse(ComboBoxSmallFreqStepping.SelectedValue.ToString(), numberFormat);
+                    _radioPanelPZ69SRS.SmallFreqStepping = double.Parse(ComboBoxSmallFreqStepping.SelectedValue.ToString(), numberFormat);
+                    Settings.Default.Save();
+                }
+            }
+            catch (Exception ex)
+            {
+                Common.ShowErrorMessageBox( ex);
+            }
+        }
+
+        private void RadioPanelPZ69UserControlSRS_OnLoaded(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                ComboBoxFreqKnobSensitivity.SelectedValue = Settings.Default.RadioFrequencyKnobSensitivity;
+                ComboBoxSmallFreqStepping.SelectedValue = Settings.Default.SRSSmallFreqStepping;
+                UserControlLoaded = true;
+            }
+            catch (Exception ex)
+            {
+                Common.ShowErrorMessageBox( ex);
+            }
+        }
+
+
+        private void ButtonGetIdentify_OnClick(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                _radioPanelPZ69SRS.Identify();
+            }
+            catch (Exception ex)
+            {
+                Common.ShowErrorMessageBox(ex);
+            }
+        }
+    }
+}

--- a/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlSpitfireLFMkIX.xaml.cs
+++ b/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlSpitfireLFMkIX.xaml.cs
@@ -8,7 +8,6 @@
     using ClassLibraryCommon;
 
     using Interfaces;
-    using PanelUserControls;
     using Properties;
     using NonVisuals.EventArgs;
     using NonVisuals.Interfaces;

--- a/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlUH1H.xaml.cs
+++ b/Source/DCSFlightpanels/Radios/PreProgrammed/RadioPanelPZ69UserControlUH1H.xaml.cs
@@ -8,7 +8,6 @@
     using ClassLibraryCommon;
 
     using Interfaces;
-    using PanelUserControls;
     using Properties;
     using NonVisuals.EventArgs;
     using NonVisuals.Interfaces;

--- a/Source/DCSFlightpanels/Windows/AboutFPWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/AboutFPWindow.xaml.cs
@@ -1,5 +1,4 @@
-﻿using ClassLibraryCommon;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Navigation;

--- a/Source/DCSFlightpanels/Windows/ChooseProfileModuleWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/ChooseProfileModuleWindow.xaml.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using System.Windows.Media;
 using ClassLibraryCommon;
 using DCS_BIOS;
 

--- a/Source/DCSFlightpanels/Windows/ChooseProfileModuleWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/ChooseProfileModuleWindow.xaml.cs
@@ -94,9 +94,9 @@ namespace DCSFlightpanels.Windows
             try
             {
                 SetAirframe();
-                if (!DCSFPProfile.IsFlamingCliff(_dcsfpProfile) &&
-                    !DCSFPProfile.IsKeyEmulator(_dcsfpProfile) &&
-                    !DCSFPProfile.IsKeyEmulatorSRS(_dcsfpProfile))
+                if (!DCSAircraft.IsFlamingCliff(_dcsAircraft) &&
+                    !DCSAircraft.IsKeyEmulator(_dcsAircraft) &&
+                    !DCSAircraft.IsKeyEmulatorSRS(_dcsAircraft))
                 {
                     //User has chosen a DCS-BIOS compatible module
                     StackPanelUseGenericRadio.Visibility = Visibility.Visible;

--- a/Source/DCSFlightpanels/Windows/ChooseProfileModuleWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/ChooseProfileModuleWindow.xaml.cs
@@ -96,8 +96,9 @@ namespace DCSFlightpanels.Windows
             try
             {
                 SetAirframe();
-                if (!DCSAircraft.IsFlamingCliff(_dcsAircraft) &&
-                    !DCSAircraft.IsKeyEmulator(_dcsAircraft))
+                if (!DCSFPProfile.IsFlamingCliff(_dcsfpProfile) &&
+                    !DCSFPProfile.IsKeyEmulator(_dcsfpProfile) &&
+                    !DCSFPProfile.IsKeyEmulatorSRS(_dcsfpProfile))
                 {
                     //User has chosen a DCS-BIOS compatible module
                     StackPanelUseGenericRadio.Visibility = Visibility.Visible;

--- a/Source/DCSFlightpanels/Windows/JaceHelpWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/JaceHelpWindow.xaml.cs
@@ -1,6 +1,5 @@
 ﻿namespace DCSFlightpanels.Windows
 {
-    using ClassLibraryCommon;
     using System;
     using System.Diagnostics;
     using System.Windows;

--- a/Source/DCSFlightpanels/Windows/KeyPressReadingBigWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/KeyPressReadingBigWindow.xaml.cs
@@ -1,6 +1,5 @@
 ﻿using System.Diagnostics;
 using System.Linq;
-using System.Windows.Media;
 
 namespace DCSFlightpanels.Windows
 {

--- a/Source/DCSFlightpanels/Windows/KeyPressReadingSmallWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/KeyPressReadingSmallWindow.xaml.cs
@@ -8,7 +8,6 @@ namespace DCSFlightpanels.Windows
     using System.Windows;
     using System.Windows.Controls;
     using System.Windows.Input;
-    using System.Windows.Media;
     using ClassLibraryCommon;
     using MEF;
     using NonVisuals;

--- a/Source/DCSFlightpanels/Windows/SettingsWindow.xaml
+++ b/Source/DCSFlightpanels/Windows/SettingsWindow.xaml
@@ -109,6 +109,19 @@
                     </TextBlock>
                 </StackPanel>
             </TabItem>
+            <TabItem Header="SRS">
+                <StackPanel Name="StackPanelSRSSettings"  Margin="0,0,0,0" Grid.Column="1" Grid.Row="0" >
+                    <Label FontWeight="Bold">SRS Settings</Label>
+                    <Label Content="IP address to read from" Margin="0,0,0,0" VerticalAlignment="Top"/>
+                    <TextBox Name="TextBoxSRSFromIP" Height="23" Margin="0,0,0,0" TextWrapping="Wrap" Text="239.255.50.10"/>
+                    <Label Content="Port to read from" Margin="0,0,0,0" VerticalAlignment="Top"/>
+                    <TextBox Name="TextBoxSRSFromPort" Height="23" Margin="0,0,0,0" TextWrapping="Wrap" Text="5010"/>
+                    <Label Content="IP address to write to" Margin="0,0,0,0" VerticalAlignment="Top"/>
+                    <TextBox Name="TextBoxSRSToIP" Height="23" Margin="0,0,0,0" TextWrapping="Wrap" Text="127.0.0.1"/>
+                    <Label Content="Port to write to " Margin="0,0,0,0" VerticalAlignment="Top"/>
+                    <TextBox Name="TextBoxSRSToPort" Height="23" Margin="0,0,0,0" TextWrapping="Wrap" Text="7778"/>
+                </StackPanel>
+            </TabItem>
         </TabControl>
 
 

--- a/Source/DCSFlightpanels/Windows/SettingsWindow.xaml
+++ b/Source/DCSFlightpanels/Windows/SettingsWindow.xaml
@@ -113,13 +113,13 @@
                 <StackPanel Name="StackPanelSRSSettings"  Margin="0,0,0,0" Grid.Column="1" Grid.Row="0" >
                     <Label FontWeight="Bold">SRS Settings</Label>
                     <Label Content="IP address to read from" Margin="0,0,0,0" VerticalAlignment="Top"/>
-                    <TextBox Name="TextBoxSRSFromIP" Height="23" Margin="0,0,0,0" TextWrapping="Wrap" Text="239.255.50.10"/>
+                    <TextBox Name="TextBoxSRSFromIP" Height="23" Margin="0,0,0,0" TextWrapping="Wrap" Text="127.0.0.1"/>
                     <Label Content="Port to read from" Margin="0,0,0,0" VerticalAlignment="Top"/>
-                    <TextBox Name="TextBoxSRSFromPort" Height="23" Margin="0,0,0,0" TextWrapping="Wrap" Text="5010"/>
+                    <TextBox Name="TextBoxSRSFromPort" Height="23" Margin="0,0,0,0" TextWrapping="Wrap" Text="7082"/>
                     <Label Content="IP address to write to" Margin="0,0,0,0" VerticalAlignment="Top"/>
                     <TextBox Name="TextBoxSRSToIP" Height="23" Margin="0,0,0,0" TextWrapping="Wrap" Text="127.0.0.1"/>
                     <Label Content="Port to write to " Margin="0,0,0,0" VerticalAlignment="Top"/>
-                    <TextBox Name="TextBoxSRSToPort" Height="23" Margin="0,0,0,0" TextWrapping="Wrap" Text="7778"/>
+                    <TextBox Name="TextBoxSRSToPort" Height="23" Margin="0,0,0,0" TextWrapping="Wrap" Text="9040"/>
                 </StackPanel>
             </TabItem>
         </TabControl>

--- a/Source/DCSFlightpanels/Windows/SettingsWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/SettingsWindow.xaml.cs
@@ -12,7 +12,6 @@ using ClassLibraryCommon;
 using DCS_BIOS;
 using DCSFlightpanels.Properties;
 using NonVisuals.EventArgs;
-using Cursors = System.Windows.Forms.Cursors;
 
 namespace DCSFlightpanels.Windows
 {

--- a/Source/DCSFlightpanels/Windows/TextBlockDialogWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/TextBlockDialogWindow.xaml.cs
@@ -1,6 +1,5 @@
 ﻿namespace DCSFlightpanels.Windows
 {
-    using ClassLibraryCommon;
     using System.Windows;
     using System.Windows.Documents;
 

--- a/Source/DCSFlightpanels/Windows/WindowsKeyAPIDialog.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/WindowsKeyAPIDialog.xaml.cs
@@ -1,5 +1,4 @@
-﻿using ClassLibraryCommon;
-using System.Windows;
+﻿using System.Windows;
 
 namespace DCSFlightpanels.Windows
 {

--- a/Source/DCSFlightpanels/app.config
+++ b/Source/DCSFlightpanels/app.config
@@ -58,6 +58,18 @@
             <setting name="RunMinimized" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="SRSIpFrom" serializeAs="String">
+                <value>127.0.0.1</value>
+            </setting>
+            <setting name="SRSIpTo" serializeAs="String">
+                <value>127.0.0.1</value>
+            </setting>
+            <setting name="SRSPortFrom" serializeAs="String">
+                <value>7082</value>
+            </setting>
+            <setting name="SRSPortTo" serializeAs="String">
+                <value>9040</value>
+            </setting>
             <setting name="LastGitHubCheck" serializeAs="String">
                 <value>2018-01-01</value>
             </setting>

--- a/Source/MEF/Switches.cs
+++ b/Source/MEF/Switches.cs
@@ -290,19 +290,4 @@
         LowerXPDR = 262144,
         Unknown = 0x80000
     }
-
-    /*
-     *
-     */
-    public enum CurrentSRSRadioMode
-    {
-        COM1 = 0,
-        COM2 = 2,
-        NAV1 = 4,
-        NAV2 = 8,
-        ADF = 16,
-        DME = 32,
-        XPDR = 64
-    }
- 
 }

--- a/Source/NonVisuals/BindingClasses/DCSBIOSBindings/DCSBIOSActionBindingBase.cs
+++ b/Source/NonVisuals/BindingClasses/DCSBIOSBindings/DCSBIOSActionBindingBase.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Source/NonVisuals/BindingClasses/Key/KeyBindingPZ70.cs
+++ b/Source/NonVisuals/BindingClasses/Key/KeyBindingPZ70.cs
@@ -96,16 +96,6 @@ namespace NonVisuals.BindingClasses.Key
                 {
                     if (keyBinding != keyBindingPZ70 && keyBinding.MultiPanelPZ70Knob == keyBindingPZ70.MultiPanelPZ70Knob && keyBinding.WhenTurnedOn != keyBindingPZ70.WhenTurnedOn)
                     {
-                        /*if (keyBinding.MultiPanelPZ70Knob == MultiPanelPZ70Knobs.FLAPS_LEVER_UP ||
-                            keyBinding.MultiPanelPZ70Knob == MultiPanelPZ70Knobs.FLAPS_LEVER_DOWN)
-                        {
-                            Debug.WriteLine("Adding " + keyBinding.MultiPanelPZ70Knob + "(" + keyBinding.WhenTurnedOn + ") as negator to " +
-                                            keyBindingPZ70.MultiPanelPZ70Knob + "(" + keyBindingPZ70.WhenTurnedOn + ")");
-                        }
-                        if (keyBinding.OSKeyPress.KeyPressSequence.Count == 0)
-                        {
-                            Debugger.Break();
-                        }*/
                         keyBindingPZ70.OSKeyPress.NegatorOSKeyPresses.Add(keyBinding.OSKeyPress);
                     }
                 }
@@ -154,10 +144,6 @@ namespace NonVisuals.BindingClasses.Key
                     {
                         if (keyBinding != keyBindingPZ70 && keyBinding.MultiPanelPZ70Knob == negatorKnob)
                         {
-                            /*if (keyBinding.OSKeyPress.KeyPressSequence.Count == 0)
-                            {
-                                Debugger.Break();
-                            }*/
                             keyBindingPZ70.OSKeyPress.NegatorOSKeyPresses.Add(keyBinding.OSKeyPress);
                         }
                     }

--- a/Source/NonVisuals/BindingMappingManager.cs
+++ b/Source/NonVisuals/BindingMappingManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Diagnostics;
+using System.Linq;
 using NonVisuals.EventArgs;
 
 namespace NonVisuals
@@ -62,6 +63,7 @@ namespace NonVisuals
             {
                 var hardwareFound = HIDHandler.GetInstance().HIDSkeletons
                     .Any(o => o.IsAttached && o.HIDInstance.Equals(hidInstance));
+
                 foreach (var genericPanelBinding in _genericBindings)
                 {
                     if (genericPanelBinding.HIDInstance.Equals(hidInstance) && genericPanelBinding.InUse == false &&
@@ -70,6 +72,7 @@ namespace NonVisuals
                         genericPanelBinding.InUse = true;
                         AppEventHandler.ProfileEvent(null, ProfileEventEnum.ProfileSettings, genericPanelBinding,
                             DCSAircraft.SelectedAircraft);
+                        break;
                     }
                 }
             }

--- a/Source/NonVisuals/ClickSpeedDetector.cs
+++ b/Source/NonVisuals/ClickSpeedDetector.cs
@@ -1,8 +1,15 @@
-﻿namespace NonVisuals
+﻿using System.Diagnostics;
+
+namespace NonVisuals
 {
     using System;
     using System.Collections.Generic;
 
+    /// <summary>
+    /// Used for especially radio dials so that when the user turns the dial faster
+    /// the rate at which it changes the frequency increases. Slowing down resets the
+    /// delta to base line.
+    /// </summary>
     public class ClickSpeedDetector
     {
         private readonly List<long> _clicksTimeTicksList = new();
@@ -54,6 +61,7 @@
         public bool ClickThresholdReached()
         {
             var count = ClicksWithinDefaultPeriod();
+            //Debug.WriteLine($"[{_clickCountThreshold}] Value is {count}. Threshold reached = {count >= _clickCountThreshold}");
             return count >= _clickCountThreshold;
         }
 

--- a/Source/NonVisuals/HID/HIDHandler.cs
+++ b/Source/NonVisuals/HID/HIDHandler.cs
@@ -53,13 +53,7 @@ namespace NonVisuals.HID
 
             return stringBuilder.ToString();
         }
-
-        /// <summary>
-        /// searchForNew is used when panel has been detached => attached but not found again because there is no hook (new HID instance ID).
-        /// So already found panels should be left as is.
-        /// </summary>
-        /// <param name="loadStreamDeck"></param>
-        /// <param name="searchForNew"></param>
+        
         public void Startup(bool loadStreamDeck)
         {
             try
@@ -75,10 +69,10 @@ namespace NonVisuals.HID
                                 continue;
                             }
 
-                            var hidIinstance = hidDevice.DevicePath;
-                            if (!HIDDeviceAlreadyExists(hidIinstance))
+                            var hidInstance = hidDevice.DevicePath;
+                            if (!HIDDeviceAlreadyExists(hidInstance))
                             {
-                                var hidSkeleton = new HIDSkeleton(gamingPanelSkeleton, hidIinstance);
+                                var hidSkeleton = new HIDSkeleton(gamingPanelSkeleton, hidInstance);
                                 HIDSkeletons.Add(hidSkeleton);
 
                                 hidDevice.MonitorDeviceEvents = true;
@@ -103,15 +97,7 @@ namespace NonVisuals.HID
                         }
                     }
                 }
-
-                /*foreach (var hidSkeleton in HIDSkeletons)
-                {
-                    if (hidSkeleton.IsAttached)
-                    {
-                        Debug.WriteLine(hidSkeleton.GamingPanelType + "   " + hidSkeleton.HIDInstance);
-                    }
-                }*/
-                Debug.WriteLine($"*** HIDSkeleton count is {HIDSkeletons.Count}");
+                
                 //Broadcast that this panel was found.
                 HIDSkeletons.FindAll(o => o.IsAttached).ToList().ForEach(o => AppEventHandler.PanelEvent(this, o.HIDInstance, o, PanelEventType.Found));
 

--- a/Source/NonVisuals/Interfaces/ISRSHandler.cs
+++ b/Source/NonVisuals/Interfaces/ISRSHandler.cs
@@ -1,0 +1,12 @@
+﻿namespace NonVisuals.Interfaces
+{
+    using NonVisuals.Radios.SRS;
+
+    public interface ISRSHandler
+    {
+        bool GuardIsOn { get; set; }
+        double Frequency { get; set; }
+        double Channel { get; set; }
+        SRSRadioMode RadioMode { get; set; }
+    }
+}

--- a/Source/NonVisuals/KeyPress.cs
+++ b/Source/NonVisuals/KeyPress.cs
@@ -117,12 +117,6 @@ namespace NonVisuals
                 Debug.WriteLine($"Looking for negators. Count is {_negatorOSKeyPresses.Count}");
                 foreach (var negatorOSKeyPress in _negatorOSKeyPresses)
                 {
-                    /*if (negatorOSKeyPress.KeyPressSequence.Count == 0)
-                    {
-                        Debugger.Break();
-                    }
-                    Debug.WriteLine("Current negatorOSKeyPress.KeyPressSequence count is " + negatorOSKeyPress.KeyPressSequence.Count);
-                    Debug.WriteLine("Aborting keypress : " + negatorOSKeyPress.KeyPressSequence[0].VirtualKeyCodesAsString);*/
                     negatorOSKeyPress.Abort = true;
                 }
 

--- a/Source/NonVisuals/Panels/StreamDeck/Events/SDEventHandler.cs
+++ b/Source/NonVisuals/Panels/StreamDeck/Events/SDEventHandler.cs
@@ -1,9 +1,6 @@
 ﻿namespace NonVisuals.Panels.StreamDeck.Events
 {
     using System.Text;
-
-    using MEF;
-
     using Interfaces;
     using Panels;
     using StreamDeck;

--- a/Source/NonVisuals/Radios/Knobs/RadioPanelKnobPZ69SRS.cs
+++ b/Source/NonVisuals/Radios/Knobs/RadioPanelKnobPZ69SRS.cs
@@ -1,0 +1,101 @@
+﻿using NonVisuals.Interfaces;
+using System;
+using System.Collections.Generic;
+
+namespace NonVisuals.Radios.Knobs
+{
+    public enum CurrentSRSRadioMode
+    {
+        COM1 = 0,
+        COM2 = 2,
+        NAV1 = 4,
+        NAV2 = 8,
+        ADF = 16,
+        DME = 32,
+        XPDR = 64
+    }
+
+    public enum RadioPanelPZ69KnobsSRS
+    {
+        UPPER_COM1 = 0,   //COM1
+        UPPER_COM2 = 2,  //COM2
+        UPPER_NAV1 = 4, //NAV1
+        UPPER_NAV2 = 8, //NAV2
+        UPPER_ADF = 16, //ADF
+        UPPER_DME = 32, //DME_
+        UPPER_XPDR = 64, //XPDR
+        UPPER_SMALL_FREQ_WHEEL_INC = 128,
+        UPPER_SMALL_FREQ_WHEEL_DEC = 256,
+        UPPER_LARGE_FREQ_WHEEL_INC = 512,
+        UPPER_LARGE_FREQ_WHEEL_DEC = 1024,
+        UPPER_FREQ_SWITCH = 2056,
+        LOWER_COM1 = 4096,
+        LOWER_COM2 = 8192,
+        LOWER_NAV1 = 16384,
+        LOWER_NAV2 = 32768,
+        LOWER_ADF = 65536,
+        LOWER_DME = 131072,
+        LOWER_XPDR = 262144,
+        LOWER_SMALL_FREQ_WHEEL_INC = 8388608,
+        LOWER_SMALL_FREQ_WHEEL_DEC = 524288,
+        LOWER_LARGE_FREQ_WHEEL_INC = 1048576,
+        LOWER_LARGE_FREQ_WHEEL_DEC = 2097152,
+        LOWER_FREQ_SWITCH = 4194304
+    }
+
+    public class RadioPanelKnobSRS : ISaitekPanelKnob
+    {
+        public RadioPanelKnobSRS(int group, int mask, bool isOn, RadioPanelPZ69KnobsSRS radioPanelPZ69Knob)
+        {
+            Group = group;
+            Mask = mask;
+            IsOn = isOn;
+            RadioPanelPZ69Knob = radioPanelPZ69Knob;
+        }
+
+        public int Group { get; set; }
+
+        public int Mask { get; set; }
+
+        public bool IsOn { get; set; }
+
+        public RadioPanelPZ69KnobsSRS RadioPanelPZ69Knob { get; set; }
+
+        public static HashSet<ISaitekPanelKnob> GetRadioPanelKnobs()
+        {
+            // true means clockwise turn
+            var result = new HashSet<ISaitekPanelKnob>
+            {
+                // Group 0
+                new RadioPanelKnobSRS(2, Convert.ToInt32("1", 2), true, RadioPanelPZ69KnobsSRS.UPPER_SMALL_FREQ_WHEEL_INC),
+                new RadioPanelKnobSRS(2, Convert.ToInt32("10", 2), false, RadioPanelPZ69KnobsSRS.UPPER_SMALL_FREQ_WHEEL_DEC),
+                new RadioPanelKnobSRS(2, Convert.ToInt32("100", 2), true, RadioPanelPZ69KnobsSRS.UPPER_LARGE_FREQ_WHEEL_INC),
+                new RadioPanelKnobSRS(2, Convert.ToInt32("1000", 2), false, RadioPanelPZ69KnobsSRS.UPPER_LARGE_FREQ_WHEEL_DEC),
+                new RadioPanelKnobSRS(2, Convert.ToInt32("10000", 2), true, RadioPanelPZ69KnobsSRS.LOWER_SMALL_FREQ_WHEEL_INC),
+                new RadioPanelKnobSRS(2, Convert.ToInt32("100000", 2), false, RadioPanelPZ69KnobsSRS.LOWER_SMALL_FREQ_WHEEL_DEC),
+                new RadioPanelKnobSRS(2, Convert.ToInt32("1000000", 2), true, RadioPanelPZ69KnobsSRS.LOWER_LARGE_FREQ_WHEEL_INC),
+                new RadioPanelKnobSRS(2, Convert.ToInt32("10000000", 2), false, RadioPanelPZ69KnobsSRS.LOWER_LARGE_FREQ_WHEEL_DEC),
+                // Group 1
+                new RadioPanelKnobSRS(1, Convert.ToInt32("1", 2), true, RadioPanelPZ69KnobsSRS.LOWER_COM2), // LOWER COM2
+                new RadioPanelKnobSRS(1, Convert.ToInt32("10", 2), true, RadioPanelPZ69KnobsSRS.LOWER_NAV1), // LOWER NAV1
+                new RadioPanelKnobSRS(1, Convert.ToInt32("100", 2), true, RadioPanelPZ69KnobsSRS.LOWER_NAV2), // LOWER NAV2
+                new RadioPanelKnobSRS(1, Convert.ToInt32("1000", 2), true, RadioPanelPZ69KnobsSRS.LOWER_ADF), // LOWER ADF
+                new RadioPanelKnobSRS(1, Convert.ToInt32("10000", 2), true, RadioPanelPZ69KnobsSRS.LOWER_DME), // LOWER DME
+                new RadioPanelKnobSRS(1, Convert.ToInt32("100000", 2), true, RadioPanelPZ69KnobsSRS.LOWER_XPDR), // LOWER XPDR
+                new RadioPanelKnobSRS(1, Convert.ToInt32("1000000", 2), true, RadioPanelPZ69KnobsSRS.UPPER_FREQ_SWITCH),
+                new RadioPanelKnobSRS(1, Convert.ToInt32("10000000", 2), true, RadioPanelPZ69KnobsSRS.LOWER_FREQ_SWITCH),
+                // Group 2
+                new RadioPanelKnobSRS(0, Convert.ToInt32("1", 2), true, RadioPanelPZ69KnobsSRS.UPPER_COM1), // UPPER COM1
+                new RadioPanelKnobSRS(0, Convert.ToInt32("10", 2), true, RadioPanelPZ69KnobsSRS.UPPER_COM2), // UPPER COM2
+                new RadioPanelKnobSRS(0, Convert.ToInt32("100", 2), true, RadioPanelPZ69KnobsSRS.UPPER_NAV1), // UPPER NAV1
+                new RadioPanelKnobSRS(0, Convert.ToInt32("1000", 2), true, RadioPanelPZ69KnobsSRS.UPPER_NAV2), // UPPER NAV2
+                new RadioPanelKnobSRS(0, Convert.ToInt32("10000", 2), true, RadioPanelPZ69KnobsSRS.UPPER_ADF), // UPPER ADF
+                new RadioPanelKnobSRS(0, Convert.ToInt32("100000", 2), true, RadioPanelPZ69KnobsSRS.UPPER_DME), // UPPER DME
+                new RadioPanelKnobSRS(0, Convert.ToInt32("1000000", 2), true, RadioPanelPZ69KnobsSRS.UPPER_XPDR), // UPPER XPDR
+                new RadioPanelKnobSRS(0, Convert.ToInt32("10000000", 2), true, RadioPanelPZ69KnobsSRS.LOWER_COM1) // LOWER COM1
+            };
+
+            return result;
+        }
+    }
+}

--- a/Source/NonVisuals/Radios/RadioPanelPZ69AH64D.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69AH64D.cs
@@ -4,7 +4,6 @@ namespace NonVisuals.Radios
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Threading;
 
     using ClassLibraryCommon;

--- a/Source/NonVisuals/Radios/RadioPanelPZ69SRS.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69SRS.cs
@@ -14,12 +14,9 @@
     using NonVisuals.Plugin;
     using NonVisuals.Radios.Knobs;
     using NonVisuals.Radios.SRS;
-    using NLog;
     using NonVisuals.Panels.Saitek;
     using NonVisuals.HID;
     using NonVisuals.BindingClasses.BIP;
-    using NonVisuals.Panels.Saitek.Switches;
-    using System.Windows.Input;
 
     public struct SRSRadioSmallFreqStepping
     {

--- a/Source/NonVisuals/Radios/RadioPanelPZ69SRS.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69SRS.cs
@@ -495,7 +495,7 @@
                                                 changeValue = 10.0;
                                             }
 
-                                            SRSListenerFactory.GetSRSListener().ChangeFrequency(_currentUpperRadioMode, changeValue);
+                                            SRSListenerFactory.GetSRSListener().ChangeFrequency(_currentLowerRadioMode, changeValue);
                                         }
                                     }
 
@@ -519,7 +519,7 @@
                                                 changeValue = -10.0;
                                             }
 
-                                            SRSListenerFactory.GetSRSListener().ChangeFrequency(_currentUpperRadioMode, changeValue);
+                                            SRSListenerFactory.GetSRSListener().ChangeFrequency(_currentLowerRadioMode, changeValue);
                                         }
                                     }
 
@@ -549,7 +549,7 @@
                                                 changeValue *= 100;
                                             }
 
-                                            SRSListenerFactory.GetSRSListener().ChangeFrequency(_currentUpperRadioMode, changeValue);
+                                            SRSListenerFactory.GetSRSListener().ChangeFrequency(_currentLowerRadioMode, changeValue);
                                         }
                                     }
 
@@ -579,7 +579,7 @@
                                                 changeValue *= 100;
                                             }
 
-                                            SRSListenerFactory.GetSRSListener().ChangeFrequency(_currentUpperRadioMode, changeValue);
+                                            SRSListenerFactory.GetSRSListener().ChangeFrequency(_currentLowerRadioMode, changeValue);
                                         }
                                     }
 
@@ -594,7 +594,6 @@
                 Logger.Error(ex);
             }
         }
-
         
         private void ShowFrequenciesOnPanel()
         {

--- a/Source/NonVisuals/Radios/RadioPanelPZ69SRS.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69SRS.cs
@@ -65,8 +65,8 @@
 
         public RadioPanelPZ69SRS(int portFrom, string ipAddressTo, int portTo, HIDSkeleton hidSkeleton) : base(hidSkeleton)
         {
-            SRSListenerFactory.SetParams(portFrom, ipAddressTo, portTo);
-            SRSListenerFactory.GetSRSListener().Attach(this);
+            SRSRadioFactory.SetParams(portFrom, ipAddressTo, portTo);
+            SRSRadioFactory.GetSRSRadio().Attach(this);
             CreateRadioKnobs();
             Startup();
         }
@@ -79,8 +79,8 @@
             {
                 if (disposing)
                 {
-                    SRSListenerFactory.GetSRSListener().Detach(this);
-                    SRSListenerFactory.Shutdown();
+                    SRSRadioFactory.GetSRSRadio().Detach(this);
+                    SRSRadioFactory.Shutdown();
                 }
 
                 _disposed = true;
@@ -112,10 +112,10 @@
         {
             try
             {
-                _upperMainFreq = SRSListenerFactory.GetSRSListener().GetFrequencyOrChannel(_currentUpperRadioMode);
-                _upperGuardFreq = SRSListenerFactory.GetSRSListener().GetFrequencyOrChannel(_currentUpperRadioMode, true);
-                _lowerMainFreq = SRSListenerFactory.GetSRSListener().GetFrequencyOrChannel(_currentLowerRadioMode);
-                _lowerGuardFreq = SRSListenerFactory.GetSRSListener().GetFrequencyOrChannel(_currentLowerRadioMode, true);
+                _upperMainFreq = SRSRadioFactory.GetSRSRadio().GetFrequencyOrChannel(_currentUpperRadioMode);
+                _upperGuardFreq = SRSRadioFactory.GetSRSRadio().GetFrequencyOrChannel(_currentUpperRadioMode, true);
+                _lowerMainFreq = SRSRadioFactory.GetSRSRadio().GetFrequencyOrChannel(_currentLowerRadioMode);
+                _lowerGuardFreq = SRSRadioFactory.GetSRSRadio().GetFrequencyOrChannel(_currentLowerRadioMode, true);
                 Interlocked.Increment(ref _doUpdatePanelLCD);
                 ShowFrequenciesOnPanel();
             }
@@ -307,7 +307,7 @@
                                         var timeSpan = new TimeSpan(DateTime.Now.Ticks - _upperFreqSwitchPressed);
                                         if (timeSpan.Seconds <= 2)
                                         {
-                                            SRSListenerFactory.GetSRSListener().ToggleBetweenGuardAndFrequency(_currentUpperRadioMode);
+                                            SRSRadioFactory.GetSRSRadio().ToggleBetweenGuardAndFrequency(_currentUpperRadioMode);
                                         }
                                     }
 
@@ -326,7 +326,7 @@
                                         var timeSpan = new TimeSpan(DateTime.Now.Ticks - _lowerFreqSwitchPressed);
                                         if (timeSpan.Seconds <= 2)
                                         {
-                                            SRSListenerFactory.GetSRSListener().ToggleBetweenGuardAndFrequency(_currentLowerRadioMode);
+                                            SRSRadioFactory.GetSRSRadio().ToggleBetweenGuardAndFrequency(_currentLowerRadioMode);
                                         }
                                     }
 
@@ -375,9 +375,9 @@
                                     _largeDialIncreaseChangeMonitor.Click();
                                     if (!SkipLargeDialDialChange())
                                     {
-                                        if (SRSListenerFactory.GetSRSListener().GetRadioMode(_currentUpperRadioMode) == SRSRadioMode.Channel)
+                                        if (SRSRadioFactory.GetSRSRadio().GetRadioMode(_currentUpperRadioMode) == SRSRadioMode.Channel)
                                         {
-                                            SRSListenerFactory.GetSRSListener().ChangeChannel(_currentUpperRadioMode, true);
+                                            SRSRadioFactory.GetSRSRadio().ChangeChannel(_currentUpperRadioMode, true);
                                         }
                                         else
                                         {
@@ -387,7 +387,7 @@
                                                 changeValue = 5.0;
                                             }
 
-                                            SRSListenerFactory.GetSRSListener().ChangeFrequency(_currentUpperRadioMode, changeValue);
+                                            SRSRadioFactory.GetSRSRadio().ChangeFrequency(_currentUpperRadioMode, changeValue);
                                         }
                                     }
 
@@ -399,9 +399,9 @@
                                     _largeDialDecreaseChangeMonitor.Click();
                                     if (!SkipLargeDialDialChange())
                                     {
-                                        if (SRSListenerFactory.GetSRSListener().GetRadioMode(_currentUpperRadioMode) == SRSRadioMode.Channel)
+                                        if (SRSRadioFactory.GetSRSRadio().GetRadioMode(_currentUpperRadioMode) == SRSRadioMode.Channel)
                                         {
-                                            SRSListenerFactory.GetSRSListener().ChangeChannel(_currentUpperRadioMode, false);
+                                            SRSRadioFactory.GetSRSRadio().ChangeChannel(_currentUpperRadioMode, false);
                                         }
                                         else
                                         {
@@ -411,7 +411,7 @@
                                                 changeValue = -5.0;
                                             }
 
-                                            SRSListenerFactory.GetSRSListener().ChangeFrequency(_currentUpperRadioMode, changeValue);
+                                            SRSRadioFactory.GetSRSRadio().ChangeFrequency(_currentUpperRadioMode, changeValue);
                                         }
                                     }
 
@@ -424,9 +424,9 @@
                                     _secondSmallDialIncreaseChangeMonitor.Click();
                                     if (!SkipSmallDialDialChange())
                                     {
-                                        if (SRSListenerFactory.GetSRSListener().GetRadioMode(_currentUpperRadioMode) == SRSRadioMode.Channel)
+                                        if (SRSRadioFactory.GetSRSRadio().GetRadioMode(_currentUpperRadioMode) == SRSRadioMode.Channel)
                                         {
-                                            SRSListenerFactory.GetSRSListener().ChangeChannel(_currentUpperRadioMode, true);
+                                            SRSRadioFactory.GetSRSRadio().ChangeChannel(_currentUpperRadioMode, true);
                                         }
                                         else
                                         {
@@ -441,7 +441,7 @@
                                                 changeValue *= 100;
                                             }
 
-                                            SRSListenerFactory.GetSRSListener().ChangeFrequency(_currentUpperRadioMode, changeValue);
+                                            SRSRadioFactory.GetSRSRadio().ChangeFrequency(_currentUpperRadioMode, changeValue);
                                         }
                                     }
 
@@ -454,9 +454,9 @@
                                     _secondSmallDialDecreaseChangeMonitor.Click();
                                     if (!SkipSmallDialDialChange())
                                     {
-                                        if (SRSListenerFactory.GetSRSListener().GetRadioMode(_currentUpperRadioMode) == SRSRadioMode.Channel)
+                                        if (SRSRadioFactory.GetSRSRadio().GetRadioMode(_currentUpperRadioMode) == SRSRadioMode.Channel)
                                         {
-                                            SRSListenerFactory.GetSRSListener().ChangeChannel(_currentUpperRadioMode, false);
+                                            SRSRadioFactory.GetSRSRadio().ChangeChannel(_currentUpperRadioMode, false);
                                         }
                                         else
                                         {
@@ -471,7 +471,7 @@
                                                 changeValue *= 100;
                                             }
 
-                                            SRSListenerFactory.GetSRSListener().ChangeFrequency(_currentUpperRadioMode, changeValue);
+                                            SRSRadioFactory.GetSRSRadio().ChangeFrequency(_currentUpperRadioMode, changeValue);
                                         }
                                     }
 
@@ -483,9 +483,9 @@
                                     _largeDialIncreaseChangeMonitor.Click();
                                     if (!SkipLargeDialDialChange())
                                     {
-                                        if (SRSListenerFactory.GetSRSListener().GetRadioMode(_currentLowerRadioMode) == SRSRadioMode.Channel)
+                                        if (SRSRadioFactory.GetSRSRadio().GetRadioMode(_currentLowerRadioMode) == SRSRadioMode.Channel)
                                         {
-                                            SRSListenerFactory.GetSRSListener().ChangeChannel(_currentLowerRadioMode, true);
+                                            SRSRadioFactory.GetSRSRadio().ChangeChannel(_currentLowerRadioMode, true);
                                         }
                                         else
                                         {
@@ -495,7 +495,7 @@
                                                 changeValue = 10.0;
                                             }
 
-                                            SRSListenerFactory.GetSRSListener().ChangeFrequency(_currentLowerRadioMode, changeValue);
+                                            SRSRadioFactory.GetSRSRadio().ChangeFrequency(_currentLowerRadioMode, changeValue);
                                         }
                                     }
 
@@ -507,9 +507,9 @@
                                     _largeDialDecreaseChangeMonitor.Click();
                                     if (!SkipLargeDialDialChange())
                                     {
-                                        if (SRSListenerFactory.GetSRSListener().GetRadioMode(_currentLowerRadioMode) == SRSRadioMode.Channel)
+                                        if (SRSRadioFactory.GetSRSRadio().GetRadioMode(_currentLowerRadioMode) == SRSRadioMode.Channel)
                                         {
-                                            SRSListenerFactory.GetSRSListener().ChangeChannel(_currentLowerRadioMode, false);
+                                            SRSRadioFactory.GetSRSRadio().ChangeChannel(_currentLowerRadioMode, false);
                                         }
                                         else
                                         {
@@ -519,7 +519,7 @@
                                                 changeValue = -10.0;
                                             }
 
-                                            SRSListenerFactory.GetSRSListener().ChangeFrequency(_currentLowerRadioMode, changeValue);
+                                            SRSRadioFactory.GetSRSRadio().ChangeFrequency(_currentLowerRadioMode, changeValue);
                                         }
                                     }
 
@@ -532,9 +532,9 @@
                                     _secondSmallDialIncreaseChangeMonitor.Click();
                                     if (!SkipSmallDialDialChange())
                                     {
-                                        if (SRSListenerFactory.GetSRSListener().GetRadioMode(_currentLowerRadioMode) == SRSRadioMode.Channel)
+                                        if (SRSRadioFactory.GetSRSRadio().GetRadioMode(_currentLowerRadioMode) == SRSRadioMode.Channel)
                                         {
-                                            SRSListenerFactory.GetSRSListener().ChangeChannel(_currentLowerRadioMode, true);
+                                            SRSRadioFactory.GetSRSRadio().ChangeChannel(_currentLowerRadioMode, true);
                                         }
                                         else
                                         {
@@ -549,7 +549,7 @@
                                                 changeValue *= 100;
                                             }
 
-                                            SRSListenerFactory.GetSRSListener().ChangeFrequency(_currentLowerRadioMode, changeValue);
+                                            SRSRadioFactory.GetSRSRadio().ChangeFrequency(_currentLowerRadioMode, changeValue);
                                         }
                                     }
 
@@ -562,9 +562,9 @@
                                     _secondSmallDialDecreaseChangeMonitor.Click();
                                     if (!SkipSmallDialDialChange())
                                     {
-                                        if (SRSListenerFactory.GetSRSListener().GetRadioMode(_currentLowerRadioMode) == SRSRadioMode.Channel)
+                                        if (SRSRadioFactory.GetSRSRadio().GetRadioMode(_currentLowerRadioMode) == SRSRadioMode.Channel)
                                         {
-                                            SRSListenerFactory.GetSRSListener().ChangeChannel(_currentLowerRadioMode, false);
+                                            SRSRadioFactory.GetSRSRadio().ChangeChannel(_currentLowerRadioMode, false);
                                         }
                                         else
                                         {
@@ -579,7 +579,7 @@
                                                 changeValue *= 100;
                                             }
 
-                                            SRSListenerFactory.GetSRSListener().ChangeFrequency(_currentLowerRadioMode, changeValue);
+                                            SRSRadioFactory.GetSRSRadio().ChangeFrequency(_currentLowerRadioMode, changeValue);
                                         }
                                     }
 
@@ -612,7 +612,7 @@
                     {
                         if (_upperMainFreq > 0)
                         {
-                            if (SRSListenerFactory.GetSRSListener().GetRadioMode(_currentUpperRadioMode) == SRSRadioMode.Channel)
+                            if (SRSRadioFactory.GetSRSRadio().GetRadioMode(_currentUpperRadioMode) == SRSRadioMode.Channel)
                             {
                                 SetPZ69DisplayBytesUnsignedInteger(ref bytes, (uint)Math.Floor(_upperMainFreq), PZ69LCDPosition.UPPER_STBY_RIGHT);
                             }
@@ -637,7 +637,7 @@
 
                         if (_lowerMainFreq > 0)
                         {
-                            if (SRSListenerFactory.GetSRSListener().GetRadioMode(_currentLowerRadioMode) == SRSRadioMode.Channel)
+                            if (SRSRadioFactory.GetSRSRadio().GetRadioMode(_currentLowerRadioMode) == SRSRadioMode.Channel)
                             {
                                 SetPZ69DisplayBytesUnsignedInteger(ref bytes, (uint)Math.Floor(_lowerMainFreq), PZ69LCDPosition.LOWER_STBY_RIGHT);
                             }

--- a/Source/NonVisuals/Radios/RadioPanelPZ69SRS.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69SRS.cs
@@ -336,7 +336,7 @@
 
                         if (PluginManager.PlugSupportActivated && PluginManager.HasPlugin())
                         {
-                            PluginManager.DoEvent(DCSFPProfile.SelectedProfile.Description,
+                            PluginManager.DoEvent(DCSAircraft.SelectedAircraft.Description,
                                 HIDInstance,
                                 PluginGamingPanelEnum.PZ69RadioPanel,
                                 (int)radioPanelKnob.RadioPanelPZ69Knob,

--- a/Source/NonVisuals/Radios/RadioPanelPZ69SRS.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69SRS.cs
@@ -1,0 +1,819 @@
+﻿namespace NonVisuals.Radios
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Threading;
+
+    using ClassLibraryCommon;
+
+    using DCS_BIOS;
+    using DCS_BIOS.EventArgs;
+
+    using MEF;
+    using NonVisuals.Plugin;
+    using NonVisuals.Radios.Knobs;
+    using NonVisuals.Radios.SRS;
+    using NLog;
+    using NonVisuals.Panels.Saitek;
+    using NonVisuals.HID;
+    using NonVisuals.BindingClasses.BIP;
+    using NonVisuals.Panels.Saitek.Switches;
+    using System.Windows.Input;
+
+    public struct SRSRadioSmallFreqStepping
+    {
+        public const double One = 0.001;
+        public const double Five = 0.005;
+        public const double Ten = 0.010;
+        public const double Fifty = 0.050;
+    }
+
+    public class RadioPanelPZ69SRS : RadioPanelPZ69Base, ISRSDataListener
+    {
+        private CurrentSRSRadioMode _currentUpperRadioMode = CurrentSRSRadioMode.COM1;
+        private CurrentSRSRadioMode _currentLowerRadioMode = CurrentSRSRadioMode.COM1;
+
+        // private List<double> _listMainFrequencies = new List<double>(7) { 0, 0, 0, 0, 0, 0, 0 };
+        // private List<double> _listGuardFrequencies = new List<double>(7) { 0, 0, 0, 0, 0, 0, 0 };
+        private readonly object _freqListLockObject = new object();
+
+        /*Radio1 COM1*/
+        /*Radio2 COM2*/
+        /*Radio3 NAV1*/
+        /*Radio4 NAV2*/
+        /*Radio5 ADF*/
+        /*Radio6 DME*/
+        /*Radio7 XPDR*/
+        // Large dial
+        // Small dial
+        private double _upperMainFreq;
+        private double _lowerMainFreq;
+        private double _upperGuardFreq;
+        private double _lowerGuardFreq;
+        private long _upperFreqSwitchPressed;
+        private long _lowerFreqSwitchPressed;
+        private int _largeDialSkipper;
+        private int _smallDialSkipper;
+        private readonly ClickSpeedDetector _largeDialIncreaseChangeMonitor = new ClickSpeedDetector(20);
+        private readonly ClickSpeedDetector _largeDialDecreaseChangeMonitor = new ClickSpeedDetector(20);
+        private readonly ClickSpeedDetector _firstSmallDialIncreaseChangeMonitor = new ClickSpeedDetector(30);
+        private readonly ClickSpeedDetector _firstSmallDialDecreaseChangeMonitor = new ClickSpeedDetector(30);
+        private readonly ClickSpeedDetector _secondSmallDialIncreaseChangeMonitor = new ClickSpeedDetector(36);
+        private readonly ClickSpeedDetector _secondSmallDialDecreaseChangeMonitor = new ClickSpeedDetector(36);
+
+        private readonly object _lockShowFrequenciesOnPanelObject = new object();
+        private long _doUpdatePanelLCD;
+        private double _smallFreqStepping = 0.001;
+
+        public RadioPanelPZ69SRS(int portFrom, string ipAddressTo, int portTo, HIDSkeleton hidSkeleton) : base(hidSkeleton)
+        {
+            SRSListenerFactory.SetParams(portFrom, ipAddressTo, portTo);
+            SRSListenerFactory.GetSRSListener().Attach(this);
+            CreateRadioKnobs();
+            Startup();
+        }
+
+        private bool _disposed;
+        // Protected implementation of Dispose pattern.
+        protected override void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    SRSListenerFactory.GetSRSListener().Detach(this);
+                    SRSListenerFactory.Shutdown();
+                }
+
+                _disposed = true;
+            }
+
+            // Call base class implementation.
+            base.Dispose(disposing);
+        }
+
+        public sealed override void Startup()
+        {
+            try
+            {
+                StartListeningForHidPanelChanges();
+            }
+            catch (Exception ex)
+            {
+                SetLastException(ex);
+            }
+        }
+        
+        public double SmallFreqStepping
+        {
+            get => _smallFreqStepping;
+            set => _smallFreqStepping = value;
+        }
+
+        public void SRSDataReceived(object sender)
+        {
+            try
+            {
+                _upperMainFreq = SRSListenerFactory.GetSRSListener().GetFrequencyOrChannel(_currentUpperRadioMode);
+                _upperGuardFreq = SRSListenerFactory.GetSRSListener().GetFrequencyOrChannel(_currentUpperRadioMode, true);
+                _lowerMainFreq = SRSListenerFactory.GetSRSListener().GetFrequencyOrChannel(_currentLowerRadioMode);
+                _lowerGuardFreq = SRSListenerFactory.GetSRSListener().GetFrequencyOrChannel(_currentLowerRadioMode, true);
+                Interlocked.Increment(ref _doUpdatePanelLCD);
+                ShowFrequenciesOnPanel();
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex);
+            }
+        }
+
+        private void PZ69KnobChanged(bool isFirstReport, IEnumerable<object> hashSet)
+        {
+            if (isFirstReport)
+            {
+                return;
+            }
+
+            try
+            {
+                lock (LockLCDUpdateObject)
+                {
+                    foreach (var radioPanelKnobObject in hashSet)
+                    {
+                        var radioPanelKnob = (RadioPanelKnobSRS)radioPanelKnobObject;
+
+                        switch (radioPanelKnob.RadioPanelPZ69Knob)
+                        {
+                            case RadioPanelPZ69KnobsSRS.UPPER_COM1:
+                                {
+                                    if (radioPanelKnob.IsOn)
+                                    {
+                                        SetUpperRadioMode(CurrentSRSRadioMode.COM1);
+                                    }
+
+                                    break;
+                                }
+
+                            case RadioPanelPZ69KnobsSRS.UPPER_COM2:
+                                {
+                                    if (radioPanelKnob.IsOn)
+                                    {
+                                        SetUpperRadioMode(CurrentSRSRadioMode.COM2);
+                                    }
+
+                                    break;
+                                }
+
+                            case RadioPanelPZ69KnobsSRS.UPPER_NAV1:
+                                {
+                                    if (radioPanelKnob.IsOn)
+                                    {
+                                        SetUpperRadioMode(CurrentSRSRadioMode.NAV1);
+                                    }
+
+                                    break;
+                                }
+
+                            case RadioPanelPZ69KnobsSRS.UPPER_NAV2:
+                                {
+                                    if (radioPanelKnob.IsOn)
+                                    {
+                                        SetUpperRadioMode(CurrentSRSRadioMode.NAV2);
+                                    }
+
+                                    break;
+                                }
+
+                            case RadioPanelPZ69KnobsSRS.UPPER_ADF:
+                                {
+                                    if (radioPanelKnob.IsOn)
+                                    {
+                                        SetUpperRadioMode(CurrentSRSRadioMode.ADF);
+                                    }
+
+                                    break;
+                                }
+
+                            case RadioPanelPZ69KnobsSRS.UPPER_DME:
+                                {
+                                    if (radioPanelKnob.IsOn)
+                                    {
+                                        SetUpperRadioMode(CurrentSRSRadioMode.DME);
+                                    }
+
+                                    break;
+                                }
+
+                            case RadioPanelPZ69KnobsSRS.UPPER_XPDR:
+                                {
+                                    if (radioPanelKnob.IsOn)
+                                    {
+                                        SetUpperRadioMode(CurrentSRSRadioMode.XPDR);
+                                    }
+
+                                    break;
+                                }
+
+                            case RadioPanelPZ69KnobsSRS.LOWER_COM1:
+                                {
+                                    if (radioPanelKnob.IsOn)
+                                    {
+                                        SetLowerRadioMode(CurrentSRSRadioMode.COM1);
+                                    }
+
+                                    break;
+                                }
+
+                            case RadioPanelPZ69KnobsSRS.LOWER_COM2:
+                                {
+                                    if (radioPanelKnob.IsOn)
+                                    {
+                                        SetLowerRadioMode(CurrentSRSRadioMode.COM2);
+                                    }
+
+                                    break;
+                                }
+
+                            case RadioPanelPZ69KnobsSRS.LOWER_NAV1:
+                                {
+                                    if (radioPanelKnob.IsOn)
+                                    {
+                                        SetLowerRadioMode(CurrentSRSRadioMode.NAV1);
+                                    }
+
+                                    break;
+                                }
+
+                            case RadioPanelPZ69KnobsSRS.LOWER_NAV2:
+                                {
+                                    if (radioPanelKnob.IsOn)
+                                    {
+                                        SetLowerRadioMode(CurrentSRSRadioMode.NAV2);
+                                    }
+
+                                    break;
+                                }
+
+                            case RadioPanelPZ69KnobsSRS.LOWER_ADF:
+                                {
+                                    if (radioPanelKnob.IsOn)
+                                    {
+                                        SetLowerRadioMode(CurrentSRSRadioMode.ADF);
+                                    }
+
+                                    break;
+                                }
+
+                            case RadioPanelPZ69KnobsSRS.LOWER_DME:
+                                {
+                                    if (radioPanelKnob.IsOn)
+                                    {
+                                        SetLowerRadioMode(CurrentSRSRadioMode.DME);
+                                    }
+
+                                    break;
+                                }
+
+                            case RadioPanelPZ69KnobsSRS.LOWER_XPDR:
+                                {
+                                    if (radioPanelKnob.IsOn)
+                                    {
+                                        SetLowerRadioMode(CurrentSRSRadioMode.XPDR);
+                                    }
+
+                                    break;
+                                }
+
+                            case RadioPanelPZ69KnobsSRS.UPPER_LARGE_FREQ_WHEEL_INC:
+                            case RadioPanelPZ69KnobsSRS.UPPER_LARGE_FREQ_WHEEL_DEC:
+                            case RadioPanelPZ69KnobsSRS.UPPER_SMALL_FREQ_WHEEL_INC:
+                            case RadioPanelPZ69KnobsSRS.UPPER_SMALL_FREQ_WHEEL_DEC:
+                            case RadioPanelPZ69KnobsSRS.LOWER_LARGE_FREQ_WHEEL_INC:
+                            case RadioPanelPZ69KnobsSRS.LOWER_LARGE_FREQ_WHEEL_DEC:
+                            case RadioPanelPZ69KnobsSRS.LOWER_SMALL_FREQ_WHEEL_INC:
+                            case RadioPanelPZ69KnobsSRS.LOWER_SMALL_FREQ_WHEEL_DEC:
+                                {
+                                    // Ignore
+                                    break;
+                                }
+
+                            case RadioPanelPZ69KnobsSRS.UPPER_FREQ_SWITCH:
+                                {
+                                    if (radioPanelKnob.IsOn)
+                                    {
+                                        _upperFreqSwitchPressed = DateTime.Now.Ticks;
+                                    }
+
+                                    if (!radioPanelKnob.IsOn)
+                                    {
+                                        var timeSpan = new TimeSpan(DateTime.Now.Ticks - _upperFreqSwitchPressed);
+                                        if (timeSpan.Seconds <= 2)
+                                        {
+                                            SRSListenerFactory.GetSRSListener().ToggleBetweenGuardAndFrequency(_currentUpperRadioMode);
+                                        }
+                                    }
+
+                                    break;
+                                }
+
+                            case RadioPanelPZ69KnobsSRS.LOWER_FREQ_SWITCH:
+                                {
+                                    if (radioPanelKnob.IsOn)
+                                    {
+                                        _lowerFreqSwitchPressed = DateTime.Now.Ticks;
+                                    }
+
+                                    if (!radioPanelKnob.IsOn)
+                                    {
+                                        var timeSpan = new TimeSpan(DateTime.Now.Ticks - _lowerFreqSwitchPressed);
+                                        if (timeSpan.Seconds <= 2)
+                                        {
+                                            SRSListenerFactory.GetSRSListener().ToggleBetweenGuardAndFrequency(_currentLowerRadioMode);
+                                        }
+                                    }
+
+                                    break;
+                                }
+                        }
+
+                        if (PluginManager.PlugSupportActivated && PluginManager.HasPlugin())
+                        {
+                            PluginManager.DoEvent(DCSFPProfile.SelectedProfile.Description,
+                                HIDInstance,
+                                PluginGamingPanelEnum.PZ69RadioPanel,
+                                (int)radioPanelKnob.RadioPanelPZ69Knob,
+                                radioPanelKnob.IsOn,
+                                null);
+                        }
+                    }
+
+                    AdjustFrequency(hashSet);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex);
+            }
+        }
+
+        private void AdjustFrequency(IEnumerable<object> hashSet)
+        {
+            try
+            {
+                if (SkipCurrentFrequencyChange())
+                {
+                    return;
+                }
+
+                foreach (var o in hashSet)
+                {
+                    var radioPanelKnobSRS = (RadioPanelKnobSRS)o;
+                    if (radioPanelKnobSRS.IsOn)
+                    {
+                        switch (radioPanelKnobSRS.RadioPanelPZ69Knob)
+                        {
+                            case RadioPanelPZ69KnobsSRS.UPPER_LARGE_FREQ_WHEEL_INC:
+                                {
+                                    _largeDialIncreaseChangeMonitor.Click();
+                                    if (!SkipLargeDialDialChange())
+                                    {
+                                        if (SRSListenerFactory.GetSRSListener().GetRadioMode(_currentUpperRadioMode) == SRSRadioMode.Channel)
+                                        {
+                                            SRSListenerFactory.GetSRSListener().ChangeChannel(_currentUpperRadioMode, true);
+                                        }
+                                        else
+                                        {
+                                            var changeValue = 1.0;
+                                            if (_largeDialIncreaseChangeMonitor.ClickThresholdReached())
+                                            {
+                                                changeValue = 5.0;
+                                            }
+
+                                            SRSListenerFactory.GetSRSListener().ChangeFrequency(_currentUpperRadioMode, changeValue);
+                                        }
+                                    }
+
+                                    break;
+                                }
+
+                            case RadioPanelPZ69KnobsSRS.UPPER_LARGE_FREQ_WHEEL_DEC:
+                                {
+                                    _largeDialDecreaseChangeMonitor.Click();
+                                    if (!SkipLargeDialDialChange())
+                                    {
+                                        if (SRSListenerFactory.GetSRSListener().GetRadioMode(_currentUpperRadioMode) == SRSRadioMode.Channel)
+                                        {
+                                            SRSListenerFactory.GetSRSListener().ChangeChannel(_currentUpperRadioMode, false);
+                                        }
+                                        else
+                                        {
+                                            var changeValue = -1.0;
+                                            if (_largeDialDecreaseChangeMonitor.ClickThresholdReached())
+                                            {
+                                                changeValue = -5.0;
+                                            }
+
+                                            SRSListenerFactory.GetSRSListener().ChangeFrequency(_currentUpperRadioMode, changeValue);
+                                        }
+                                    }
+
+                                    break;
+                                }
+
+                            case RadioPanelPZ69KnobsSRS.UPPER_SMALL_FREQ_WHEEL_INC:
+                                {
+                                    _firstSmallDialIncreaseChangeMonitor.Click();
+                                    _secondSmallDialIncreaseChangeMonitor.Click();
+                                    if (!SkipSmallDialDialChange())
+                                    {
+                                        if (SRSListenerFactory.GetSRSListener().GetRadioMode(_currentUpperRadioMode) == SRSRadioMode.Channel)
+                                        {
+                                            SRSListenerFactory.GetSRSListener().ChangeChannel(_currentUpperRadioMode, true);
+                                        }
+                                        else
+                                        {
+                                            var changeValue = _smallFreqStepping;
+                                            if (_firstSmallDialIncreaseChangeMonitor.ClickThresholdReached())
+                                            {
+                                                changeValue *= 10;
+                                            }
+
+                                            if (_secondSmallDialIncreaseChangeMonitor.ClickThresholdReached())
+                                            {
+                                                changeValue *= 100;
+                                            }
+
+                                            SRSListenerFactory.GetSRSListener().ChangeFrequency(_currentUpperRadioMode, changeValue);
+                                        }
+                                    }
+
+                                    break;
+                                }
+
+                            case RadioPanelPZ69KnobsSRS.UPPER_SMALL_FREQ_WHEEL_DEC:
+                                {
+                                    _firstSmallDialDecreaseChangeMonitor.Click();
+                                    _secondSmallDialDecreaseChangeMonitor.Click();
+                                    if (!SkipSmallDialDialChange())
+                                    {
+                                        if (SRSListenerFactory.GetSRSListener().GetRadioMode(_currentUpperRadioMode) == SRSRadioMode.Channel)
+                                        {
+                                            SRSListenerFactory.GetSRSListener().ChangeChannel(_currentUpperRadioMode, false);
+                                        }
+                                        else
+                                        {
+                                            var changeValue = _smallFreqStepping * -1;
+                                            if (_firstSmallDialDecreaseChangeMonitor.ClickThresholdReached())
+                                            {
+                                                changeValue *= 10;
+                                            }
+
+                                            if (_secondSmallDialDecreaseChangeMonitor.ClickThresholdReached())
+                                            {
+                                                changeValue *= 100;
+                                            }
+
+                                            SRSListenerFactory.GetSRSListener().ChangeFrequency(_currentUpperRadioMode, changeValue);
+                                        }
+                                    }
+
+                                    break;
+                                }
+
+                            case RadioPanelPZ69KnobsSRS.LOWER_LARGE_FREQ_WHEEL_INC:
+                                {
+                                    _largeDialIncreaseChangeMonitor.Click();
+                                    if (!SkipLargeDialDialChange())
+                                    {
+                                        if (SRSListenerFactory.GetSRSListener().GetRadioMode(_currentLowerRadioMode) == SRSRadioMode.Channel)
+                                        {
+                                            SRSListenerFactory.GetSRSListener().ChangeChannel(_currentLowerRadioMode, true);
+                                        }
+                                        else
+                                        {
+                                            var changeValue = 1.0;
+                                            if (_largeDialIncreaseChangeMonitor.ClickThresholdReached())
+                                            {
+                                                changeValue = 10.0;
+                                            }
+
+                                            SRSListenerFactory.GetSRSListener().ChangeFrequency(_currentUpperRadioMode, changeValue);
+                                        }
+                                    }
+
+                                    break;
+                                }
+
+                            case RadioPanelPZ69KnobsSRS.LOWER_LARGE_FREQ_WHEEL_DEC:
+                                {
+                                    _largeDialDecreaseChangeMonitor.Click();
+                                    if (!SkipLargeDialDialChange())
+                                    {
+                                        if (SRSListenerFactory.GetSRSListener().GetRadioMode(_currentLowerRadioMode) == SRSRadioMode.Channel)
+                                        {
+                                            SRSListenerFactory.GetSRSListener().ChangeChannel(_currentLowerRadioMode, false);
+                                        }
+                                        else
+                                        {
+                                            var changeValue = -1.0;
+                                            if (_largeDialDecreaseChangeMonitor.ClickThresholdReached())
+                                            {
+                                                changeValue = -10.0;
+                                            }
+
+                                            SRSListenerFactory.GetSRSListener().ChangeFrequency(_currentUpperRadioMode, changeValue);
+                                        }
+                                    }
+
+                                    break;
+                                }
+
+                            case RadioPanelPZ69KnobsSRS.LOWER_SMALL_FREQ_WHEEL_INC:
+                                {
+                                    _firstSmallDialIncreaseChangeMonitor.Click();
+                                    _secondSmallDialIncreaseChangeMonitor.Click();
+                                    if (!SkipSmallDialDialChange())
+                                    {
+                                        if (SRSListenerFactory.GetSRSListener().GetRadioMode(_currentLowerRadioMode) == SRSRadioMode.Channel)
+                                        {
+                                            SRSListenerFactory.GetSRSListener().ChangeChannel(_currentLowerRadioMode, true);
+                                        }
+                                        else
+                                        {
+                                            var changeValue = _smallFreqStepping;
+                                            if (_firstSmallDialIncreaseChangeMonitor.ClickThresholdReached())
+                                            {
+                                                changeValue *= 10;
+                                            }
+
+                                            if (_secondSmallDialIncreaseChangeMonitor.ClickThresholdReached())
+                                            {
+                                                changeValue *= 100;
+                                            }
+
+                                            SRSListenerFactory.GetSRSListener().ChangeFrequency(_currentUpperRadioMode, changeValue);
+                                        }
+                                    }
+
+                                    break;
+                                }
+
+                            case RadioPanelPZ69KnobsSRS.LOWER_SMALL_FREQ_WHEEL_DEC:
+                                {
+                                    _firstSmallDialDecreaseChangeMonitor.Click();
+                                    _secondSmallDialDecreaseChangeMonitor.Click();
+                                    if (!SkipSmallDialDialChange())
+                                    {
+                                        if (SRSListenerFactory.GetSRSListener().GetRadioMode(_currentLowerRadioMode) == SRSRadioMode.Channel)
+                                        {
+                                            SRSListenerFactory.GetSRSListener().ChangeChannel(_currentLowerRadioMode, false);
+                                        }
+                                        else
+                                        {
+                                            var changeValue = _smallFreqStepping * -1;
+                                            if (_firstSmallDialDecreaseChangeMonitor.ClickThresholdReached())
+                                            {
+                                                changeValue *= 10;
+                                            }
+
+                                            if (_secondSmallDialDecreaseChangeMonitor.ClickThresholdReached())
+                                            {
+                                                changeValue *= 100;
+                                            }
+
+                                            SRSListenerFactory.GetSRSListener().ChangeFrequency(_currentUpperRadioMode, changeValue);
+                                        }
+                                    }
+
+                                    break;
+                                }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex);
+            }
+        }
+
+        
+        private void ShowFrequenciesOnPanel()
+        {
+            try
+            {
+                lock (_lockShowFrequenciesOnPanelObject)
+                {
+                    if (Interlocked.Read(ref _doUpdatePanelLCD) == 0)
+                    {
+                        return;
+                    }
+
+                    var bytes = new byte[21];
+                    bytes[0] = 0x0;
+                    lock (_freqListLockObject)
+                    {
+                        if (_upperMainFreq > 0)
+                        {
+                            if (SRSListenerFactory.GetSRSListener().GetRadioMode(_currentUpperRadioMode) == SRSRadioMode.Channel)
+                            {
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, (uint)Math.Floor(_upperMainFreq), PZ69LCDPosition.UPPER_STBY_RIGHT);
+                            }
+                            else
+                            {
+                                SetPZ69DisplayBytesDefault(ref bytes, (_upperMainFreq / 1000000).ToString("0.000", CultureInfo.InvariantCulture), PZ69LCDPosition.UPPER_STBY_RIGHT);
+                            }
+                        }
+                        else
+                        {
+                            SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.UPPER_STBY_RIGHT);
+                        }
+
+                        if (_upperGuardFreq > 0)
+                        {
+                            SetPZ69DisplayBytesDefault(ref bytes, (_upperGuardFreq / 1000000).ToString("0.000", CultureInfo.InvariantCulture), PZ69LCDPosition.UPPER_ACTIVE_LEFT);
+                        }
+                        else
+                        {
+                            SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.UPPER_ACTIVE_LEFT);
+                        }
+
+                        if (_lowerMainFreq > 0)
+                        {
+                            if (SRSListenerFactory.GetSRSListener().GetRadioMode(_currentLowerRadioMode) == SRSRadioMode.Channel)
+                            {
+                                SetPZ69DisplayBytesUnsignedInteger(ref bytes, (uint)Math.Floor(_lowerMainFreq), PZ69LCDPosition.LOWER_STBY_RIGHT);
+                            }
+                            else
+                            {
+                                SetPZ69DisplayBytesDefault(ref bytes, (_lowerMainFreq / 1000000).ToString("0.000", CultureInfo.InvariantCulture), PZ69LCDPosition.LOWER_STBY_RIGHT);
+                            }
+                        }
+                        else
+                        {
+                            SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.LOWER_STBY_RIGHT);
+                        }
+
+                        if (_lowerGuardFreq > 0)
+                        {
+                            SetPZ69DisplayBytesDefault(ref bytes, (_lowerGuardFreq / 1000000).ToString("0.000", CultureInfo.InvariantCulture), PZ69LCDPosition.LOWER_ACTIVE_LEFT);
+                        }
+                        else
+                        {
+                            SetPZ69DisplayBlank(ref bytes, PZ69LCDPosition.LOWER_ACTIVE_LEFT);
+                        }
+
+                        SendLCDData(bytes);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex);
+            }
+
+            Interlocked.Decrement(ref _doUpdatePanelLCD);
+        }
+
+
+        protected override void GamingPanelKnobChanged(bool isFirstReport, IEnumerable<object> hashSet)
+        {
+            PZ69KnobChanged(isFirstReport, hashSet);
+        }
+
+        public override void ClearSettings(bool setIsDirty = false) { }
+
+        public override DcsOutputAndColorBinding CreateDcsOutputAndColorBinding(SaitekPanelLEDPosition saitekPanelLEDPosition, PanelLEDColor panelLEDColor, DCSBIOSOutput dcsBiosOutput)
+        {
+            var dcsOutputAndColorBinding = new DcsOutputAndColorBindingPZ55
+            {
+                DCSBiosOutputLED = dcsBiosOutput,
+                LEDColor = panelLEDColor,
+                SaitekLEDPosition = saitekPanelLEDPosition
+            };
+            return dcsOutputAndColorBinding;
+        }
+
+        private void CreateRadioKnobs()
+        {
+            SaitekPanelKnobs = RadioPanelKnobSRS.GetRadioPanelKnobs();
+        }
+
+        private void SetUpperRadioMode(CurrentSRSRadioMode currentBf109RadioMode)
+        {
+            try
+            {
+                _currentUpperRadioMode = currentBf109RadioMode;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex);
+            }
+        }
+
+        private void SetLowerRadioMode(CurrentSRSRadioMode currentBf109RadioMode)
+        {
+            try
+            {
+                _currentLowerRadioMode = currentBf109RadioMode;
+
+                // If NOUSE then send next round of data to the panel in order to clear the LCD.
+                // _sendNextRoundToPanel = true;catch (Exception ex)
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex);
+            }
+        }
+
+        private bool SkipSmallDialDialChange()
+        {
+            try
+            {
+                if (_smallDialSkipper > 2)
+                {
+                    _smallDialSkipper = 0;
+                    return false;
+                }
+
+                _smallDialSkipper++;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex);
+            }
+
+            return false;
+        }
+
+        private bool SkipLargeDialDialChange()
+        {
+            try
+            {
+                if (_largeDialSkipper > 2)
+                {
+                    _largeDialSkipper = 0;
+                    return false;
+                }
+
+                _largeDialSkipper++;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex);
+            }
+
+            return false;
+        }
+
+
+        public void DCSBIOSStringReceived(object sender, DCSBIOSStringDataEventArgs e)
+        {
+            try
+            {
+            }
+            catch (Exception ex)
+            {
+                Common.ShowErrorMessageBox( ex, "DCSBIOSStringReceived()");
+            }
+        }
+
+        public override void DcsBiosDataReceived(object sender, DCSBIOSDataEventArgs e)
+        {
+            try
+            {
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex);
+            }
+        }
+
+        public override void RemoveSwitchFromList(object controlList, PanelSwitchOnOff panelSwitchOnOff)
+        {
+        }
+
+        public override void AddOrUpdateKeyStrokeBinding(PanelSwitchOnOff panelSwitchOnOff, string keyPress, KeyPressLength keyPressLength)
+        {
+        }
+
+        public override void AddOrUpdateSequencedKeyBinding(PanelSwitchOnOff panelSwitchOnOff, string description, SortedList<int, IKeyPressInfo> keySequence)
+        {
+        }
+
+        public override void AddOrUpdateDCSBIOSBinding(PanelSwitchOnOff panelSwitchOnOff, List<DCSBIOSInput> dcsbiosInputs, string description, bool isSequenced)
+        {
+        }
+
+        public override void AddOrUpdateBIPLinkBinding(PanelSwitchOnOff panelSwitchOnOff, BIPLinkBase bipLink)
+        {
+        }
+
+        public override void AddOrUpdateOSCommandBinding(PanelSwitchOnOff panelSwitchOnOff, OSCommand operatingSystemCommand)
+        {
+        }
+    }
+}

--- a/Source/NonVisuals/Radios/RadioPanelPZ69SRS.cs
+++ b/Source/NonVisuals/Radios/RadioPanelPZ69SRS.cs
@@ -33,7 +33,7 @@
 
         // private List<double> _listMainFrequencies = new List<double>(7) { 0, 0, 0, 0, 0, 0, 0 };
         // private List<double> _listGuardFrequencies = new List<double>(7) { 0, 0, 0, 0, 0, 0, 0 };
-        private readonly object _freqListLockObject = new object();
+        private readonly object _freqListLockObject = new();
 
         /*Radio1 COM1*/
         /*Radio2 COM2*/
@@ -52,14 +52,14 @@
         private long _lowerFreqSwitchPressed;
         private int _largeDialSkipper;
         private int _smallDialSkipper;
-        private readonly ClickSpeedDetector _largeDialIncreaseChangeMonitor = new ClickSpeedDetector(20);
-        private readonly ClickSpeedDetector _largeDialDecreaseChangeMonitor = new ClickSpeedDetector(20);
-        private readonly ClickSpeedDetector _firstSmallDialIncreaseChangeMonitor = new ClickSpeedDetector(30);
-        private readonly ClickSpeedDetector _firstSmallDialDecreaseChangeMonitor = new ClickSpeedDetector(30);
-        private readonly ClickSpeedDetector _secondSmallDialIncreaseChangeMonitor = new ClickSpeedDetector(36);
-        private readonly ClickSpeedDetector _secondSmallDialDecreaseChangeMonitor = new ClickSpeedDetector(36);
+        private readonly ClickSpeedDetector _largeDialIncreaseChangeMonitor = new(20);
+        private readonly ClickSpeedDetector _largeDialDecreaseChangeMonitor = new(20);
+        private readonly ClickSpeedDetector _firstSmallDialIncreaseChangeMonitor = new(25);
+        private readonly ClickSpeedDetector _firstSmallDialDecreaseChangeMonitor = new(25);
+        private readonly ClickSpeedDetector _secondSmallDialIncreaseChangeMonitor = new(36);
+        private readonly ClickSpeedDetector _secondSmallDialDecreaseChangeMonitor = new (36);
 
-        private readonly object _lockShowFrequenciesOnPanelObject = new object();
+        private readonly object _lockShowFrequenciesOnPanelObject = new();
         private long _doUpdatePanelLCD;
         private double _smallFreqStepping = 0.001;
 
@@ -381,12 +381,7 @@
                                         }
                                         else
                                         {
-                                            var changeValue = 1.0;
-                                            if (_largeDialIncreaseChangeMonitor.ClickThresholdReached())
-                                            {
-                                                changeValue = 5.0;
-                                            }
-
+                                            var changeValue = _largeDialIncreaseChangeMonitor.ClickThresholdReached() ? 10.0 : 1.0;
                                             SRSRadioFactory.GetSRSRadio().ChangeFrequency(_currentUpperRadioMode, changeValue);
                                         }
                                     }
@@ -405,12 +400,7 @@
                                         }
                                         else
                                         {
-                                            var changeValue = -1.0;
-                                            if (_largeDialDecreaseChangeMonitor.ClickThresholdReached())
-                                            {
-                                                changeValue = -5.0;
-                                            }
-
+                                            var changeValue = _largeDialDecreaseChangeMonitor.ClickThresholdReached() ? -10.0 : -1.0;
                                             SRSRadioFactory.GetSRSRadio().ChangeFrequency(_currentUpperRadioMode, changeValue);
                                         }
                                     }
@@ -438,7 +428,7 @@
 
                                             if (_secondSmallDialIncreaseChangeMonitor.ClickThresholdReached())
                                             {
-                                                changeValue *= 100;
+                                                changeValue *= 30;
                                             }
 
                                             SRSRadioFactory.GetSRSRadio().ChangeFrequency(_currentUpperRadioMode, changeValue);
@@ -468,7 +458,7 @@
 
                                             if (_secondSmallDialDecreaseChangeMonitor.ClickThresholdReached())
                                             {
-                                                changeValue *= 100;
+                                                changeValue *= 30;
                                             }
 
                                             SRSRadioFactory.GetSRSRadio().ChangeFrequency(_currentUpperRadioMode, changeValue);
@@ -489,12 +479,7 @@
                                         }
                                         else
                                         {
-                                            var changeValue = 1.0;
-                                            if (_largeDialIncreaseChangeMonitor.ClickThresholdReached())
-                                            {
-                                                changeValue = 10.0;
-                                            }
-
+                                            var changeValue = _largeDialIncreaseChangeMonitor.ClickThresholdReached() ? 10.0 : 1.0;
                                             SRSRadioFactory.GetSRSRadio().ChangeFrequency(_currentLowerRadioMode, changeValue);
                                         }
                                     }
@@ -513,12 +498,7 @@
                                         }
                                         else
                                         {
-                                            var changeValue = -1.0;
-                                            if (_largeDialDecreaseChangeMonitor.ClickThresholdReached())
-                                            {
-                                                changeValue = -10.0;
-                                            }
-
+                                            var changeValue = _largeDialDecreaseChangeMonitor.ClickThresholdReached() ? -10.0 : -1.0;
                                             SRSRadioFactory.GetSRSRadio().ChangeFrequency(_currentLowerRadioMode, changeValue);
                                         }
                                     }
@@ -546,7 +526,7 @@
 
                                             if (_secondSmallDialIncreaseChangeMonitor.ClickThresholdReached())
                                             {
-                                                changeValue *= 100;
+                                                changeValue *= 30;
                                             }
 
                                             SRSRadioFactory.GetSRSRadio().ChangeFrequency(_currentLowerRadioMode, changeValue);
@@ -576,7 +556,7 @@
 
                                             if (_secondSmallDialDecreaseChangeMonitor.ClickThresholdReached())
                                             {
-                                                changeValue *= 100;
+                                                changeValue *= 30;
                                             }
 
                                             SRSRadioFactory.GetSRSRadio().ChangeFrequency(_currentLowerRadioMode, changeValue);
@@ -766,50 +746,20 @@
         }
 
 
-        public void DCSBIOSStringReceived(object sender, DCSBIOSStringDataEventArgs e)
-        {
-            try
-            {
-            }
-            catch (Exception ex)
-            {
-                Common.ShowErrorMessageBox( ex, "DCSBIOSStringReceived()");
-            }
-        }
+        public void DCSBIOSStringReceived(object sender, DCSBIOSStringDataEventArgs e) { }
 
-        public override void DcsBiosDataReceived(object sender, DCSBIOSDataEventArgs e)
-        {
-            try
-            {
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex);
-            }
-        }
+        public override void DcsBiosDataReceived(object sender, DCSBIOSDataEventArgs e) { }
 
-        public override void RemoveSwitchFromList(object controlList, PanelSwitchOnOff panelSwitchOnOff)
-        {
-        }
+        public override void RemoveSwitchFromList(object controlList, PanelSwitchOnOff panelSwitchOnOff) { }
 
-        public override void AddOrUpdateKeyStrokeBinding(PanelSwitchOnOff panelSwitchOnOff, string keyPress, KeyPressLength keyPressLength)
-        {
-        }
+        public override void AddOrUpdateKeyStrokeBinding(PanelSwitchOnOff panelSwitchOnOff, string keyPress, KeyPressLength keyPressLength) { }
 
-        public override void AddOrUpdateSequencedKeyBinding(PanelSwitchOnOff panelSwitchOnOff, string description, SortedList<int, IKeyPressInfo> keySequence)
-        {
-        }
+        public override void AddOrUpdateSequencedKeyBinding(PanelSwitchOnOff panelSwitchOnOff, string description, SortedList<int, IKeyPressInfo> keySequence) { }
 
-        public override void AddOrUpdateDCSBIOSBinding(PanelSwitchOnOff panelSwitchOnOff, List<DCSBIOSInput> dcsbiosInputs, string description, bool isSequenced)
-        {
-        }
+        public override void AddOrUpdateDCSBIOSBinding(PanelSwitchOnOff panelSwitchOnOff, List<DCSBIOSInput> dcsbiosInputs, string description, bool isSequenced) { }
 
-        public override void AddOrUpdateBIPLinkBinding(PanelSwitchOnOff panelSwitchOnOff, BIPLinkBase bipLink)
-        {
-        }
+        public override void AddOrUpdateBIPLinkBinding(PanelSwitchOnOff panelSwitchOnOff, BIPLinkBase bipLink) { }
 
-        public override void AddOrUpdateOSCommandBinding(PanelSwitchOnOff panelSwitchOnOff, OSCommand operatingSystemCommand)
-        {
-        }
+        public override void AddOrUpdateOSCommandBinding(PanelSwitchOnOff panelSwitchOnOff, OSCommand operatingSystemCommand) { }
     }
 }

--- a/Source/NonVisuals/Radios/SRS/SRSAircraftCapabilities.cs
+++ b/Source/NonVisuals/Radios/SRS/SRSAircraftCapabilities.cs
@@ -1,0 +1,15 @@
+﻿namespace NonVisuals.Radios.SRS
+{
+    public struct SRSAircraftCapabilities
+    {
+        public bool dcsPtt;
+
+        public bool dcsIFF;
+
+        public bool dcsRadioSwitch;
+
+        public bool intercomHotMic;
+
+        public string desc;
+    }
+}

--- a/Source/NonVisuals/Radios/SRS/SRSCombinedRadioState.cs
+++ b/Source/NonVisuals/Radios/SRS/SRSCombinedRadioState.cs
@@ -1,0 +1,15 @@
+﻿namespace NonVisuals.Radios.SRS
+{
+    internal class SRSCombinedRadioState
+    {
+        public SRSPlayerRadioInfo RadioInfo;
+
+        public SRSRadioSendingState RadioSendingState;
+
+        public SRSRadioReceivingState[] RadioReceivingState;
+
+        public int ClientCountConnected;
+
+        public int[] TunedClients;
+    }
+}

--- a/Source/NonVisuals/Radios/SRS/SRSLatLngPosition.cs
+++ b/Source/NonVisuals/Radios/SRS/SRSLatLngPosition.cs
@@ -1,0 +1,19 @@
+﻿namespace NonVisuals.Radios.SRS
+{
+    public class SRSLatLngPosition
+    {
+        public double lat;
+        public double lng;
+        public double alt;
+
+        public bool isValid()
+        {
+            return lat != 0 && lng != 0;
+        }
+
+        public override string ToString()
+        {
+            return $"Pos:[{lat},{lng},{alt}]";
+        }
+    }
+}

--- a/Source/NonVisuals/Radios/SRS/SRSListenerFactory.cs
+++ b/Source/NonVisuals/Radios/SRS/SRSListenerFactory.cs
@@ -1,0 +1,42 @@
+﻿namespace NonVisuals.Radios.SRS
+{
+    public static class SRSListenerFactory
+    {
+        private static SRSRadio _srsListener;
+        private static string _srsSendToIPUdp = "127.0.0.1";
+        private static int _srsReceivePortUdp = 7082;
+        private static int _srsSendPortUdp = 9040;
+
+        public static void SetParams(int portFrom, string ipAddressTo, int portTo)
+        {
+            _srsSendToIPUdp = ipAddressTo;
+            _srsReceivePortUdp = portFrom;
+            _srsSendPortUdp = portTo;
+        }
+
+        public static void Shutdown()
+        {
+            _srsListener?.Shutdown();
+            _srsListener = null;
+        }
+
+        public static void ReStart()
+        {
+            Shutdown();
+            if (_srsListener == null)
+            {
+                _srsListener = new SRSRadio(_srsReceivePortUdp, _srsSendToIPUdp, _srsSendPortUdp);
+            }
+        }
+
+        public static SRSRadio GetSRSListener()
+        {
+            if (_srsListener == null)
+            {
+                _srsListener = new SRSRadio(_srsReceivePortUdp, _srsSendToIPUdp, _srsSendPortUdp);
+            }
+
+            return _srsListener;
+        }
+    }
+}

--- a/Source/NonVisuals/Radios/SRS/SRSPlayerRadioInfo.cs
+++ b/Source/NonVisuals/Radios/SRS/SRSPlayerRadioInfo.cs
@@ -1,0 +1,156 @@
+﻿
+
+// ReSharper disable All
+/*
+ * Do not change SRS code
+ */
+namespace NonVisuals.Radios.SRS
+{
+    using System;
+
+    using Newtonsoft.Json;
+
+    public class SRSRadioReceivingState
+    {
+        [JsonIgnore]
+        public double LastReceviedAt { get; set; }
+
+        public bool IsSecondary { get; set; }
+        public int ReceivedOn { get; set; }
+
+        public bool PlayedEndOfTransmission { get; set; }
+
+        public bool IsReceiving => (Environment.TickCount - LastReceviedAt) < 500;
+    }
+
+    public class SRSRadioSendingState
+    {
+        [JsonIgnore]
+        public double LastSentAt { get; set; }
+
+        public bool IsSending { get; set; }
+
+        public int SendingOn { get; set; }
+
+        public int IsEncrypted { get; set; }
+    }
+
+    public struct SRSCombinedRadioState
+    {
+        public SRSPlayerRadioInfo RadioInfo;
+
+        public SRSRadioSendingState RadioSendingState;
+
+        public SRSRadioReceivingState[] RadioReceivingState;
+    }
+
+    public struct SRSDcsPosition
+    {
+        public double x;
+        public double y;
+        public double z;
+
+        public override string ToString()
+        {
+            return $"Pos:[{x},{y},{z}]";
+        }
+    }
+
+    public class SRSPlayerRadioInfo
+    {
+
+        // HOTAS or IN COCKPIT controls
+        public enum RadioSwitchControls
+        {
+            HOTAS = 0,
+            IN_COCKPIT = 1
+        }
+
+        public string name = string.Empty;
+        public SRSDcsPosition pos = new SRSDcsPosition();
+        public volatile bool ptt = false;
+
+        public SRSRadioInformation[] radios = new SRSRadioInformation[11]; // 10 + intercom
+        public RadioSwitchControls control = RadioSwitchControls.HOTAS;
+        public short selected = 0;
+        public string unit = string.Empty;
+        public uint unitId;
+
+        public static readonly uint UnitIdOffset = 100000001; // this is where non aircraft "Unit" Ids start from for satcom intercom
+
+        public SRSPlayerRadioInfo()
+        {
+            for (var i = 0; i < 11; i++)
+            {
+                radios[i] = new SRSRadioInformation();
+            }
+        }
+
+        [JsonIgnore]
+        public long LastUpdate { get; set; }
+
+        // override object.Equals
+        public override bool Equals(object compare)
+        {
+            if ((compare == null) || (GetType() != compare.GetType()))
+            {
+                return false;
+            }
+
+            var compareRadio = compare as SRSPlayerRadioInfo;
+
+            if (control != compareRadio.control)
+            {
+                return false;
+            }
+
+            // if (side != compareRadio.side)
+            // {
+            // return false;
+            // }
+            if (!name.Equals(compareRadio.name))
+            {
+                return false;
+            }
+
+            if (!unit.Equals(compareRadio.unit))
+            {
+                return false;
+            }
+
+            if (unitId != compareRadio.unitId)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < radios.Length; i++)
+            {
+                var radio1 = radios[i];
+                var radio2 = compareRadio.radios[i];
+
+                if ((radio1 != null) && (radio2 != null))
+                {
+                    if (!radio1.Equals(radio2))
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        /*
+         * Was Radio updated in the last 10 Seconds
+         */
+        public bool IsCurrent()
+        {
+            return LastUpdate > Environment.TickCount - 10000;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(name, pos, radios, control, unit, unitId);
+        }
+    }
+}

--- a/Source/NonVisuals/Radios/SRS/SRSPlayerRadioInfo.cs
+++ b/Source/NonVisuals/Radios/SRS/SRSPlayerRadioInfo.cs
@@ -1,82 +1,77 @@
-﻿
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
 
-// ReSharper disable All
-/*
- * Do not change SRS code
- */
 namespace NonVisuals.Radios.SRS
 {
-    using System;
-
-    using Newtonsoft.Json;
-
-    public class SRSRadioReceivingState
-    {
-        [JsonIgnore]
-        public double LastReceviedAt { get; set; }
-
-        public bool IsSecondary { get; set; }
-        public int ReceivedOn { get; set; }
-
-        public bool PlayedEndOfTransmission { get; set; }
-
-        public bool IsReceiving => (Environment.TickCount - LastReceviedAt) < 500;
-    }
-
-    public class SRSRadioSendingState
-    {
-        [JsonIgnore]
-        public double LastSentAt { get; set; }
-
-        public bool IsSending { get; set; }
-
-        public int SendingOn { get; set; }
-
-        public int IsEncrypted { get; set; }
-    }
-
-    public struct SRSCombinedRadioState
-    {
-        public SRSPlayerRadioInfo RadioInfo;
-
-        public SRSRadioSendingState RadioSendingState;
-
-        public SRSRadioReceivingState[] RadioReceivingState;
-    }
-
-    public struct SRSDcsPosition
-    {
-        public double x;
-        public double y;
-        public double z;
-
-        public override string ToString()
-        {
-            return $"Pos:[{x},{y},{z}]";
-        }
-    }
-
     public class SRSPlayerRadioInfo
     {
-
-        // HOTAS or IN COCKPIT controls
+        //HOTAS or IN COCKPIT controls
         public enum RadioSwitchControls
         {
             HOTAS = 0,
             IN_COCKPIT = 1
         }
 
-        public string name = string.Empty;
-        public SRSDcsPosition pos = new SRSDcsPosition();
+        
+        
+        public string name = "";
+
+        
+        
+        public SRSLatLngPosition latLng = new SRSLatLngPosition();
+
+        
+        
+        public bool inAircraft = false;
+
+        
+        
         public volatile bool ptt = false;
 
-        public SRSRadioInformation[] radios = new SRSRadioInformation[11]; // 10 + intercom
+        public SRSRadioInformation[] radios = new SRSRadioInformation[11]; //10 + intercom
+
+        
+        
         public RadioSwitchControls control = RadioSwitchControls.HOTAS;
+
+        
         public short selected = 0;
-        public string unit = string.Empty;
+
+        public string unit = "";
+
         public uint unitId;
 
-        public static readonly uint UnitIdOffset = 100000001; // this is where non aircraft "Unit" Ids start from for satcom intercom
+        
+        
+        public int seat = 0;
+
+        
+        
+        public bool intercomHotMic = false; //if true switch to intercom and transmit
+
+        public SRSTransponder iff = new SRSTransponder();
+
+        [JsonIgnore]
+        public readonly static uint UnitIdOffset = 100000000
+            ; // this is where non aircraft "Unit" Ids start from for satcom intercom
+
+        
+        
+        public bool simultaneousTransmission = false; // Global toggle enabling simultaneous transmission on multiple radios, activated via the AWACS panel
+
+        
+        public SimultaneousTransmissionControl simultaneousTransmissionControl =
+            SimultaneousTransmissionControl.EXTERNAL_DCS_CONTROL;
+
+        
+        public SRSAircraftCapabilities capabilities = new SRSAircraftCapabilities();
+
+        public enum SimultaneousTransmissionControl
+        {
+            ENABLED_INTERNAL_SRS_CONTROLS = 1,
+            EXTERNAL_DCS_CONTROL = 0,
+        }
 
         public SRSPlayerRadioInfo()
         {
@@ -89,68 +84,245 @@ namespace NonVisuals.Radios.SRS
         [JsonIgnore]
         public long LastUpdate { get; set; }
 
+        public void Reset()
+        {
+            name = "";
+            latLng = new SRSLatLngPosition();
+            ptt = false;
+            selected = 0;
+            unit = "";
+            simultaneousTransmission = false;
+            simultaneousTransmissionControl = SimultaneousTransmissionControl.EXTERNAL_DCS_CONTROL;
+            LastUpdate = 0;
+            seat = 0;
+
+            for (var i = 0; i < 11; i++)
+            {
+                radios[i] = new SRSRadioInformation();
+            }
+
+        }
+
         // override object.Equals
         public override bool Equals(object compare)
         {
-            if ((compare == null) || (GetType() != compare.GetType()))
+            try
             {
-                return false;
-            }
-
-            var compareRadio = compare as SRSPlayerRadioInfo;
-
-            if (control != compareRadio.control)
-            {
-                return false;
-            }
-
-            // if (side != compareRadio.side)
-            // {
-            // return false;
-            // }
-            if (!name.Equals(compareRadio.name))
-            {
-                return false;
-            }
-
-            if (!unit.Equals(compareRadio.unit))
-            {
-                return false;
-            }
-
-            if (unitId != compareRadio.unitId)
-            {
-                return false;
-            }
-
-            for (var i = 0; i < radios.Length; i++)
-            {
-                var radio1 = radios[i];
-                var radio2 = compareRadio.radios[i];
-
-                if ((radio1 != null) && (radio2 != null))
+                if ((compare == null) || (GetType() != compare.GetType()))
                 {
-                    if (!radio1.Equals(radio2))
+                    return false;
+                }
+
+                var compareRadio = compare as SRSPlayerRadioInfo;
+
+                if (control != compareRadio.control)
+                {
+                    return false;
+                }
+                //if (side != compareRadio.side)
+                //{
+                //    return false;
+                //}
+                if (!name.Equals(compareRadio.name))
+                {
+                    return false;
+                }
+                if (!unit.Equals(compareRadio.unit))
+                {
+                    return false;
+                }
+
+                if (unitId != compareRadio.unitId)
+                {
+                    return false;
+                }
+
+                if (inAircraft != compareRadio.inAircraft)
+                {
+                    return false;
+                }
+
+                if (((iff == null) || (compareRadio.iff == null)))
+                {
+                    return false;
+                }
+                else
+                {
+                    //check iff
+                    if (!iff.Equals(compareRadio.iff))
                     {
                         return false;
                     }
                 }
+
+                for (var i = 0; i < radios.Length; i++)
+                {
+                    var radio1 = radios[i];
+                    var radio2 = compareRadio.radios[i];
+
+                    if ((radio1 != null) && (radio2 != null))
+                    {
+                        if (!radio1.Equals(radio2))
+                        {
+                            return false;
+                        }
+                    }
+                }
             }
+            catch
+            {
+                return false;
+            }
+
 
             return true;
         }
 
+
         /*
          * Was Radio updated in the last 10 Seconds
          */
+
         public bool IsCurrent()
         {
-            return LastUpdate > Environment.TickCount - 10000;
+            return LastUpdate > DateTime.Now.Ticks - 100000000;
         }
 
-        public override int GetHashCode()
+        //comparing doubles is risky - check that we're close enough to hear (within 100hz)
+        public static bool FreqCloseEnough(double freq1, double freq2)
         {
-            return HashCode.Combine(name, pos, radios, control, unit, unitId);
+            var diff = Math.Abs(freq1 - freq2);
+
+            return diff < 500;
+        }
+
+        public SRSRadioInformation CanHearTransmission(double frequency,
+            SRSRadioInformation.Modulation modulation,
+            byte encryptionKey,
+            bool strictEncryption,
+            uint sendingUnitId,
+            List<int> blockedRadios,
+            out SRSRadioReceivingState receivingState,
+            out bool decryptable)
+        {
+            //    if (!IsCurrent())
+            //     {
+            //         receivingState = null;
+            //        decryptable = false;
+            //       return null;
+            //   }
+
+            SRSRadioInformation bestMatchingRadio = null;
+            SRSRadioReceivingState bestMatchingRadioState = null;
+            bool bestMatchingDecryptable = false;
+
+            for (var i = 0; i < radios.Length; i++)
+            {
+                var receivingRadio = radios[i];
+
+                if (receivingRadio != null)
+                {
+                    //handle INTERCOM Modulation is 2
+                    if ((receivingRadio.modulation == SRSRadioInformation.Modulation.INTERCOM) &&
+                        (modulation == SRSRadioInformation.Modulation.INTERCOM))
+                    {
+                        if ((unitId > 0) && (sendingUnitId > 0)
+                            && (unitId == sendingUnitId))
+                        {
+                            receivingState = new SRSRadioReceivingState
+                            {
+                                IsSecondary = false,
+                                LastReceviedAt = DateTime.Now.Ticks,
+                                ReceivedOn = i
+                            };
+                            decryptable = true;
+                            return receivingRadio;
+                        }
+                        decryptable = false;
+                        receivingState = null;
+                        return null;
+                    }
+
+                    if (modulation == SRSRadioInformation.Modulation.DISABLED
+                        || receivingRadio.modulation == SRSRadioInformation.Modulation.DISABLED)
+                    {
+                        continue;
+                    }
+
+                    //within 1khz
+                    if ((FreqCloseEnough(receivingRadio.freq, frequency))
+                        && (receivingRadio.modulation == modulation)
+                        && (receivingRadio.freq > 10000))
+                    {
+                        bool isDecryptable = (receivingRadio.enc ? receivingRadio.encKey : (byte)0) == encryptionKey || (!strictEncryption && encryptionKey == 0);
+
+                        if (isDecryptable && !blockedRadios.Contains(i))
+                        {
+                            receivingState = new SRSRadioReceivingState
+                            {
+                                IsSecondary = false,
+                                LastReceviedAt = DateTime.Now.Ticks,
+                                ReceivedOn = i
+                            };
+                            decryptable = true;
+                            return receivingRadio;
+                        }
+
+                        bestMatchingRadio = receivingRadio;
+                        bestMatchingRadioState = new SRSRadioReceivingState
+                        {
+                            IsSecondary = false,
+                            LastReceviedAt = DateTime.Now.Ticks,
+                            ReceivedOn = i
+                        };
+                        bestMatchingDecryptable = isDecryptable;
+                    }
+                    if ((receivingRadio.secFreq == frequency)
+                        && (receivingRadio.secFreq > 10000))
+                    {
+                        if ((receivingRadio.enc ? receivingRadio.encKey : (byte)0) == encryptionKey || (!strictEncryption && encryptionKey == 0))
+                        {
+                            receivingState = new SRSRadioReceivingState
+                            {
+                                IsSecondary = true,
+                                LastReceviedAt = DateTime.Now.Ticks,
+                                ReceivedOn = i
+                            };
+                            decryptable = true;
+                            return receivingRadio;
+                        }
+
+                        bestMatchingRadio = receivingRadio;
+                        bestMatchingRadioState = new SRSRadioReceivingState
+                        {
+                            IsSecondary = true,
+                            LastReceviedAt = DateTime.Now.Ticks,
+                            ReceivedOn = i
+                        };
+                    }
+                }
+            }
+
+            decryptable = bestMatchingDecryptable;
+            receivingState = bestMatchingRadioState;
+            return bestMatchingRadio;
+        }
+
+        public SRSPlayerRadioInfo DeepClone()
+        {
+            var clone = (SRSPlayerRadioInfo)this.MemberwiseClone();
+
+            clone.iff = this.iff.Copy();
+            //ignore position
+            clone.radios = new SRSRadioInformation[11];
+
+            for (var i = 0; i < 11; i++)
+            {
+                clone.radios[i] = this.radios[i].Copy();
+            }
+
+            return clone;
+
         }
     }
 }

--- a/Source/NonVisuals/Radios/SRS/SRSRadio.cs
+++ b/Source/NonVisuals/Radios/SRS/SRSRadio.cs
@@ -9,6 +9,7 @@
     using System.Threading;
     using System.Timers;
     using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
     using NLog;
     using NonVisuals.Radios.Knobs;
 
@@ -417,20 +418,34 @@
 
         public void ChangeFrequency(CurrentSRSRadioMode currentSRSRadioMode, double value)
         {
-            int radioId = GetRadioIdFromCurrentSrsRadioMode(currentSRSRadioMode);
-
+            //int radioId = GetRadioIdFromCurrentSrsRadioMode(currentSRSRadioMode);
             //var result = "{ \"Command\": 0,\"RadioId\": " + radioId + ",\"Frequency\": " + value.ToString("0.000", CultureInfo.InvariantCulture) + " }\n";
-            var result = $@"{{ ""Command"": 99,""RadioId"": {radioId},""Frequency"": {value.ToString("0.000", CultureInfo.InvariantCulture)},""Volume"": 0,""Enabled"": 0,""Code"": 0  }}\n";
-            SendDataFunction(result);
+            //SendDataFunction(result);
+
+            int radioId = GetRadioIdFromCurrentSrsRadioMode(currentSRSRadioMode);
+            UDPInterfaceCommand udpOrder = new()
+            {
+                Command = UDPInterfaceCommand.UDPCommandType.FREQUENCY_DELTA,
+                RadioId = GetRadioIdFromCurrentSrsRadioMode(currentSRSRadioMode),
+                Frequency = value,
+            };
+            string order = JsonConvert.SerializeObject(udpOrder);
+            SendDataFunction(order);
         }
 
         public void ToggleBetweenGuardAndFrequency(CurrentSRSRadioMode currentSRSRadioMode)
         {
-            var radioId = GetRadioIdFromCurrentSrsRadioMode(currentSRSRadioMode);
-            var result = "{\"Command\": 2,\"RadioId\":" + radioId + "}\n";
+            //var radioId = GetRadioIdFromCurrentSrsRadioMode(currentSRSRadioMode);
+            //var result = "{\"Command\": 2,\"RadioId\":" + radioId + "}\n";
+            // { "Command": 2,"RadioId":2}
 
-            // { "Command": 2,"RadioId":2} 
-            SendDataFunction(result);
+            UDPInterfaceCommand udpOrder = new()
+            {
+                Command = UDPInterfaceCommand.UDPCommandType.TOGGLE_GUARD,
+                RadioId = GetRadioIdFromCurrentSrsRadioMode(currentSRSRadioMode),
+            };
+            string order = JsonConvert.SerializeObject(udpOrder);
+            SendDataFunction(order);
         }
 
         public void ChangeChannel(CurrentSRSRadioMode currentSRSRadioMode, bool increase)
@@ -443,17 +458,23 @@
                 { "Command": 4,"RadioId":1}
                 --channel down(if channels have been configured)
             */
-            string result;
+            UDPInterfaceCommand udpOrder = new()
+            {
+                RadioId = radioId,
+            };
+
             if (increase)
             {
-                result = "{\"Command\": 3,\"RadioId\":" + radioId + "}\n";
+                //result = "{\"Command\": 3,\"RadioId\":" + radioId + "}\n";
+                udpOrder.Command = UDPInterfaceCommand.UDPCommandType.CHANNEL_UP;
             }
             else
             {
-                result = "{\"Command\": 4,\"RadioId\":" + radioId + "}\n";
+                //result = "{\"Command\": 4,\"RadioId\":" + radioId + "}\n";
+                udpOrder.Command = UDPInterfaceCommand.UDPCommandType.CHANNEL_DOWN;
             }
-
-            SendDataFunction(result);
+            string order = JsonConvert.SerializeObject(udpOrder);
+            SendDataFunction(order);
         }
 
         public void Shutdown()

--- a/Source/NonVisuals/Radios/SRS/SRSRadio.cs
+++ b/Source/NonVisuals/Radios/SRS/SRSRadio.cs
@@ -96,13 +96,13 @@
                     }
                     catch (Exception ex)
                     {
-                        logger.Error(ex, "SRSListener.ReceiveDataUdp()");
+                        logger.Error(ex, "SRSRadio.ReceiveDataUdp()");
                     }
                 }
             }
             catch (Exception ex)
             {
-                logger.Error(ex, "SRSListener.ReceiveDataUdp()");
+                logger.Error(ex, "SRSRadio.ReceiveDataUdp()");
             }
         }
 
@@ -168,7 +168,7 @@
             }
             catch (Exception ex)
             {
-                logger.Error(ex, "SRSListener.StartupRP()");
+                logger.Error(ex, "SRSRadio.StartupRP()");
                 if (_udpReceiveClient != null && _udpReceiveClient.Client.Connected)
                 {
                     _udpReceiveClient.Close();
@@ -515,7 +515,7 @@
             }
             catch (Exception ex)
             {
-                logger.Error(ex, "SRSListener.ShutdownRP()");
+                logger.Error(ex, "SRSRadio.ShutdownRP()");
             }
         }
     }

--- a/Source/NonVisuals/Radios/SRS/SRSRadio.cs
+++ b/Source/NonVisuals/Radios/SRS/SRSRadio.cs
@@ -60,8 +60,6 @@
 
             return _srsListener;
         }
-
-        public static bool IsRunning => _srsListener != null && _srsListener.IsRunning;
     }
 
     public class SRSRadio
@@ -78,7 +76,6 @@
         private bool _started;
         private readonly object _sendSRSDataLockObject = new object();
         private readonly object _readSRSDataLockObject = new object();
-        public bool IsRunning;
 
 
         public SRSRadio(int portFrom, string ipAddressTo, int portTo)
@@ -93,7 +90,6 @@
         {
             try
             {
-                IsRunning = true;
                 while (!_shutdownThread)
                 {
                     var ipEndPointReceiverUdp = new IPEndPoint(IPAddress.Any, _srsReceivePortUdp);
@@ -129,8 +125,6 @@
             {
                 logger.Error(ex, "SRSListener.ReceiveDataUdp()");
             }
-
-            IsRunning = false;
         }
 
         public int SendDataFunction(string stringData)

--- a/Source/NonVisuals/Radios/SRS/SRSRadio.cs
+++ b/Source/NonVisuals/Radios/SRS/SRSRadio.cs
@@ -1,0 +1,728 @@
+﻿namespace NonVisuals.Radios.SRS
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Net;
+    using System.Net.Sockets;
+    using System.Text;
+    using System.Threading;
+
+    using MEF;
+
+    using Newtonsoft.Json;
+    using NLog;
+    using NonVisuals.Radios.Knobs;
+
+    public enum SRSRadioMode
+    {
+        Frequency,
+        Channel
+    }
+
+    public interface ISRSDataListener
+    {
+        void SRSDataReceived(object sender);
+    }
+
+    public static class SRSListenerFactory
+    {
+        private static SRSRadio _srsListener;
+        private static string _srsSendToIPUdp = "127.0.0.1";
+        private static int _srsReceivePortUdp = 7082;
+        private static int _srsSendPortUdp = 9040;
+
+        public static void SetParams(int portFrom, string ipAddressTo, int portTo)
+        {
+            _srsSendToIPUdp = ipAddressTo;
+            _srsReceivePortUdp = portFrom;
+            _srsSendPortUdp = portTo;
+        }
+
+        public static void Shutdown()
+        {
+            _srsListener?.Shutdown();
+            _srsListener = null;
+        }
+
+        public static void ReStart()
+        {
+            Shutdown();
+            if (_srsListener == null)
+            {
+                _srsListener = new SRSRadio(_srsReceivePortUdp, _srsSendToIPUdp, _srsSendPortUdp);
+            }
+        }
+
+        public static SRSRadio GetSRSListener()
+        {
+            if (_srsListener == null)
+            {
+                _srsListener = new SRSRadio(_srsReceivePortUdp, _srsSendToIPUdp, _srsSendPortUdp);
+            }
+
+            return _srsListener;
+        }
+
+        public static bool IsRunning => _srsListener != null && _srsListener.IsRunning;
+    }
+
+    public class SRSRadio
+    {
+        internal static Logger logger = LogManager.GetCurrentClassLogger();
+        private UdpClient _udpReceiveClient;
+        private UdpClient _udpSendClient;
+        private Thread _srsListeningThread;
+        private readonly string _srsSendToIPUdp;
+        private readonly int _srsReceivePortUdp;
+        private readonly int _srsSendPortUdp;
+        private SRSPlayerRadioInfo _srsPlayerRadioInfo;
+        private volatile bool _shutdownThread;
+        private bool _started;
+        private readonly object _sendSRSDataLockObject = new object();
+        private readonly object _readSRSDataLockObject = new object();
+        public bool IsRunning;
+
+
+        public SRSRadio(int portFrom, string ipAddressTo, int portTo)
+        {
+            _srsSendToIPUdp = ipAddressTo;
+            _srsReceivePortUdp = portFrom;
+            _srsSendPortUdp = portTo;
+            Startup();
+        }
+
+        private void ReceiveDataUdp()
+        {
+            try
+            {
+                IsRunning = true;
+                while (!_shutdownThread)
+                {
+                    var ipEndPointReceiverUdp = new IPEndPoint(IPAddress.Any, _srsReceivePortUdp);
+                    
+                    var byteData = _udpReceiveClient.Receive(ref ipEndPointReceiverUdp);
+                    try
+                    {
+                        var message = Encoding.UTF8.GetString(byteData, 0, byteData.Length);
+
+                        // Console.WriteLine(HIDSkeletonBase.InstanceId + " Message received on UDP");
+                        var srsCombinedRadioState = JsonConvert.DeserializeObject<SRSCombinedRadioState>(message);
+                        var srsPlayerRadioInfo = srsCombinedRadioState.RadioInfo;
+                        if (srsPlayerRadioInfo != null)
+                        {
+                            lock (_readSRSDataLockObject)
+                            {
+                                _srsPlayerRadioInfo = srsPlayerRadioInfo;
+                            }
+
+                            OnSRSDataReceived?.Invoke(this);
+                        }
+                    }
+                    catch (SocketException)
+                    {
+                        continue;
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.Error(ex, "SRSListener.ReceiveDataUdp()");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.Error(ex, "SRSListener.ReceiveDataUdp()");
+            }
+
+            IsRunning = false;
+        }
+
+        public int SendDataFunction(string stringData)
+        {
+            var result = 0;
+            lock (_sendSRSDataLockObject)
+            {
+                try
+                {
+                    var ipEndPointSenderUdp = new IPEndPoint(IPAddress.Parse(_srsSendToIPUdp), _srsSendPortUdp);
+                    var unicodeBytes = Encoding.Unicode.GetBytes(stringData);
+                    var asciiBytes = new List<byte>(stringData.Length);
+                    asciiBytes.AddRange(Encoding.Convert(Encoding.Unicode, Encoding.ASCII, unicodeBytes));
+                    result = _udpSendClient.Send(asciiBytes.ToArray(), asciiBytes.ToArray().Length, ipEndPointSenderUdp);
+                }
+                catch (Exception ex)
+                {
+                    logger.Error(ex, $"Error sending data to SRS. {ex.Message}{Environment.NewLine}{ex.StackTrace}");
+                }
+            }
+
+            return result;
+        }
+
+        private void Startup()
+        {
+            try
+            {
+                if (_started)
+                {
+                    return;
+                }
+
+                _shutdownThread = true;
+
+                var ipEndPointReceiverUdp = new IPEndPoint(IPAddress.Any, _srsReceivePortUdp);
+                var ipEndPointSenderUdp = new IPEndPoint(IPAddress.Parse(_srsSendToIPUdp), _srsSendPortUdp);
+
+                _udpReceiveClient?.Close();
+                _udpReceiveClient = new UdpClient();
+                _udpReceiveClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+                _udpReceiveClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReceiveTimeout, 200);
+                _udpReceiveClient.ExclusiveAddressUse = false;
+                _udpReceiveClient.Client.Bind(ipEndPointReceiverUdp);
+                
+                lock (_sendSRSDataLockObject)
+                {
+                    _udpSendClient?.Close();
+                    _udpSendClient = new UdpClient();
+                    _udpSendClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+                    _udpSendClient.EnableBroadcast = true;
+                }
+
+                Thread.Sleep(Constants.ThreadShutDownWaitTime);
+                _shutdownThread = false;
+                _srsListeningThread = new Thread(ReceiveDataUdp);
+                _srsListeningThread.Start();
+
+                _started = true;
+            }
+            catch (Exception ex)
+            {
+                logger.Error(ex, "SRSListener.StartupRP()");
+                if (_udpReceiveClient != null && _udpReceiveClient.Client.Connected)
+                {
+                    _udpReceiveClient.Close();
+                    _udpReceiveClient = null;
+                }
+
+                lock (_sendSRSDataLockObject)
+                {
+                    if (_udpSendClient != null && _udpSendClient.Client.Connected)
+                    {
+                        _udpSendClient.Close();
+                        _udpSendClient = null;
+                    }
+                }
+            }
+        }
+
+        private CurrentSRSRadioMode TranslateSRSRadioMode(int radioNumber)
+        {
+            CurrentSRSRadioMode currentSRSRadioMode;
+
+            switch (radioNumber)
+            {
+                case 1:
+                    currentSRSRadioMode = CurrentSRSRadioMode.COM1;
+                    break;
+                case 2:
+                    currentSRSRadioMode = CurrentSRSRadioMode.COM2;
+                    break;
+                case 3:
+                    currentSRSRadioMode = CurrentSRSRadioMode.NAV1;
+                    break;
+                case 4:
+                    currentSRSRadioMode = CurrentSRSRadioMode.NAV2;
+                    break;
+                case 5:
+                    currentSRSRadioMode = CurrentSRSRadioMode.ADF;
+                    break;
+                case 6:
+                    currentSRSRadioMode = CurrentSRSRadioMode.DME;
+                    break;
+                case 7:
+                    currentSRSRadioMode = CurrentSRSRadioMode.XPDR;
+                    break;
+                default:
+                    currentSRSRadioMode = CurrentSRSRadioMode.COM1;
+                    break;
+            }
+
+            return currentSRSRadioMode;
+        }
+
+
+
+
+
+
+        public SRSRadioMode GetRadioMode(int radioNumber)
+        {
+            var currentSRSRadioMode = TranslateSRSRadioMode(radioNumber);
+            return GetRadioMode(currentSRSRadioMode);
+        }
+
+        public SRSRadioMode GetRadioMode(CurrentSRSRadioMode currentSRSRadioMode)
+        {
+            lock (_readSRSDataLockObject)
+            {
+                switch (currentSRSRadioMode)
+                {
+                    case CurrentSRSRadioMode.COM1:
+                        {
+                            if (_srsPlayerRadioInfo.radios[1].channel == -1)
+                            {
+                                return SRSRadioMode.Frequency;
+                            }
+
+                            return SRSRadioMode.Channel;
+                        }
+
+                    case CurrentSRSRadioMode.COM2:
+                        {
+                            if (_srsPlayerRadioInfo.radios[2].channel == -1)
+                            {
+                                return SRSRadioMode.Frequency;
+                            }
+
+                            return SRSRadioMode.Channel;
+                        }
+
+                    case CurrentSRSRadioMode.NAV1:
+                        {
+                            if (_srsPlayerRadioInfo.radios[3].channel == -1)
+                            {
+                                return SRSRadioMode.Frequency;
+                            }
+
+                            return SRSRadioMode.Channel;
+                        }
+
+                    case CurrentSRSRadioMode.NAV2:
+                        {
+                            if (_srsPlayerRadioInfo.radios[4].channel == -1)
+                            {
+                                return SRSRadioMode.Frequency;
+                            }
+
+                            return SRSRadioMode.Channel;
+                        }
+
+                    case CurrentSRSRadioMode.ADF:
+                        {
+                            if (_srsPlayerRadioInfo.radios[5].channel == -1)
+                            {
+                                return SRSRadioMode.Frequency;
+                            }
+
+                            return SRSRadioMode.Channel;
+                        }
+
+                    case CurrentSRSRadioMode.DME:
+                        {
+                            if (_srsPlayerRadioInfo.radios[6].channel == -1)
+                            {
+                                return SRSRadioMode.Frequency;
+                            }
+
+                            return SRSRadioMode.Channel;
+                        }
+
+                    case CurrentSRSRadioMode.XPDR:
+                        {
+                            if (_srsPlayerRadioInfo.radios[7].channel == -1)
+                            {
+                                return SRSRadioMode.Frequency;
+                            }
+
+                            return SRSRadioMode.Channel;
+                        }
+                }
+            }
+
+            return SRSRadioMode.Frequency;
+        }
+
+        public double GetFrequencyOrChannel(int radioNumber, bool guard = false)
+        {
+            var currentSRSRadioMode = TranslateSRSRadioMode(radioNumber);
+            return GetFrequencyOrChannel(currentSRSRadioMode, guard);
+        }
+
+        public double GetFrequencyOrChannel(CurrentSRSRadioMode currentSRSRadioMode, bool guard = false)
+        {
+            lock (_readSRSDataLockObject)
+            {
+                switch (currentSRSRadioMode)
+                {
+                    case CurrentSRSRadioMode.COM1:
+                        {
+                            if (!guard)
+                            {
+                                if (_srsPlayerRadioInfo.radios[1].channel == -1)
+                                {
+                                    return _srsPlayerRadioInfo.radios[1].freq;
+                                }
+
+                                return _srsPlayerRadioInfo.radios[1].channel;
+                            }
+
+                            return _srsPlayerRadioInfo.radios[1].secFreq;
+                        }
+
+                    case CurrentSRSRadioMode.COM2:
+                        {
+                            if (!guard)
+                            {
+                                if (_srsPlayerRadioInfo.radios[2].channel == -1)
+                                {
+                                    return _srsPlayerRadioInfo.radios[2].freq;
+                                }
+
+                                return _srsPlayerRadioInfo.radios[2].channel;
+                            }
+
+                            return _srsPlayerRadioInfo.radios[2].secFreq;
+                        }
+
+                    case CurrentSRSRadioMode.NAV1:
+                        {
+                            if (!guard)
+                            {
+                                if (_srsPlayerRadioInfo.radios[3].channel == -1)
+                                {
+                                    return _srsPlayerRadioInfo.radios[3].freq;
+                                }
+
+                                return _srsPlayerRadioInfo.radios[3].channel;
+                            }
+
+                            return _srsPlayerRadioInfo.radios[3].secFreq;
+                        }
+
+                    case CurrentSRSRadioMode.NAV2:
+                        {
+                            if (!guard)
+                            {
+                                if (_srsPlayerRadioInfo.radios[4].channel == -1)
+                                {
+                                    return _srsPlayerRadioInfo.radios[4].freq;
+                                }
+
+                                return _srsPlayerRadioInfo.radios[4].channel;
+                            }
+
+                            return _srsPlayerRadioInfo.radios[4].secFreq;
+                        }
+
+                    case CurrentSRSRadioMode.ADF:
+                        {
+                            if (!guard)
+                            {
+                                if (_srsPlayerRadioInfo.radios[5].channel == -1)
+                                {
+                                    return _srsPlayerRadioInfo.radios[5].freq;
+                                }
+
+                                return _srsPlayerRadioInfo.radios[5].channel;
+                            }
+
+                            return _srsPlayerRadioInfo.radios[5].secFreq;
+                        }
+
+                    case CurrentSRSRadioMode.DME:
+                        {
+                            if (!guard)
+                            {
+                                if (_srsPlayerRadioInfo.radios[6].channel == -1)
+                                {
+                                    return _srsPlayerRadioInfo.radios[6].freq;
+                                }
+
+                                return _srsPlayerRadioInfo.radios[6].channel;
+                            }
+
+                            return _srsPlayerRadioInfo.radios[6].secFreq;
+                        }
+
+                    case CurrentSRSRadioMode.XPDR:
+                        {
+                            if (!guard)
+                            {
+                                if (_srsPlayerRadioInfo.radios[7].channel == -1)
+                                {
+                                    return _srsPlayerRadioInfo.radios[7].freq;
+                                }
+
+                                return _srsPlayerRadioInfo.radios[7].channel;
+                            }
+
+                            return _srsPlayerRadioInfo.radios[7].secFreq;
+                        }
+                }
+            }
+
+            return -1;
+        }
+
+
+
+
+
+
+        public void ChangeFrequency(int radioNumber, double value)
+        {
+            var currentSRSRadioMode = TranslateSRSRadioMode(radioNumber);
+            ChangeFrequency(currentSRSRadioMode, value);
+        }
+
+        public void ChangeFrequency(CurrentSRSRadioMode currentSRSRadioMode, double value)
+        {
+            int radioId;
+            switch (currentSRSRadioMode)
+            {
+                case CurrentSRSRadioMode.COM1:
+                    {
+                        radioId = 1;
+                        break;
+                    }
+
+                case CurrentSRSRadioMode.COM2:
+                    {
+                        radioId = 2;
+                        break;
+                    }
+
+                case CurrentSRSRadioMode.NAV1:
+                    {
+                        radioId = 3;
+                        break;
+                    }
+
+                case CurrentSRSRadioMode.NAV2:
+                    {
+                        radioId = 4;
+                        break;
+                    }
+
+                case CurrentSRSRadioMode.ADF:
+                    {
+                        radioId = 5;
+                        break;
+                    }
+
+                case CurrentSRSRadioMode.DME:
+                    {
+                        radioId = 6;
+                        break;
+                    }
+
+                case CurrentSRSRadioMode.XPDR:
+                    {
+                        radioId = 7;
+                        break;
+                    }
+
+                default:
+                    {
+                        radioId = 1;
+                        break;
+                    }
+            }
+            var result = "{ \"Command\": 0,\"RadioId\":" + radioId + ",\"Frequency\": " + value.ToString("0.000", CultureInfo.InvariantCulture) + " }\n";
+            SendDataFunction(result);
+        }
+
+
+
+
+
+
+        public void ToggleGuard(int radioNumber)
+        {
+            var currentSRSRadioMode = TranslateSRSRadioMode(radioNumber);
+            ToggleBetweenGuardAndFrequency(currentSRSRadioMode);
+        }
+
+        public void ToggleBetweenGuardAndFrequency(CurrentSRSRadioMode currentSRSRadioMode)
+        {
+            var radioId = 0;
+            switch (currentSRSRadioMode)
+            {
+                case CurrentSRSRadioMode.COM1:
+                    {
+                        radioId = 1;
+                        break;
+                    }
+
+                case CurrentSRSRadioMode.COM2:
+                    {
+                        radioId = 2;
+                        break;
+                    }
+
+                case CurrentSRSRadioMode.NAV1:
+                    {
+                        radioId = 3;
+                        break;
+                    }
+
+                case CurrentSRSRadioMode.NAV2:
+                    {
+                        radioId = 4;
+                        break;
+                    }
+
+                case CurrentSRSRadioMode.ADF:
+                    {
+                        radioId = 5;
+                        break;
+                    }
+
+                case CurrentSRSRadioMode.DME:
+                    {
+                        radioId = 6;
+                        break;
+                    }
+
+                case CurrentSRSRadioMode.XPDR:
+                    {
+                        radioId = 7;
+                        break;
+                    }
+            }
+
+            var result = "{\"Command\": 2,\"RadioId\":" + radioId + "}\n";
+
+            // { "Command": 2,"RadioId":2} 
+            SendDataFunction(result);
+        }
+
+        public void ChangeChannel(int radioNumber, bool increase)
+        {
+            var currentSRSRadioMode = TranslateSRSRadioMode(radioNumber);
+            ChangeChannel(currentSRSRadioMode, increase);
+        }
+
+        public void ChangeChannel(CurrentSRSRadioMode currentSRSRadioMode, bool increase)
+        {
+            var radioId = 0;
+            switch (currentSRSRadioMode)
+            {
+                case CurrentSRSRadioMode.COM1:
+                    {
+                        radioId = 1;
+                        break;
+                    }
+
+                case CurrentSRSRadioMode.COM2:
+                    {
+                        radioId = 2;
+                        break;
+                    }
+
+                case CurrentSRSRadioMode.NAV1:
+                    {
+                        radioId = 3;
+                        break;
+                    }
+
+                case CurrentSRSRadioMode.NAV2:
+                    {
+                        radioId = 4;
+                        break;
+                    }
+
+                case CurrentSRSRadioMode.ADF:
+                    {
+                        radioId = 5;
+                        break;
+                    }
+
+                case CurrentSRSRadioMode.DME:
+                    {
+                        radioId = 6;
+                        break;
+                    }
+
+                case CurrentSRSRadioMode.XPDR:
+                    {
+                        radioId = 7;
+                        break;
+                    }
+            }
+
+            /*{ "Command": 3,"RadioId":1}
+                        --channel up(if channels have been configured)
+            
+                        { "Command": 4,"RadioId":1}
+                        --channel down(if channels have been configured)*/
+            string result;
+            if (increase)
+            {
+                result = "{\"Command\": 3,\"RadioId\":" + radioId + "}\n";
+            }
+            else
+            {
+                result = "{\"Command\": 4,\"RadioId\":" + radioId + "}\n";
+            }
+
+            SendDataFunction(result);
+        }
+
+        public void Shutdown()
+        {
+            try
+            {
+                try
+                {
+                    _shutdownThread = true;
+                }
+                catch (Exception)
+                {
+                    // ignored
+                }
+
+                try
+                {
+                    _udpReceiveClient?.Close();
+                }
+                catch (Exception)
+                {
+                    // ignored
+                }
+
+                try
+                {
+                    lock (_sendSRSDataLockObject)
+                    {
+                        _udpSendClient?.Close();
+                    }
+                }
+                catch (Exception)
+                {
+                    // ignored
+                }
+
+                _started = false;
+            }
+            catch (Exception ex)
+            {
+                logger.Error(ex, "SRSListener.ShutdownRP()");
+            }
+        }
+
+
+        public delegate void SRSDataReceivedEventHandler(object sender);
+        public event SRSDataReceivedEventHandler OnSRSDataReceived;
+
+        public void Attach(ISRSDataListener srsDataListener)
+        {
+            OnSRSDataReceived += srsDataListener.SRSDataReceived;
+        }
+
+        public void Detach(ISRSDataListener srsDataListener)
+        {
+            OnSRSDataReceived -= srsDataListener.SRSDataReceived;
+        }
+    }
+}

--- a/Source/NonVisuals/Radios/SRS/SRSRadio.cs
+++ b/Source/NonVisuals/Radios/SRS/SRSRadio.cs
@@ -7,9 +7,6 @@
     using System.Net.Sockets;
     using System.Text;
     using System.Threading;
-
-    using MEF;
-
     using Newtonsoft.Json;
     using NLog;
     using NonVisuals.Radios.Knobs;
@@ -105,8 +102,7 @@
                     try
                     {
                         var message = Encoding.UTF8.GetString(byteData, 0, byteData.Length);
-
-                        // Console.WriteLine(HIDSkeletonBase.InstanceId + " Message received on UDP");
+                        
                         var srsCombinedRadioState = JsonConvert.DeserializeObject<SRSCombinedRadioState>(message);
                         var srsPlayerRadioInfo = srsCombinedRadioState.RadioInfo;
                         if (srsPlayerRadioInfo != null)

--- a/Source/NonVisuals/Radios/SRS/SRSRadioFactory.cs
+++ b/Source/NonVisuals/Radios/SRS/SRSRadioFactory.cs
@@ -1,8 +1,8 @@
 ﻿namespace NonVisuals.Radios.SRS
 {
-    public static class SRSListenerFactory
+    public static class SRSRadioFactory
     {
-        private static SRSRadio _srsListener;
+        private static SRSRadio _srsRadio;
         private static string _srsSendToIPUdp = "127.0.0.1";
         private static int _srsReceivePortUdp = 7082;
         private static int _srsSendPortUdp = 9040;
@@ -16,27 +16,27 @@
 
         public static void Shutdown()
         {
-            _srsListener?.Shutdown();
-            _srsListener = null;
+            _srsRadio?.Shutdown();
+            _srsRadio = null;
         }
 
         public static void ReStart()
         {
             Shutdown();
-            if (_srsListener == null)
+            if (_srsRadio == null)
             {
-                _srsListener = new SRSRadio(_srsReceivePortUdp, _srsSendToIPUdp, _srsSendPortUdp);
+                _srsRadio = new SRSRadio(_srsReceivePortUdp, _srsSendToIPUdp, _srsSendPortUdp);
             }
         }
 
-        public static SRSRadio GetSRSListener()
+        public static SRSRadio GetSRSRadio()
         {
-            if (_srsListener == null)
+            if (_srsRadio == null)
             {
-                _srsListener = new SRSRadio(_srsReceivePortUdp, _srsSendToIPUdp, _srsSendPortUdp);
+                _srsRadio = new SRSRadio(_srsReceivePortUdp, _srsSendToIPUdp, _srsSendPortUdp);
             }
 
-            return _srsListener;
+            return _srsRadio;
         }
     }
 }

--- a/Source/NonVisuals/Radios/SRS/SRSRadioInformation.cs
+++ b/Source/NonVisuals/Radios/SRS/SRSRadioInformation.cs
@@ -1,0 +1,132 @@
+﻿using System;
+
+namespace NonVisuals.Radios.SRS
+{
+    // ReSharper disable All
+    /*
+     * Do not change SRS code
+     */
+    public class SRSRadioInformation
+    {
+        public enum EncryptionMode
+        {
+            NO_ENCRYPTION = 0,
+
+            ENCRYPTION_JUST_OVERLAY = 1,
+
+            ENCRYPTION_FULL = 2,
+
+            ENCRYPTION_COCKPIT_TOGGLE_OVERLAY_CODE = 3
+
+            // 0  is no controls
+            // 1 is FC3 Gui Toggle + Gui Enc key setting
+            // 2 is InCockpit toggle + Incockpit Enc setting
+            // 3 is Incockpit toggle + Gui Enc Key setting
+        }
+
+        public enum VolumeMode
+        {
+            COCKPIT = 0,
+
+            OVERLAY = 1,
+        }
+
+        public enum FreqMode
+        {
+            COCKPIT = 0,
+
+            OVERLAY = 1,
+        }
+
+        public enum Modulation
+        {
+            AM = 0,
+
+            FM = 1,
+
+            INTERCOM = 2,
+
+            DISABLED = 3
+        }
+
+        public bool enc = false; // encrytion enabled
+
+        public byte encKey = 0;
+
+        public EncryptionMode encMode = EncryptionMode.NO_ENCRYPTION;
+
+        public double freqMax = 1;
+
+        public double freqMin = 1;
+
+        public double freq = 1;
+
+        public Modulation modulation = Modulation.DISABLED;
+
+        public string name = string.Empty;
+
+        public double secFreq = 1;
+
+        public float volume = 1.0f;
+
+        public FreqMode freqMode = FreqMode.COCKPIT;
+
+        public VolumeMode volMode = VolumeMode.COCKPIT;
+
+        public bool expansion = false;
+
+        public int channel = -1;
+
+        /**
+         * Used to determine if we should send an update to the server or not
+         * We only need to do that if something that would stop us Receiving happens which
+         * is frequencies and modulation
+         */
+        public override bool Equals(object obj)
+        {
+            if ((obj == null) || (GetType() != obj.GetType()))
+                return false;
+
+            var compare = (SRSRadioInformation)obj;
+
+            if (!name.Equals(compare.name))
+            {
+                return false;
+            }
+
+            if (freq != compare.freq)
+            {
+                return false;
+            }
+
+            if (modulation != compare.modulation)
+            {
+                return false;
+            }
+
+            if (secFreq != compare.secFreq)
+            {
+                return false;
+            }
+
+            // if (volume != compare.volume)
+            // {
+            // return false;
+            // }
+            // if (freqMin != compare.freqMin)
+            // {
+            // return false;
+            // }
+            // if (freqMax != compare.freqMax)
+            // {
+            // return false;
+            // }
+            return true;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(name, freq, modulation, secFreq);
+        }
+    }
+}

--- a/Source/NonVisuals/Radios/SRS/SRSRadioInformation.cs
+++ b/Source/NonVisuals/Radios/SRS/SRSRadioInformation.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace NonVisuals.Radios.SRS
+﻿namespace NonVisuals.Radios.SRS
 {
     // ReSharper disable All
     /*
@@ -11,11 +9,8 @@ namespace NonVisuals.Radios.SRS
         public enum EncryptionMode
         {
             NO_ENCRYPTION = 0,
-
             ENCRYPTION_JUST_OVERLAY = 1,
-
             ENCRYPTION_FULL = 2,
-
             ENCRYPTION_COCKPIT_TOGGLE_OVERLAY_CODE = 3
 
             // 0  is no controls
@@ -27,61 +22,93 @@ namespace NonVisuals.Radios.SRS
         public enum VolumeMode
         {
             COCKPIT = 0,
-
             OVERLAY = 1,
         }
 
         public enum FreqMode
         {
             COCKPIT = 0,
-
             OVERLAY = 1,
+        }
+
+        public enum RetransmitMode
+        {
+            COCKPIT = 0,
+            OVERLAY = 1,
+            DISABLED = 2,
         }
 
         public enum Modulation
         {
             AM = 0,
-
             FM = 1,
-
             INTERCOM = 2,
-
-            DISABLED = 3
+            DISABLED = 3,
+            HAVEQUICK = 4,
+            SATCOM = 5,
+            MIDS = 6,
         }
 
-        public bool enc = false; // encrytion enabled
-
+        public bool enc = false; // encryption enabled
         public byte encKey = 0;
 
+        
         public EncryptionMode encMode = EncryptionMode.NO_ENCRYPTION;
 
+        
+        
         public double freqMax = 1;
 
+        
+        
         public double freqMin = 1;
 
         public double freq = 1;
 
         public Modulation modulation = Modulation.DISABLED;
 
-        public string name = string.Empty;
+        
+        public string name = "";
 
         public double secFreq = 1;
 
+        
+        
+        public RetransmitMode rtMode = RetransmitMode.DISABLED;
+
+        //should the radio restransmit?
+        public bool retransmit = false;
+
+        
         public float volume = 1.0f;
 
+        
+        
         public FreqMode freqMode = FreqMode.COCKPIT;
 
-        public VolumeMode volMode = VolumeMode.COCKPIT;
+        
+        
+        public FreqMode guardFreqMode = FreqMode.COCKPIT;
 
+        
+        
+        public VolumeMode volMode = VolumeMode.COCKPIT;
+        
+        
         public bool expansion = false;
 
+        
         public int channel = -1;
+
+        
+        public bool simul = false;
 
         /**
          * Used to determine if we should send an update to the server or not
          * We only need to do that if something that would stop us Receiving happens which
          * is frequencies and modulation
          */
+
         public override bool Equals(object obj)
         {
             if ((obj == null) || (GetType() != obj.GetType()))
@@ -93,40 +120,72 @@ namespace NonVisuals.Radios.SRS
             {
                 return false;
             }
-
-            if (freq != compare.freq)
+            if (!SRSPlayerRadioInfo.FreqCloseEnough(freq, compare.freq))
             {
                 return false;
             }
-
             if (modulation != compare.modulation)
             {
                 return false;
             }
-
-            if (secFreq != compare.secFreq)
+            if (enc != compare.enc)
             {
                 return false;
             }
+            if (encKey != compare.encKey)
+            {
+                return false;
+            }
+            if (retransmit != compare.retransmit)
+            {
+                return false;
+            }
+            if (!SRSPlayerRadioInfo.FreqCloseEnough(secFreq, compare.secFreq))
+            {
+                return false;
+            }
+            //if (volume != compare.volume)
+            //{
+            //    return false;
+            //}
+            //if (freqMin != compare.freqMin)
+            //{
+            //    return false;
+            //}
+            //if (freqMax != compare.freqMax)
+            //{
+            //    return false;
+            //}
 
-            // if (volume != compare.volume)
-            // {
-            // return false;
-            // }
-            // if (freqMin != compare.freqMin)
-            // {
-            // return false;
-            // }
-            // if (freqMax != compare.freqMax)
-            // {
-            // return false;
-            // }
+
             return true;
         }
 
-        public override int GetHashCode()
+        internal SRSRadioInformation Copy()
         {
-            return HashCode.Combine(name, freq, modulation, secFreq);
+            //probably can use memberswise clone
+            return new SRSRadioInformation()
+            {
+                channel = this.channel,
+                enc = this.enc,
+                encKey = this.encKey,
+                encMode = this.encMode,
+                expansion = this.expansion,
+                freq = this.freq,
+                freqMax = this.freqMax,
+                freqMin = this.freqMin,
+                freqMode = this.freqMode,
+                guardFreqMode = this.guardFreqMode,
+                modulation = this.modulation,
+                secFreq = this.secFreq,
+                name = this.name,
+                simul = this.simul,
+                volMode = this.volMode,
+                volume = this.volume,
+                retransmit = this.retransmit,
+                rtMode = this.rtMode
+
+            };
         }
     }
 }

--- a/Source/NonVisuals/Radios/SRS/SRSRadioReceivingState.cs
+++ b/Source/NonVisuals/Radios/SRS/SRSRadioReceivingState.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace NonVisuals.Radios.SRS
+{
+    public class SRSRadioReceivingState
+    {
+        [JsonIgnore]
+        public long LastReceviedAt { get; set; }
+
+        public bool IsSecondary { get; set; }
+        public bool IsSimultaneous { get; set; }
+        public int ReceivedOn { get; set; }
+
+        public string SentBy { get; set; }
+
+        public bool IsReceiving
+        {
+            get
+            {
+                return (DateTime.Now.Ticks - LastReceviedAt) < 3500000;
+            }
+        }
+    }
+}

--- a/Source/NonVisuals/Radios/SRS/SRSRadioSendingState.cs
+++ b/Source/NonVisuals/Radios/SRS/SRSRadioSendingState.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+
+namespace NonVisuals.Radios.SRS
+{
+    public class SRSRadioSendingState
+    {
+        [JsonIgnore]
+        public long LastSentAt { get; set; }
+
+        public bool IsSending { get; set; }
+
+        public int SendingOn { get; set; }
+
+        public int IsEncrypted { get; set; }
+    }
+}

--- a/Source/NonVisuals/Radios/SRS/SRSTransponder.cs
+++ b/Source/NonVisuals/Radios/SRS/SRSTransponder.cs
@@ -1,0 +1,81 @@
+﻿using Newtonsoft.Json;
+
+namespace NonVisuals.Radios.SRS
+{
+    public class SRSTransponder
+    {
+        /**
+         *  -- IFF_STATUS:  OFF = 0,  NORMAL = 1 , or IDENT = 2 (IDENT means Blink on LotATC) 
+            -- M1:-1 = off, any other number on 
+            -- M3: -1 = OFF, any other number on 
+            -- M4: 1 = ON or 0 = OFF
+            -- EXPANSION: only enabled if IFF Expansion is enabled
+            -- CONTROL: 1 - OVERLAY / SRS, 0 - COCKPIT / Realistic, 2 = DISABLED / NOT FITTED AT ALL
+            -- IFF STATUS{"control":1,"expansion":false,"mode1":51,"mode3":7700,"mode4":1,"status":2}
+         */
+
+        public enum IFFControlMode
+        {
+            COCKPIT = 0,
+            OVERLAY = 1,
+            DISABLED = 2
+        }
+
+        public enum IFFStatus
+        {
+            OFF = 0,
+            NORMAL = 1,
+            IDENT = 2
+        }
+
+        public IFFControlMode control = IFFControlMode.DISABLED;
+
+        [JsonIgnore]
+        public bool expansion = false;
+
+        public int mode1 = -1;
+        public int mode3 = -1;
+        public bool mode4 = false;
+
+        public int mic = -1;
+
+        public IFFStatus status = IFFStatus.OFF;
+
+        public override bool Equals(object obj)
+        {
+            if ((obj == null) || (GetType() != obj.GetType()))
+                return false;
+
+            var compare = (SRSTransponder)obj;
+
+
+            if (mode1 != compare.mode1)
+            {
+                return false;
+            }
+
+            if (mode3 != compare.mode3)
+            {
+                return false;
+            }
+
+            if (mode4 != compare.mode4)
+            {
+                return false;
+            }
+
+            if (status != compare.status)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        public SRSTransponder Copy()
+        {
+            return new SRSTransponder() { mode1 = mode1, mode3 = mode3, mode4 = mode4, status = status, mic = mic };
+        }
+    }
+}
+

--- a/Source/NonVisuals/Radios/SRS/UDPInterfaceCommand.cs
+++ b/Source/NonVisuals/Radios/SRS/UDPInterfaceCommand.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NonVisuals.Radios.SRS
+{
+    // Class from Ciribob.DCS.SimpleRadio.Standalone.Common.Network
+
+    internal class UDPInterfaceCommand
+    {
+        public enum UDPCommandType
+        {
+            FREQUENCY_DELTA = 0,
+            ACTIVE_RADIO = 1,
+            TOGGLE_GUARD = 2,
+            CHANNEL_UP = 3,
+            CHANNEL_DOWN = 4,
+            SET_VOLUME = 5,
+            TRANSPONDER_POWER = 6,
+            TRANSPONDER_M1_CODE = 7,
+            TRANSPONDER_M3_CODE = 8,
+            TRANSPONDER_M4 = 9,
+            TRANSPONDER_IDENT = 10,
+            GUARD = 11, // SET guard
+            FREQUENCY_SET = 12,
+        }
+
+        public int RadioId { get; set; }
+        public double Frequency { get; set; }
+        public UDPCommandType Command { get; set; }
+        public float Volume { get; set; }
+        public bool Enabled { get; set; }
+        public int Code { get; set; }
+    }
+}

--- a/Source/Tests/ClassLibraryCommon/CommonTests.cs
+++ b/Source/Tests/ClassLibraryCommon/CommonTests.cs
@@ -70,9 +70,13 @@ namespace Tests.ClassLibraryCommon
             EmulationMode.DCSBIOSInputEnabled,
             EmulationMode.DCSBIOSOutputEnabled }, 3)]
         [InlineData(new EmulationMode[] {
+            EmulationMode.SRSEnabled,
+            EmulationMode.SRSEnabled }, 8)]
+        [InlineData(new EmulationMode[] {
             EmulationMode.DCSBIOSInputEnabled,
             EmulationMode.DCSBIOSOutputEnabled,
-            EmulationMode.NS430Enabled }, 19)]
+            EmulationMode.SRSEnabled,
+            EmulationMode.NS430Enabled }, 27)]
         public void EmulationModes_SetMultipleValue_ShouldSet_ExpectedValue(EmulationMode[] modes, int expectedValue)
         {
             try
@@ -104,6 +108,31 @@ namespace Tests.ClassLibraryCommon
                 Assert.Throws<Exception>(
                 () => modes.ToList().ForEach(x => Common.SetEmulationModes(x))
                 );
+            }
+            finally
+            {
+                EmulationModes_ResetStaticFlagValuesAfterTest();
+            }
+        }
+
+        [Theory]
+        //we want to remove SRSEnabled in those tests
+        [InlineData(new EmulationMode[] {
+            EmulationMode.DCSBIOSInputEnabled,
+            EmulationMode.DCSBIOSOutputEnabled,
+            EmulationMode.SRSEnabled,
+            EmulationMode.NS430Enabled }, 19)] 
+        
+        [InlineData(new EmulationMode[] {
+            EmulationMode.SRSEnabled }, 0)]
+        public void EmulationModes_Clear_ShouldRemove_TheFlag(EmulationMode[] modes, int expectedValueAfterRemove)
+        {
+            try
+            {
+                modes.ToList().ForEach(x => Common.SetEmulationModes(x));
+                Common.ClearEmulationModesFlag(EmulationMode.SRSEnabled);
+                Common.ClearEmulationModesFlag(EmulationMode.SRSEnabled); //A double clear should not affect result
+                Assert.Equal(expectedValueAfterRemove, Common.GetEmulationModesFlag());
             }
             finally
             {

--- a/Source/Tests/NonVisuals/RadioPanelPZ69Mi24PTests.cs
+++ b/Source/Tests/NonVisuals/RadioPanelPZ69Mi24PTests.cs
@@ -1,5 +1,4 @@
 ﻿using NonVisuals.Radios;
-using System;
 using Xunit;
 
 namespace Tests.NonVisuals


### PR DESCRIPTION
SRS PZ69 Radio support re-added.

- Fully clickable cockpit : Displays the radios frequencies on PZ69, no encoding of frequencies possible with PZ69. Frequencies must be set in cockpit.
- Non fully clickable cockpit (flaming cliffs) : Frequencies sets on SRS will be displayed on PZ69. Encoding of frequencies is possible with the 2 wheels or better with the SRS Radio overlay, changes will be reflected on SRS radio overlay &  PZ69. Encoding with the small wheel is not perfect and could be improved since it only increase / decrease with steps of '0.001 %'.

