### PR TITLE
[DCSBIOS] Improvement on DCSBIOS search textboxes

### DIFF
--- a/Source/DCSFlightpanels/Windows/DCSBiosInputWindow.xaml
+++ b/Source/DCSFlightpanels/Windows/DCSBiosInputWindow.xaml
@@ -52,7 +52,7 @@
             <Label Name="LabelProfileDescription" Content="Profile Description here" HorizontalAlignment="Stretch" Margin="10,0,0,10" FontWeight="Bold" FontSize="12"/>
             <Label Name="LabelDescription" Content="Description here" HorizontalAlignment="Stretch" Margin="10,0,0,10" FontWeight="Bold" FontSize="12"/>
             <Label Content="Type aircraft control search words:" HorizontalAlignment="Stretch" Margin="10,0,0,0" IsEnabled="True"/>
-            <TextBox Name="TextBoxSearchWord" HorizontalAlignment="Stretch" Height="23" TextWrapping="Wrap" Text=""  Margin="10,0,10,10" TextChanged="TextBoxSearchWord_OnTextChanged" KeyUp="TextBoxSearchWord_OnKeyUp"  IsEnabled="true">
+            <TextBox Name="TextBoxSearchWord" HorizontalAlignment="Stretch" Height="23" TextWrapping="Wrap" Text=""  Margin="10,0,10,10" TextChanged="TextBoxSearchWord_OnTextChanged" KeyUp="TextBoxSearchWord_OnKeyUp"  IsEnabled="true" PreviewKeyDown="TextBoxSearchWord_PreviewKeyDown">
                 <TextBox.Background>
                     <ImageBrush ImageSource="/Images/cue_banner_search_dcsbios.png" AlignmentX="Left" Stretch="Uniform" />
                 </TextBox.Background>

--- a/Source/DCSFlightpanels/Windows/DCSBiosInputWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/DCSBiosInputWindow.xaml.cs
@@ -504,5 +504,9 @@ namespace DCSFlightpanels.Windows
             }
         }
 
+        private void TextBoxSearchWord_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            TextBoxSearchCommon.HandleFirstSpace(sender, e);
+        }
     }
 }

--- a/Source/DCSFlightpanels/Windows/DCSBiosInputWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/DCSBiosInputWindow.xaml.cs
@@ -1,12 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
 using ClassLibraryCommon;
 using DCS_BIOS;
 using DCS_BIOS.Json;
@@ -16,7 +13,7 @@ namespace DCSFlightpanels.Windows
     /// <summary>
     /// Interaction logic for DCSBiosInputWindow.xaml
     /// </summary>
-    public partial class DCSBiosInputWindow
+    public partial class DCSBiosInputWindow 
     {
         private DCSBIOSInput _dcsBiosInput;
         private readonly string _description;
@@ -341,43 +338,11 @@ namespace DCSFlightpanels.Windows
             set { _dcsBiosInput = value; }
         }
 
-        private void AdjustShownPopupData()
-        {
-            try
-            {
-                _popupSearch.PlacementTarget = TextBoxSearchWord;
-                _popupSearch.Placement = PlacementMode.Bottom;
-                if (!_popupSearch.IsOpen)
-                {
-                    _popupSearch.IsOpen = true;
-                }
-                if (_dataGridValues != null)
-                {
-                    if (string.IsNullOrEmpty(TextBoxSearchWord.Text))
-                    {
-                        _dataGridValues.DataContext = _dcsbiosControls;
-                        _dataGridValues.ItemsSource = _dcsbiosControls;
-                        _dataGridValues.Items.Refresh();
-                        return;
-                    }
-                    var subList = _dcsbiosControls.Where(controlObject => (!string.IsNullOrWhiteSpace(controlObject.Identifier) && controlObject.Identifier.ToUpper().Contains(TextBoxSearchWord.Text.ToUpper()))
-                                                                          || (!string.IsNullOrWhiteSpace(controlObject.Description) && controlObject.Description.ToUpper().Contains(TextBoxSearchWord.Text.ToUpper())));
-                    _dataGridValues.DataContext = subList;
-                    _dataGridValues.ItemsSource = subList;
-                    _dataGridValues.Items.Refresh();
-                }
-            }
-            catch (Exception ex)
-            {
-                Common.ShowErrorMessageBox(ex, "AdjustShownPopupData()");
-            }
-        }
-
         private void TextBoxSearchWord_OnKeyUp(object sender, KeyEventArgs e)
         {
             try
             {
-                AdjustShownPopupData();
+                TextBoxSearchCommon.AdjustShownPopupData(TextBoxSearchWord, _popupSearch, _dataGridValues, _dcsbiosControls);
                 SetFormState();
             }
             catch (Exception ex)
@@ -388,29 +353,7 @@ namespace DCSFlightpanels.Windows
 
         private void TextBoxSearchWord_OnTextChanged(object sender, TextChangedEventArgs e)
         {
-            try
-            {
-                if (TextBoxSearchWord.Text == string.Empty)
-                {
-                    // Create an ImageBrush.
-                    var textImageBrush = new ImageBrush
-                    {
-                        ImageSource = new BitmapImage(new Uri("pack://application:,,,/dcsfp;component/Images/cue_banner_search_dcsbios.png", UriKind.RelativeOrAbsolute)),
-                        AlignmentX = AlignmentX.Left,
-                        Stretch = Stretch.Uniform
-                    };
-                    // Use the brush to paint the button's background.
-                    TextBoxSearchWord.Background = textImageBrush;
-                }
-                else
-                {
-                    TextBoxSearchWord.Background = null;
-                }
-            }
-            catch (Exception ex)
-            {
-                Common.ShowErrorMessageBox(ex);
-            }
+            TextBoxSearchCommon.SetBackgroundSearchBanner(TextBoxSearchWord);           
         }
 
         private void DataGridValues_OnMouseDoubleClick(object sender, MouseButtonEventArgs e)

--- a/Source/DCSFlightpanels/Windows/DCSBiosOutputFormulaWindow.xaml
+++ b/Source/DCSFlightpanels/Windows/DCSBiosOutputFormulaWindow.xaml
@@ -59,7 +59,7 @@
                 <Label Name="LabelUserDescription" Content="Description"></Label>
                 <TextBox Name="TextBoxUserDescription" HorizontalAlignment="Stretch" Height="23" TextWrapping="Wrap" Text=""  Margin="10,0,10,10" IsEnabled="true"/>
                 <Label Content="Search Box : Type aircraft control search words:" HorizontalAlignment="Stretch" Margin="10,0,0,0" IsEnabled="True"/>
-                <TextBox Name="TextBoxSearchWord" HorizontalAlignment="Stretch" Height="23" TextWrapping="Wrap" Text=""  Margin="10,0,10,10" TextChanged="TextBoxSearchWord_OnTextChanged" KeyUp="TextBoxSearchWord_OnKeyUp"  IsEnabled="true">
+                <TextBox Name="TextBoxSearchWord" HorizontalAlignment="Stretch" Height="23" TextWrapping="Wrap" Text=""  Margin="10,0,10,10" TextChanged="TextBoxSearchWord_OnTextChanged" KeyUp="TextBoxSearchWord_OnKeyUp"  IsEnabled="true" PreviewKeyDown="TextBoxSearchWord_PreviewKeyDown">
                     <TextBox.Background>
                         <ImageBrush ImageSource="/Images/cue_banner_search_dcsbios.png" AlignmentX="Left" Stretch="Uniform" />
                     </TextBox.Background>

--- a/Source/DCSFlightpanels/Windows/DCSBiosOutputFormulaWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/DCSBiosOutputFormulaWindow.xaml.cs
@@ -548,5 +548,10 @@ namespace DCSFlightpanels.Windows
                 Common.ShowErrorMessageBox(ex);
             }
         }
