### PR TITLE
ctrlref and dcsfp shows DCS-BIOS version in UI

### DIFF
--- a/Source/ControlReference/MainWindow.xaml
+++ b/Source/ControlReference/MainWindow.xaml
@@ -29,6 +29,7 @@
                 <MenuItem Name="MenuItemExit" Header="Exit" Click="MenuItemExit_OnClick" />
             </MenuItem>
             <MenuItem Header="Options">
+                <MenuItem Name ="MenuItemErrorLog" Header="Open error log" Click="MenuItemErrorLog_OnClick" />
                 <MenuItem Name ="MenuSetDCSBIOSPath" Header="Set DCS-BIOS Path" Click="MenuSetDCSBIOSPath_OnClick" />
                 <MenuItem Name ="MenuSetAlwaysOnTop" Header="Always On Top" Click="MenuSetAlwaysOnTop_OnClick" />
             </MenuItem>
@@ -84,9 +85,10 @@
             <StatusBarItem HorizontalAlignment="Stretch" HorizontalContentAlignment="Right">
                 <TextBlock Name="LabelStatusBarLeftInformation" HorizontalAlignment="Right" Margin="0,0,10,0" Width="300"/>
             </StatusBarItem>
-            <StatusBarItem HorizontalAlignment="Stretch" HorizontalContentAlignment="Right">
+            <StatusBarItem HorizontalContentAlignment="Right">
                 <StackPanel Orientation="Horizontal">
                     <TextBlock Name="LabelStatusBarRightInformation" Text="" HorizontalAlignment="Right" Margin="0,0,10,0"/>
+                    <TextBlock Name="LabelDCSBIOSVersion" Visibility="Hidden" HorizontalAlignment="Right" Margin="0,0,10,0"/>
                 </StackPanel>
             </StatusBarItem>
         </StatusBar>

--- a/Source/DCSFlightpanels/MainWindow.xaml
+++ b/Source/DCSFlightpanels/MainWindow.xaml
@@ -196,7 +196,7 @@
             <StatusBarItem HorizontalAlignment="Stretch" HorizontalContentAlignment="Right">
                 <StackPanel Orientation="Horizontal">
                     <TextBlock Name="LabelPluginInfo" Text="Plugin support disabled." HorizontalAlignment="Right" Margin="0,0,10,0"/>
-                    <TextBlock Name="LabelDCSBIOSReleaseDate" HorizontalAlignment="Right" Margin="0,0,10,0"/>
+                    <TextBlock Name="LabelDCSBIOSVersion" Visibility="Hidden" HorizontalAlignment="Right" Margin="0,0,10,0"/>
                 </StackPanel>
             </StatusBarItem>
         </StatusBar>


### PR DESCRIPTION
Didn't know version info existed so I added it.
Removed the info where it showed last release date of DCS-BIOS which it fetched from Github.

This is sort of a hack. The DCSBIOSControlLocator must be refactored because it is a small mess right now. Problem is the different categories of things to load depending on whether it is FC3 or full module.