+
+        private void TextBoxSearchWord_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            TextBoxSearchCommon.HandleFirstSpace(sender, e);
+        }
     }
 }

--- a/Source/DCSFlightpanels/Windows/DCSBiosOutputFormulaWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/DCSBiosOutputFormulaWindow.xaml.cs
@@ -5,13 +5,10 @@ namespace DCSFlightpanels.Windows
     using System;
     using System.Collections.Generic;
     using System.ComponentModel;
-    using System.Linq;
     using System.Windows;
     using System.Windows.Controls;
     using System.Windows.Controls.Primitives;
     using System.Windows.Input;
-    using System.Windows.Media;
-    using System.Windows.Media.Imaging;
     using ClassLibraryCommon;
     using DCS_BIOS;
     using DCS_BIOS.EventArgs;
@@ -298,36 +295,11 @@ namespace DCSFlightpanels.Windows
             set { _dcsBiosOutput = value; }
         }
 
-        private void AdjustShownPopupData()
-        {
-            _popupSearch.PlacementTarget = TextBoxSearchWord;
-            _popupSearch.Placement = PlacementMode.Bottom;
-            if (!_popupSearch.IsOpen)
-            {
-                _popupSearch.IsOpen = true;
-            }
-            if (_dataGridValues != null)
-            {
-                if (string.IsNullOrEmpty(TextBoxSearchWord.Text))
-                {
-                    _dataGridValues.DataContext = _dcsbiosControls;
-                    _dataGridValues.ItemsSource = _dcsbiosControls;
-                    _dataGridValues.Items.Refresh();
-                    return;
-                }
-                var subList = _dcsbiosControls.Where(controlObject => (!string.IsNullOrWhiteSpace(controlObject.Identifier) && controlObject.Identifier.ToUpper().Contains(TextBoxSearchWord.Text.ToUpper()))
-                    || (!string.IsNullOrWhiteSpace(controlObject.Description) && controlObject.Description.ToUpper().Contains(TextBoxSearchWord.Text.ToUpper())));
-                _dataGridValues.DataContext = subList;
-                _dataGridValues.ItemsSource = subList;
-                _dataGridValues.Items.Refresh();
-            }
-        }
-
         private void TextBoxSearchWord_OnKeyUp(object sender, KeyEventArgs e)
         {
             try
             {
-                AdjustShownPopupData();
+                TextBoxSearchCommon.AdjustShownPopupData(TextBoxSearchWord, _popupSearch, _dataGridValues, _dcsbiosControls);
                 SetFormState();
             }
             catch (Exception ex)
@@ -338,31 +310,7 @@ namespace DCSFlightpanels.Windows
 
         private void TextBoxSearchWord_OnTextChanged(object sender, TextChangedEventArgs e)
         {
-            try
-            {
-                if (TextBoxSearchWord.Text == string.Empty)
-                {
-                    // Create an ImageBrush.
-                    var textImageBrush = new ImageBrush
-                    {
-                        ImageSource = new BitmapImage(
-                            new Uri("pack://application:,,,/dcsfp;component/Images/cue_banner_search_dcsbios.png", UriKind.RelativeOrAbsolute)),
-                        AlignmentX = AlignmentX.Left,
-                        Stretch = Stretch.Uniform
-                    };
-
-                    // Use the brush to paint the button's background.
-                    TextBoxSearchWord.Background = textImageBrush;
-                }
-                else
-                {
-                    TextBoxSearchWord.Background = null;
-                }
-            }
-            catch (Exception ex)
-            {
-                Common.ShowErrorMessageBox(ex);
-            }
+            TextBoxSearchCommon.SetBackgroundSearchBanner(TextBoxSearchWord);
         }
 
         private void Control_OnMouseDoubleClick(object sender, MouseButtonEventArgs e)

--- a/Source/DCSFlightpanels/Windows/DCSBiosOutputTriggerWindow.xaml
+++ b/Source/DCSFlightpanels/Windows/DCSBiosOutputTriggerWindow.xaml
@@ -54,7 +54,7 @@
         <StackPanel Grid.Column="2" Grid.RowSpan="6">
             <Label Name="LabelDescription" Content="Description here" HorizontalAlignment="Stretch" Margin="10,0,0,10" FontWeight="Bold" FontSize="12"/>
             <Label Content="Type aircraft control search words:" HorizontalAlignment="Stretch" Margin="10,0,0,0" IsEnabled="True"/>
-            <TextBox Name="TextBoxSearchWord" HorizontalAlignment="Stretch" Height="23" TextWrapping="Wrap" Text=""  Margin="10,0,10,10" TextChanged="TextBoxSearchWord_OnTextChanged" KeyUp="TextBoxSearchWord_OnKeyUp"  IsEnabled="true">
+            <TextBox Name="TextBoxSearchWord" HorizontalAlignment="Stretch" Height="23" TextWrapping="Wrap" Text=""  Margin="10,0,10,10" TextChanged="TextBoxSearchWord_OnTextChanged" KeyUp="TextBoxSearchWord_OnKeyUp"  IsEnabled="true" PreviewKeyDown="TextBoxSearchWord_PreviewKeyDown">
                 <TextBox.Background>
                     <ImageBrush ImageSource="/Images/cue_banner_search_dcsbios.png" AlignmentX="Left" Stretch="Uniform" />
                 </TextBox.Background>

--- a/Source/DCSFlightpanels/Windows/DCSBiosOutputTriggerWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/DCSBiosOutputTriggerWindow.xaml.cs
@@ -5,13 +5,10 @@ namespace DCSFlightpanels.Windows
     using System;
     using System.Collections.Generic;
     using System.Globalization;
-    using System.Linq;
     using System.Windows;
     using System.Windows.Controls;
     using System.Windows.Controls.Primitives;
     using System.Windows.Input;
-    using System.Windows.Media;
-    using System.Windows.Media.Imaging;
     using ClassLibraryCommon;
     using DCS_BIOS;
     using EnumEx = ClassLibraryCommon.EnumEx;
@@ -225,36 +222,12 @@ namespace DCSFlightpanels.Windows
             set { _dcsBiosOutput = value; }
         }
 
-        private void AdjustShownPopupData()
-        {
-            _popupSearch.PlacementTarget = TextBoxSearchWord;
-            _popupSearch.Placement = PlacementMode.Bottom;
-            if (!_popupSearch.IsOpen)
-            {
-                _popupSearch.IsOpen = true;
-            }
-            if (_dataGridValues != null)
-            {
-                if (string.IsNullOrEmpty(TextBoxSearchWord.Text))
-                {
-                    _dataGridValues.DataContext = _dcsbiosControls;
-                    _dataGridValues.ItemsSource = _dcsbiosControls;
-                    _dataGridValues.Items.Refresh();
-                    return;
-                }
-                var subList = _dcsbiosControls.Where(controlObject => (!string.IsNullOrWhiteSpace(controlObject.Identifier) && controlObject.Identifier.ToUpper().Contains(TextBoxSearchWord.Text.ToUpper()))
-                    || (!string.IsNullOrWhiteSpace(controlObject.Description) && controlObject.Description.ToUpper().Contains(TextBoxSearchWord.Text.ToUpper())));
-                _dataGridValues.DataContext = subList;
-                _dataGridValues.ItemsSource = subList;
-                _dataGridValues.Items.Refresh();
-            }
-        }
 
         private void TextBoxSearchWord_OnKeyUp(object sender, KeyEventArgs e)
         {
             try
             {
-                AdjustShownPopupData();
+                TextBoxSearchCommon.AdjustShownPopupData(TextBoxSearchWord, _popupSearch, _dataGridValues, _dcsbiosControls);
                 SetFormState();
             }
             catch (Exception ex)
@@ -265,30 +238,7 @@ namespace DCSFlightpanels.Windows
 
         private void TextBoxSearchWord_OnTextChanged(object sender, TextChangedEventArgs e)
         {
-            try
-            {
-                if (TextBoxSearchWord.Text == string.Empty)
-                {
-                    // Create an ImageBrush.
-                    var textImageBrush = new ImageBrush
-                    {
-                        ImageSource = new BitmapImage(new Uri("pack://application:,,,/dcsfp;component/Images/cue_banner_search_dcsbios.png", UriKind.RelativeOrAbsolute)),
-                        AlignmentX = AlignmentX.Left,
-                        Stretch = Stretch.Uniform
-                    };
-
-                    // Use the brush to paint the button's background.
-                    TextBoxSearchWord.Background = textImageBrush;
-                }
-                else
-                {
-                    TextBoxSearchWord.Background = null;
-                }
-            }
-            catch (Exception ex)
-            {
-                Common.ShowErrorMessageBox(ex);
-            }
+            TextBoxSearchCommon.SetBackgroundSearchBanner(TextBoxSearchWord);            
         }
 
         private void Control_OnMouseDoubleClick(object sender, MouseButtonEventArgs e)

--- a/Source/DCSFlightpanels/Windows/DCSBiosOutputTriggerWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/DCSBiosOutputTriggerWindow.xaml.cs
@@ -326,5 +326,10 @@ namespace DCSFlightpanels.Windows
                 Close();
             }
         }
+
+        private void TextBoxSearchWord_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            TextBoxSearchCommon.HandleFirstSpace(sender, e);
+        }
     }
 }

--- a/Source/DCSFlightpanels/Windows/DCSBiosOutputWindow.xaml
+++ b/Source/DCSFlightpanels/Windows/DCSBiosOutputWindow.xaml
@@ -49,7 +49,7 @@
                 <Label Name="LabelUserDescription" Content="Description"></Label>
                 <TextBox Name="TextBoxUserDescription" HorizontalAlignment="Stretch" Height="23" TextWrapping="Wrap" Text=""  Margin="10,0,10,10" IsEnabled="true"/>
                 <Label Content="Search Box : Type aircraft control search words:" HorizontalAlignment="Stretch" Margin="10,0,0,0" IsEnabled="True"/>
-                <TextBox Name="TextBoxSearchWord" HorizontalAlignment="Stretch" Height="23" TextWrapping="Wrap" Text=""  Margin="10,0,10,10" TextChanged="TextBoxSearchWord_OnTextChanged" KeyUp="TextBoxSearchWord_OnKeyUp"  IsEnabled="true">
+                <TextBox Name="TextBoxSearchWord" HorizontalAlignment="Stretch" Height="23" TextWrapping="Wrap" Text=""  Margin="10,0,10,10" TextChanged="TextBoxSearchWord_OnTextChanged" KeyUp="TextBoxSearchWord_OnKeyUp"  IsEnabled="true" PreviewKeyDown="TextBoxSearchWord_PreviewKeyDown">
                     <TextBox.Background>
                         <ImageBrush ImageSource="/Images/cue_banner_search_dcsbios.png" AlignmentX="Left" Stretch="Uniform" />
                     </TextBox.Background>

--- a/Source/DCSFlightpanels/Windows/DCSBiosOutputWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/DCSBiosOutputWindow.xaml.cs
@@ -1,12 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
 using ClassLibraryCommon;
 using DCS_BIOS;
 using DCS_BIOS.Json;
@@ -163,36 +160,11 @@ namespace DCSFlightpanels.Windows
             set { _dcsBiosOutput = value; }
         }
 
-        private void AdjustShownPopupData()
-        {
-            _popupSearch.PlacementTarget = TextBoxSearchWord;
-            _popupSearch.Placement = PlacementMode.Bottom;
-            if (!_popupSearch.IsOpen)
-            {
-                _popupSearch.IsOpen = true;
-            }
-            if (_dataGridValues != null)
-            {
-                if (string.IsNullOrEmpty(TextBoxSearchWord.Text))
-                {
-                    _dataGridValues.DataContext = _dcsbiosControls;
-                    _dataGridValues.ItemsSource = _dcsbiosControls;
-                    _dataGridValues.Items.Refresh();
-                    return;
-                }
-                var subList = _dcsbiosControls.Where(controlObject => (!string.IsNullOrWhiteSpace(controlObject.Identifier) && controlObject.Identifier.ToUpper().Contains(TextBoxSearchWord.Text.ToUpper()))
-                    || (!string.IsNullOrWhiteSpace(controlObject.Description) && controlObject.Description.ToUpper().Contains(TextBoxSearchWord.Text.ToUpper())));
-                _dataGridValues.DataContext = subList;
-                _dataGridValues.ItemsSource = subList;
-                _dataGridValues.Items.Refresh();
-            }
-        }
-
         private void TextBoxSearchWord_OnKeyUp(object sender, KeyEventArgs e)
         {
             try
             {
-                AdjustShownPopupData();
+                TextBoxSearchCommon.AdjustShownPopupData(TextBoxSearchWord, _popupSearch, _dataGridValues, _dcsbiosControls);
                 SetFormState();
             }
             catch (Exception ex)
@@ -203,30 +175,7 @@ namespace DCSFlightpanels.Windows
 
         private void TextBoxSearchWord_OnTextChanged(object sender, TextChangedEventArgs e)
         {
-            try
-            {
-                if (TextBoxSearchWord.Text == string.Empty)
-                {
-                    // Create an ImageBrush.
-                    var textImageBrush = new ImageBrush
-                    {
-                        ImageSource = new BitmapImage(new Uri("pack://application:,,,/dcsfp;component/Images/cue_banner_search_dcsbios.png", UriKind.RelativeOrAbsolute)),
-                        AlignmentX = AlignmentX.Left,
-                        Stretch = Stretch.Uniform
-                    };
-
-                    // Use the brush to paint the button's background.
-                    TextBoxSearchWord.Background = textImageBrush;
-                }
-                else
-                {
-                    TextBoxSearchWord.Background = null;
-                }
-            }
-            catch (Exception ex)
-            {
-                Common.ShowErrorMessageBox(ex);
-            }
+            TextBoxSearchCommon.SetBackgroundSearchBanner(TextBoxSearchWord);           
         }
 
         private void Control_OnMouseDoubleClick(object sender, MouseButtonEventArgs e)

--- a/Source/DCSFlightpanels/Windows/DCSBiosOutputWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/DCSBiosOutputWindow.xaml.cs
@@ -291,5 +291,9 @@ namespace DCSFlightpanels.Windows
             get { return TextBoxUserDescription.Text; }
         }
 
+        private void TextBoxSearchWord_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            TextBoxSearchCommon.HandleFirstSpace(sender, e);
+        }
     }
 }

--- a/Source/DCSFlightpanels/Windows/JaceSandboxWindow.xaml
+++ b/Source/DCSFlightpanels/Windows/JaceSandboxWindow.xaml
@@ -52,7 +52,7 @@
                         <StackPanel Orientation="Horizontal">
                             <Label Name="LabelSource1" Content="1 : " Margin="10,10,10,0"/>
                             <Button Content="Clear" Height="23" VerticalAlignment="Bottom" Margin="10,10,10,10"  x:Name="ButtonClear1" Width="75" Click="ButtonClear1_OnClick"/>
-                            <TextBox Name="TextBoxSearch1" Text="Type to search control" Foreground="Gainsboro" FontSize="10" Height="18" Width="120" IsEnabled="True"  KeyUp="TextBoxSearch_OnKeyUp" GotFocus="TextBoxSearch_OnGotFocus" LostFocus="TextBoxSearch_OnLostFocus"/>
+                            <TextBox Name="TextBoxSearch1" Text="Type to search control" Foreground="Gainsboro" FontSize="10" Height="18" Width="120" IsEnabled="True"  KeyUp="TextBoxSearch_OnKeyUp" GotFocus="TextBoxSearch_OnGotFocus" LostFocus="TextBoxSearch_OnLostFocus" PreviewKeyDown="TextBoxSearch1_PreviewKeyDown"/>
                             <TextBox FontSize="10" Height="18" Width="150" IsReadOnly="True" Margin="10,10,10,10" Name="TextBoxId1" IsEnabled="False"/>
                             <Label Name="LabelSourceRawValue1" Content="Value : " Margin="10,10,10,0"/>
                             <Label x:Name="LabelInsert1" Content="Click to insert to formula.." FontSize="8" Foreground="DodgerBlue" VerticalContentAlignment="Center" MouseEnter="LabelInsert_OnMouseEnter" MouseLeave="LabelInsert_OnMouseLeave" MouseDown="LabelInsert_OnMouseDown"/>
@@ -60,7 +60,7 @@
                         <StackPanel Orientation="Horizontal">
                             <Label Name="LabelSource2" Content="2 : " Margin="10,10,10,0"/>
                             <Button Content="Clear" Height="23" VerticalAlignment="Bottom" Margin="10,10,10,10"  x:Name="ButtonClear2" Width="75"  Click="ButtonClear2_OnClick"/>
-                            <TextBox Name="TextBoxSearch2" Text="Type to search control" Foreground="Gainsboro" FontSize="10" Height="18" Width="120" IsEnabled="True"  KeyUp="TextBoxSearch_OnKeyUp" GotFocus="TextBoxSearch_OnGotFocus" LostFocus="TextBoxSearch_OnLostFocus" />
+                            <TextBox Name="TextBoxSearch2" Text="Type to search control" Foreground="Gainsboro" FontSize="10" Height="18" Width="120" IsEnabled="True"  KeyUp="TextBoxSearch_OnKeyUp" GotFocus="TextBoxSearch_OnGotFocus" LostFocus="TextBoxSearch_OnLostFocus" PreviewKeyDown="TextBoxSearch2_PreviewKeyDown" />
                             <TextBox FontSize="10" Height="18" Width="150"  IsReadOnly="True" Margin="10,10,10,10" Name="TextBoxId2" IsEnabled="False"/>
                             <Label Name="LabelSourceRawValue2" Content="Value : " Margin="10,10,10,0"/>
                             <Label x:Name="LabelInsert2" Content="Click to insert to formula.." FontSize="8" Foreground="DodgerBlue" VerticalContentAlignment="Center" MouseEnter="LabelInsert_OnMouseEnter" MouseLeave="LabelInsert_OnMouseLeave" MouseDown="LabelInsert_OnMouseDown"/>
@@ -68,7 +68,7 @@
                         <StackPanel Orientation="Horizontal">
                             <Label Name="LabelSource3" Content="3 : " Margin="10,10,10,0"/>
                             <Button Content="Clear" Height="23" VerticalAlignment="Bottom" Margin="10,10,10,10"  x:Name="ButtonClear3" Width="75" Click="ButtonClear3_OnClick"/>
-                            <TextBox Name="TextBoxSearch3" Text="Type to search control" Foreground="Gainsboro" FontSize="10" Height="18" Width="120" IsEnabled="True"  KeyUp="TextBoxSearch_OnKeyUp" GotFocus="TextBoxSearch_OnGotFocus" LostFocus="TextBoxSearch_OnLostFocus"/>
+                            <TextBox Name="TextBoxSearch3" Text="Type to search control" Foreground="Gainsboro" FontSize="10" Height="18" Width="120" IsEnabled="True"  KeyUp="TextBoxSearch_OnKeyUp" GotFocus="TextBoxSearch_OnGotFocus" LostFocus="TextBoxSearch_OnLostFocus" PreviewKeyDown="TextBoxSearch3_PreviewKeyDown"/>
                             <TextBox FontSize="10" Height="18"  Width="150" IsReadOnly="True" Margin="10,10,10,10" Name="TextBoxId3" IsEnabled="False"/>
                             <Label Name="LabelSourceRawValue3" Content="Value : " Margin="10,10,10,0"/>
                             <Label x:Name="LabelInsert3" Content="Click to insert to formula.." FontSize="8" Foreground="DodgerBlue" VerticalContentAlignment="Center" MouseEnter="LabelInsert_OnMouseEnter" MouseLeave="LabelInsert_OnMouseLeave" MouseDown="LabelInsert_OnMouseDown"/>
@@ -76,7 +76,7 @@
                         <StackPanel Orientation="Horizontal">
                             <Label Name="LabelSource4" Content="4 : " Margin="10,10,10,0"/>
                             <Button Content="Clear" Height="23" VerticalAlignment="Bottom" Margin="10,10,10,10"  x:Name="ButtonClear4" Width="75" Click="ButtonClear4_OnClick"/>
-                            <TextBox Name="TextBoxSearch4" Text="Type to search control" Foreground="Gainsboro" FontSize="10" Height="18" Width="120" IsEnabled="True"  KeyUp="TextBoxSearch_OnKeyUp" GotFocus="TextBoxSearch_OnGotFocus" LostFocus="TextBoxSearch_OnLostFocus"/>
+                            <TextBox Name="TextBoxSearch4" Text="Type to search control" Foreground="Gainsboro" FontSize="10" Height="18" Width="120" IsEnabled="True"  KeyUp="TextBoxSearch_OnKeyUp" GotFocus="TextBoxSearch_OnGotFocus" LostFocus="TextBoxSearch_OnLostFocus" PreviewKeyDown="TextBoxSearch4_PreviewKeyDown"/>
                             <TextBox FontSize="10" Height="18"  Width="150" IsReadOnly="True" Margin="10,10,10,10" Name="TextBoxId4" IsEnabled="False"/>
                             <Label Name="LabelSourceRawValue4" Content="Value : " Margin="10,10,10,0"/>
                             <Label x:Name="LabelInsert4" Content="Click to insert to formula.." FontSize="8" Foreground="DodgerBlue" VerticalContentAlignment="Center" MouseEnter="LabelInsert_OnMouseEnter" MouseLeave="LabelInsert_OnMouseLeave" MouseDown="LabelInsert_OnMouseDown"/>
@@ -84,7 +84,7 @@
                         <StackPanel Orientation="Horizontal">
                             <Label Name="LabelSource5" Content="5 : " Margin="10,10,10,0"/>
                             <Button Content="Clear" Height="23" VerticalAlignment="Bottom" Margin="10,10,10,10"  x:Name="ButtonClear5" Width="75" Click="ButtonClear5_OnClick"/>
-                            <TextBox Name="TextBoxSearch5" Text="Type to search control" Foreground="Gainsboro" FontSize="10" Height="18" Width="120" IsEnabled="True"  KeyUp="TextBoxSearch_OnKeyUp"  GotFocus="TextBoxSearch_OnGotFocus" LostFocus="TextBoxSearch_OnLostFocus"/>
+                            <TextBox Name="TextBoxSearch5" Text="Type to search control" Foreground="Gainsboro" FontSize="10" Height="18" Width="120" IsEnabled="True"  KeyUp="TextBoxSearch_OnKeyUp"  GotFocus="TextBoxSearch_OnGotFocus" LostFocus="TextBoxSearch_OnLostFocus" PreviewKeyDown="TextBoxSearch5_PreviewKeyDown"/>
                             <TextBox FontSize="10" Height="18"  Width="150" IsReadOnly="True" Margin="10,10,10,10" Name="TextBoxId5" IsEnabled="False"/>
                             <Label Name="LabelSourceRawValue5" Content="Value : " Margin="10,10,10,0"/>
                             <Label x:Name="LabelInsert5" Content="Click to insert to formula.." FontSize="8" Foreground="DodgerBlue" VerticalContentAlignment="Center" MouseEnter="LabelInsert_OnMouseEnter" MouseLeave="LabelInsert_OnMouseLeave" MouseDown="LabelInsert_OnMouseDown"/>

--- a/Source/DCSFlightpanels/Windows/JaceSandboxWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/JaceSandboxWindow.xaml.cs
@@ -688,5 +688,30 @@ namespace DCSFlightpanels.Windows
                 MessageBox.Show(ex.Message);
             }
         }
+
+        private void TextBoxSearch1_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            TextBoxSearchCommon.HandleFirstSpace(sender, e);
+        }
+
+        private void TextBoxSearch2_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            TextBoxSearchCommon.HandleFirstSpace(sender, e);
+        }
+
+        private void TextBoxSearch3_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            TextBoxSearchCommon.HandleFirstSpace(sender, e);
+        }
+
+        private void TextBoxSearch4_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            TextBoxSearchCommon.HandleFirstSpace(sender, e);
+        }
+
+        private void TextBoxSearch5_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            TextBoxSearchCommon.HandleFirstSpace(sender, e);
+        }
     }
 }

--- a/Source/DCSFlightpanels/Windows/JaceSandboxWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/JaceSandboxWindow.xaml.cs
@@ -445,37 +445,11 @@ namespace DCSFlightpanels.Windows
             }
         }
 
-        private void AdjustShownPopupData(TextBox textBox)
-        {
-            _popupSearch.PlacementTarget = textBox;
-            _popupSearch.Placement = PlacementMode.Bottom;
-            _dataGridValues.Tag = textBox;
-            if (!_popupSearch.IsOpen)
-            {
-                _popupSearch.IsOpen = true;
-            }
-            if (_dataGridValues != null)
-            {
-                if (string.IsNullOrEmpty(textBox.Text))
-                {
-                    _dataGridValues.DataContext = _dcsbiosControls;
-                    _dataGridValues.ItemsSource = _dcsbiosControls;
-                    _dataGridValues.Items.Refresh();
-                    return;
-                }
-                var subList = _dcsbiosControls.Where(controlObject => (!string.IsNullOrWhiteSpace(controlObject.Identifier) && controlObject.Identifier.ToUpper().Contains(textBox.Text.ToUpper()))
-                                                                      || (!string.IsNullOrWhiteSpace(controlObject.Description) && controlObject.Description.ToUpper().Contains(textBox.Text.ToUpper())));
-                _dataGridValues.DataContext = subList;
-                _dataGridValues.ItemsSource = subList;
-                _dataGridValues.Items.Refresh();
-            }
-        }
-
         private void TextBoxSearch_OnKeyUp(object sender, KeyEventArgs e)
         {
             try
             {
-                AdjustShownPopupData((TextBox)sender);
+                TextBoxSearchCommon.AdjustShownPopupData((TextBox)sender, _popupSearch, _dataGridValues, _dcsbiosControls);
                 SetFormState();
             }
             catch (Exception ex)

--- a/Source/DCSFlightpanels/Windows/StreamDeck/StreamDeckDCSBIOSDecoderWindow.xaml
+++ b/Source/DCSFlightpanels/Windows/StreamDeck/StreamDeckDCSBIOSDecoderWindow.xaml
@@ -82,7 +82,7 @@
                     </GroupBox>
                     <StackPanel Orientation="Horizontal">
                         <Button Content="Clear" Height="23" VerticalAlignment="Bottom" Margin="10,10,10,10"  x:Name="ButtonClear1" Width="75" Click="ButtonClear_OnClick"/>
-                        <TextBox Name="TextBoxSearchWord"  Margin="0,10,10,10"  Foreground="Gainsboro" FontSize="10" Height="18" Width="120" IsEnabled="True"  KeyUp="TextBoxSearch_OnKeyUp" GotFocus="TextBoxSearch_OnGotFocus" LostFocus="TextBoxSearch_OnLostFocus" TextChanged="TextBoxSearch_OnTextChanged">
+                        <TextBox Name="TextBoxSearchWord"  Margin="0,10,10,10"  Foreground="Gainsboro" FontSize="10" Height="18" Width="120" IsEnabled="True"  KeyUp="TextBoxSearch_OnKeyUp" GotFocus="TextBoxSearch_OnGotFocus" LostFocus="TextBoxSearch_OnLostFocus" TextChanged="TextBoxSearch_OnTextChanged" PreviewKeyDown="TextBoxSearchWord_PreviewKeyDown">
                             <TextBox.Background>
                                 <ImageBrush ImageSource="/Images/cue_banner_search_dcsbios.png" AlignmentX="Left" Stretch="Fill" />
                             </TextBox.Background>

--- a/Source/DCSFlightpanels/Windows/StreamDeck/StreamDeckDCSBIOSDecoderWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/StreamDeck/StreamDeckDCSBIOSDecoderWindow.xaml.cs
@@ -310,37 +310,11 @@ namespace DCSFlightpanels.Windows.StreamDeck
             }
         }
 
-        private void AdjustShownPopupData(TextBox textBox)
-        {
-            _popupSearch.PlacementTarget = textBox;
-            _popupSearch.Placement = PlacementMode.Bottom;
-            _popupDataGrid.Tag = textBox;
-            if (!_popupSearch.IsOpen)
-            {
-                _popupSearch.IsOpen = true;
-            }
-            if (_popupDataGrid != null)
-            {
-                if (string.IsNullOrEmpty(textBox.Text))
-                {
-                    _popupDataGrid.DataContext = _dcsbiosControls;
-                    _popupDataGrid.ItemsSource = _dcsbiosControls;
-                    _popupDataGrid.Items.Refresh();
-                    return;
-                }
-                var subList = _dcsbiosControls.Where(controlObject => (!string.IsNullOrWhiteSpace(controlObject.Identifier) && controlObject.Identifier.ToUpper().Contains(textBox.Text.ToUpper()))
-                                                                      || (!string.IsNullOrWhiteSpace(controlObject.Description) && controlObject.Description.ToUpper().Contains(textBox.Text.ToUpper())));
-                _popupDataGrid.DataContext = subList;
-                _popupDataGrid.ItemsSource = subList;
-                _popupDataGrid.Items.Refresh();
-            }
-        }
-
         private void TextBoxSearch_OnKeyUp(object sender, KeyEventArgs e)
         {
             try
             {
-                AdjustShownPopupData((TextBox)sender);
+                TextBoxSearchCommon.AdjustShownPopupData((TextBox)sender, _popupSearch, _popupDataGrid, _dcsbiosControls);
                 SetFormState();
             }
             catch (Exception ex)
@@ -348,7 +322,6 @@ namespace DCSFlightpanels.Windows.StreamDeck
                 Common.ShowErrorMessageBox(ex);
             }
         }
-
      
         private void SetOffset(Axis offsetAxis, int offsetChangeValue)
         {
@@ -545,31 +518,7 @@ namespace DCSFlightpanels.Windows.StreamDeck
 
         private void TextBoxSearch_OnTextChanged(object sender, TextChangedEventArgs e)
         {
-            try
-            {
-                if (TextBoxSearchWord.Text == string.Empty)
-                {
-                    // Create an ImageBrush.
-                    var textImageBrush = new ImageBrush
-                    {
-                        ImageSource = new BitmapImage(
-                            new Uri("pack://application:,,,/dcsfp;component/Images/cue_banner_search_dcsbios.png", UriKind.RelativeOrAbsolute)
-                        ),
-                        AlignmentX = AlignmentX.Left,
-                        Stretch = Stretch.Uniform
-                    };
-                    // Use the brush to paint the button's background.
-                    TextBoxSearchWord.Background = textImageBrush;
-                }
-                else
-                {
-                    TextBoxSearchWord.Background = null;
-                }
-            }
-            catch (Exception ex)
-            {
-                Common.ShowErrorMessageBox(ex);
-            }
+            TextBoxSearchCommon.SetBackgroundSearchBanner(TextBoxSearchWord);
         }
 
         private void ShowConverters()

--- a/Source/DCSFlightpanels/Windows/StreamDeck/StreamDeckDCSBIOSDecoderWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/StreamDeck/StreamDeckDCSBIOSDecoderWindow.xaml.cs
@@ -949,5 +949,10 @@ namespace DCSFlightpanels.Windows.StreamDeck
                 Common.ShowErrorMessageBox(ex);
             }
         }
+
+        private void TextBoxSearchWord_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            TextBoxSearchCommon.HandleFirstSpace(sender, e);
+        }
     }
 }

--- a/Source/DCSFlightpanels/Windows/TextBoxSearchCommon.cs
+++ b/Source/DCSFlightpanels/Windows/TextBoxSearchCommon.cs
@@ -48,6 +48,7 @@ namespace DCSFlightpanels.Windows
             {
                 popupSearch.PlacementTarget = textBoxSearch;
                 popupSearch.Placement = PlacementMode.Bottom;
+                dataGridValues.Tag = textBoxSearch;
                 if (!popupSearch.IsOpen)
                 {
                     popupSearch.IsOpen = true;

--- a/Source/DCSFlightpanels/Windows/TextBoxSearchCommon.cs
+++ b/Source/DCSFlightpanels/Windows/TextBoxSearchCommon.cs
@@ -1,0 +1,76 @@
+﻿using ClassLibraryCommon;
+using System;
+using System.Windows.Controls;
+using System.Windows.Media.Imaging;
+using System.Windows.Media;
+using DCS_BIOS.Json;
+using System.Windows.Controls.Primitives;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DCSFlightpanels.Windows
+{
+    internal static class TextBoxSearchCommon
+    {
+        internal static void SetBackgroundSearchBanner(TextBox textBoxSearch)
+        {
+            try
+            {
+                if (String.IsNullOrEmpty(textBoxSearch.Text))
+                {
+                    // Create an ImageBrush.
+                    var textImageBrush = new ImageBrush
+                    {
+                        ImageSource = new BitmapImage(
+                            new Uri("pack://application:,,,/dcsfp;component/Images/cue_banner_search_dcsbios.png", UriKind.RelativeOrAbsolute)),
+                        AlignmentX = AlignmentX.Left,
+                        Stretch = Stretch.Uniform
+                    };
+
+                    // Use the brush to paint the button's background.
+                    textBoxSearch.Background = textImageBrush;
+                }
+                else
+                {
+                    textBoxSearch.Background = null;
+                }
+            }
+            catch (Exception ex)
+            {
+                Common.ShowErrorMessageBox(ex);
+            }
+        }
+
+        internal static void AdjustShownPopupData(TextBox textBoxSearch, Popup popupSearch, DataGrid dataGridValues, IEnumerable<DCSBIOSControl> dcsbiosControls)
+        {
+            try
+            {
+                popupSearch.PlacementTarget = textBoxSearch;
+                popupSearch.Placement = PlacementMode.Bottom;
+                if (!popupSearch.IsOpen)
+                {
+                    popupSearch.IsOpen = true;
+                }
+                if (dataGridValues != null)
+                {
+                    if (string.IsNullOrEmpty(textBoxSearch.Text))
+                    {
+                        dataGridValues.DataContext = dcsbiosControls;
+                        dataGridValues.ItemsSource = dcsbiosControls;
+                        dataGridValues.Items.Refresh();
+                        return;
+                    }
+                    var subList = dcsbiosControls.Where(controlObject => (!string.IsNullOrWhiteSpace(controlObject.Identifier) && controlObject.Identifier.ToUpper().Contains(textBoxSearch.Text.ToUpper()))
+                                                                          || (!string.IsNullOrWhiteSpace(controlObject.Description) && controlObject.Description.ToUpper().Contains(textBoxSearch.Text.ToUpper())));
+                    dataGridValues.DataContext = subList;
+                    dataGridValues.ItemsSource = subList;
+                    dataGridValues.Items.Refresh();
+                }
+            }
+            catch (Exception ex)
+            {
+                Common.ShowErrorMessageBox(ex, "AdjustShownPopupData()");
+            }
+        }
+    }
+}

--- a/Source/DCSFlightpanels/Windows/TextBoxSearchCommon.cs
+++ b/Source/DCSFlightpanels/Windows/TextBoxSearchCommon.cs
@@ -7,6 +7,7 @@ using DCS_BIOS.Json;
 using System.Windows.Controls.Primitives;
 using System.Collections.Generic;
 using System.Linq;
+using System.Windows.Input;
 
 namespace DCSFlightpanels.Windows
 {
@@ -70,6 +71,14 @@ namespace DCSFlightpanels.Windows
             catch (Exception ex)
             {
                 Common.ShowErrorMessageBox(ex, "AdjustShownPopupData()");
+            }
+        }
+
+        internal static void HandleFirstSpace(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Space && ((TextBox)sender).Text == "")
+            {
+                e.Handled = true;
             }
         }
     }


### PR DESCRIPTION
* Handle the "first space" that messes with the datagrid search. 
     When space was pressed to display the control list on an empty text box, the first space was registered andt he search was done with the first space before the typed word. ex: " FLAP"  resulting in never finding the control. 
   Now the key preview handle this case
* Rationalize some big repetitive functions acrross multiple screen in a common static class.  This still could be better and improved with a custom control but it would require some  more heavy lifting.