### PR TITLE
[Streamdeck Plus] Add first basic implementation of streamdeck +

### DIFF
--- a/Source/ClassLibraryCommon/Common.cs
+++ b/Source/ClassLibraryCommon/Common.cs
@@ -87,6 +87,7 @@
             new GamingPanelSkeleton(GamingPanelVendorEnum.Elgato, GamingPanelEnum.StreamDeckXL),
             new GamingPanelSkeleton(GamingPanelVendorEnum.Elgato, GamingPanelEnum.StreamDeckXLRev2),
             new GamingPanelSkeleton(GamingPanelVendorEnum.CockpitMaster, GamingPanelEnum.CDU737),
+            new GamingPanelSkeleton(GamingPanelVendorEnum.Elgato, GamingPanelEnum.StreamDeckPlus),
         };
 
         private static void ValidateEmulationModeFlag()

--- a/Source/ClassLibraryCommon/CommonEnums.cs
+++ b/Source/ClassLibraryCommon/CommonEnums.cs
@@ -74,6 +74,8 @@ namespace ClassLibraryCommon
         StreamDeckXL = 0x006C,
         [Description("StreamDeck XL Rev2")]
         StreamDeckXLRev2 = 0x008F,
+        [Description("StreamDeck Plus")]
+        StreamDeckPlus = 0x0084,
         [Description("Logitech Farming Side Panel")]
         FarmingPanel = 0x2218
     }

--- a/Source/DCSFlightpanels/MainWindow.xaml.cs
+++ b/Source/DCSFlightpanels/MainWindow.xaml.cs
@@ -519,6 +519,7 @@ namespace DCSFlightpanels
                     case GamingPanelEnum.StreamDeckMK2:
                     case GamingPanelEnum.StreamDeckXL:
                     case GamingPanelEnum.StreamDeckXLRev2:
+                    case GamingPanelEnum.StreamDeckPlus:
                         {
                             var tabItemStreamDeck = new TabItem { Header = hidSkeleton.GamingPanelType.GetEnumDescriptionField() };
                             var streamDeckUserControl = new StreamDeckUserControl(hidSkeleton.GamingPanelType, hidSkeleton);
@@ -836,7 +837,8 @@ namespace DCSFlightpanels
         {
             var panelOrderList = new List<GamingPanelEnum>
                                      {
-                                        GamingPanelEnum.CDU737,
+                                         GamingPanelEnum.StreamDeckPlus,
+                                         GamingPanelEnum.CDU737,
                                          GamingPanelEnum.StreamDeckXL,
                                          GamingPanelEnum.StreamDeck,
                                          GamingPanelEnum.StreamDeckV2,

--- a/Source/DCSFlightpanels/PanelUserControls/StreamDeck/UserControlStreamDeckUIBase.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/StreamDeck/UserControlStreamDeckUIBase.cs
@@ -114,7 +114,7 @@
                  */
                 if (newlySelectedImage.Bill.Button != _streamDeckPanel.SelectedButton && SDEventHandler.AreThereDirtyListeners(this))
                 {
-                    if (CommonUI.DoDiscardAfterMessage(true, $"Discard Changes to {SelectedButtonName} ?"))
+                    if (CommonUI.DoDiscardAfterMessage(true, $"Discard Changes to {SelectedButtonName} on {_streamDeckPanel.TypeOfPanel} ?"))
                     {
                         SetFormState();
                     }

--- a/Source/DCSFlightpanels/PanelUserControls/StreamDeck/UserControlStreamDeckUIPlus.xaml
+++ b/Source/DCSFlightpanels/PanelUserControls/StreamDeck/UserControlStreamDeckUIPlus.xaml
@@ -1,0 +1,99 @@
+﻿<streamDeck:UserControlStreamDeckUIBase x:Class="DCSFlightpanels.PanelUserControls.StreamDeck.UserControlStreamDeckUIPlus"
+                                   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                                   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                                   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+                                   xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+                                   xmlns:customControls="clr-namespace:DCSFlightpanels.CustomControls"
+                                   xmlns:streamDeck="clr-namespace:DCSFlightpanels.PanelUserControls.StreamDeck"
+                                   Loaded="UserControlStreamDeckUIPlus_OnLoaded"
+                                   mc:Ignorable="d" 
+                                   d:DesignHeight="235" d:DesignWidth="400">
+
+    <UserControl.Resources>
+        <Style TargetType="Border" x:Key="BorderMouseHoover">
+            <Setter Property="BorderBrush" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="2"/>
+            <Style.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter Property="BorderBrush" Value="White"/>
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+        <Style TargetType="Border" x:Key="BorderSelected">
+            <Setter Property="BorderThickness" Value="2"/>
+            <Setter Property="BorderBrush" Value="LimeGreen"/>
+        </Style>
+
+        <Style TargetType="Image" x:Key="ButtonImageStyle">
+            <Setter Property="Margin" Value="1,1,1,1"/>
+            <Setter Property="HorizontalAlignment" Value="Stretch"/>
+            <Setter Property="VerticalAlignment" Value="Stretch"/>
+            <EventSetter Event="MouseUp" Handler="ButtonImage_OnMouseUp"/>
+            <EventSetter Event="PreviewMouseDown" Handler="ButtonImage_PreviewMouseDown"/>
+            <!--<EventSetter Event="KeyDown" Handler="ButtonImage_OnKeyDown"/>
+            <EventSetter Event="PreviewKeyDown" Handler="ButtonImage_OnPreviewKeyDown"/>-->
+        </Style>
+
+    </UserControl.Resources>
+
+
+    <Grid Name="GridButtons" Background="Black" >
+
+        <Grid.RowDefinitions>
+            <RowDefinition Height="118" />
+            <RowDefinition Height="118" />
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="100*" />
+            <ColumnDefinition Width="100*" />
+            <ColumnDefinition Width="100*" />
+            <ColumnDefinition Width="100*" />
+        </Grid.ColumnDefinitions>
+
+
+        <Border Style="{StaticResource BorderMouseHoover}" Grid.Column="0" Grid.Row="0">
+            <Canvas Name="Canvas1" >
+                <customControls:StreamDeckImage x:Name="ButtonImage1" Width="{Binding Path=ActualWidth, ElementName=Canvas1}" Height="{Binding Path=ActualHeight, ElementName=Canvas1}" Stretch="Uniform" Style="{StaticResource ButtonImageStyle}" />
+            </Canvas>
+        </Border>
+        <Border Style="{StaticResource BorderMouseHoover}" Grid.Column="1" Grid.Row="0">
+            <Canvas>
+                <customControls:StreamDeckImage x:Name="ButtonImage2" Width="{Binding Path=ActualWidth, ElementName=Canvas1}" Height="{Binding Path=ActualHeight, ElementName=Canvas1}" Stretch="Uniform" Style="{StaticResource ButtonImageStyle}" />
+            </Canvas>
+        </Border>
+        <Border Style="{StaticResource BorderMouseHoover}" Grid.Column="2" Grid.Row="0">
+            <Canvas>
+                <customControls:StreamDeckImage x:Name="ButtonImage3" Width="{Binding Path=ActualWidth, ElementName=Canvas1}" Height="{Binding Path=ActualHeight, ElementName=Canvas1}" Stretch="Uniform" Style="{StaticResource ButtonImageStyle}" />
+            </Canvas>
+        </Border>
+        <Border Style="{StaticResource BorderMouseHoover}" Grid.Column="3" Grid.Row="0">
+            <Canvas>
+                <customControls:StreamDeckImage x:Name="ButtonImage4" Width="{Binding Path=ActualWidth, ElementName=Canvas1}" Height="{Binding Path=ActualHeight, ElementName=Canvas1}" Stretch="Uniform" Style="{StaticResource ButtonImageStyle}" />
+            </Canvas>
+        </Border>        
+        <Border Style="{StaticResource BorderMouseHoover}" Grid.Column="0" Grid.Row="1">
+            <Canvas>
+                <customControls:StreamDeckImage x:Name="ButtonImage5" Width="{Binding Path=ActualWidth, ElementName=Canvas1}" Height="{Binding Path=ActualHeight, ElementName=Canvas1}" Stretch="Uniform" Style="{StaticResource ButtonImageStyle}" />
+            </Canvas>
+        </Border>
+        <Border Style="{StaticResource BorderMouseHoover}" Grid.Column="1" Grid.Row="1">
+            <Canvas>
+                <customControls:StreamDeckImage x:Name="ButtonImage6" Width="{Binding Path=ActualWidth, ElementName=Canvas1}" Height="{Binding Path=ActualHeight, ElementName=Canvas1}" Stretch="Uniform" Style="{StaticResource ButtonImageStyle}" />
+            </Canvas>
+        </Border>
+
+        <Border Style="{StaticResource BorderMouseHoover}" Grid.Column="2" Grid.Row="1">
+            <Canvas>
+                <customControls:StreamDeckImage x:Name="ButtonImage7" Width="{Binding Path=ActualWidth, ElementName=Canvas1}" Height="{Binding Path=ActualHeight, ElementName=Canvas1}" Stretch="Uniform" Style="{StaticResource ButtonImageStyle}" />
+            </Canvas>
+        </Border>
+        
+        <Border Style="{StaticResource BorderMouseHoover}" Grid.Column="3" Grid.Row="1">
+            <Canvas>
+                <customControls:StreamDeckImage x:Name="ButtonImage8" Width="{Binding Path=ActualWidth, ElementName=Canvas1}" Height="{Binding Path=ActualHeight, ElementName=Canvas1}" Stretch="Uniform" Style="{StaticResource ButtonImageStyle}" />
+            </Canvas>
+        </Border>        
+
+
+    </Grid>
+</streamDeck:UserControlStreamDeckUIBase>

--- a/Source/DCSFlightpanels/PanelUserControls/StreamDeck/UserControlStreamDeckUIPlus.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/StreamDeck/UserControlStreamDeckUIPlus.xaml.cs
@@ -1,0 +1,45 @@
+﻿using System.Linq;
+using System.Windows;
+using ClassLibraryCommon;
+using DCSFlightpanels.CustomControls;
+using NonVisuals.Panels.StreamDeck.Panels;
+
+namespace DCSFlightpanels.PanelUserControls.StreamDeck
+{
+    /// <summary>
+    /// Interaction logic for UserControlStreamDeckUIPlus.xaml
+    /// </summary>
+    public partial class UserControlStreamDeckUIPlus
+    {
+        public UserControlStreamDeckUIPlus(StreamDeckPanel streamDeckPanel) : base(streamDeckPanel)
+        {
+            InitializeComponent();
+        }
+
+        private void UserControlStreamDeckUIPlus_OnLoaded(object sender, RoutedEventArgs e)
+        {
+            if (!UserControlLoaded)
+            {
+                FillControlLists();
+                SetImageBills();
+                ShowGraphicConfiguration();
+                SetContextMenus();
+                UserControlLoaded = true;
+            }
+            SetFormState();
+        }
+
+        protected override int ButtonAmount()
+        {
+            return 8;
+        }
+
+        private void FillControlLists()
+        {
+            Common.FindVisualChildren<StreamDeckImage>(GridButtons).ToList()
+                .ForEach(x => ButtonImages.Add(x));
+
+            CheckButtonControlListValidity();
+        }
+    }
+}

--- a/Source/DCSFlightpanels/PanelUserControls/StreamDeckUserControl.xaml.cs
+++ b/Source/DCSFlightpanels/PanelUserControls/StreamDeckUserControl.xaml.cs
@@ -68,6 +68,13 @@
                         StackPanelButtonUI.Children.Add(child);
                         break;
                     }
+                case GamingPanelEnum.StreamDeckPlus:
+                    {
+                        var child = new UserControlStreamDeckUIPlus(_streamDeckPanel);
+                        _uiButtonGrid = child;
+                        StackPanelButtonUI.Children.Add(child);
+                        break;
+                    }
             }
 
 

--- a/Source/MEF/Switches.cs
+++ b/Source/MEF/Switches.cs
@@ -26,6 +26,8 @@
         StreamDeckMK2,
         [Description("StreamDeck XL")]
         StreamDeckXL,
+        [Description("StreamDeck Plus")]
+        StreamDeckPlus,
         [Description("Logitech Farming Side Panel")]
         FarmingPanel,
         [Description("Saitek PZ69 Radio PreProg Panel A10C")]

--- a/Source/NonVisuals/GenericPanelBinding.cs
+++ b/Source/NonVisuals/GenericPanelBinding.cs
@@ -127,12 +127,13 @@
 
         public bool IsJSON()
         {
-            return  PanelType == GamingPanelEnum.StreamDeckMini ||
+            return PanelType == GamingPanelEnum.StreamDeckMini ||
                     PanelType == GamingPanelEnum.StreamDeck ||
                     PanelType == GamingPanelEnum.StreamDeckV2 ||
                     PanelType == GamingPanelEnum.StreamDeckMK2 ||
                     PanelType == GamingPanelEnum.StreamDeckXL ||
-                    PanelType == GamingPanelEnum.StreamDeckXLRev2;
+                    PanelType == GamingPanelEnum.StreamDeckXLRev2 ||
+                    PanelType == GamingPanelEnum.StreamDeckPlus;
         }
 
         public void ClearSettings()

--- a/Source/NonVisuals/Panels/StreamDeck/Panels/StreamDeckPanel.cs
+++ b/Source/NonVisuals/Panels/StreamDeck/Panels/StreamDeckPanel.cs
@@ -106,6 +106,9 @@ namespace NonVisuals.Panels.StreamDeck.Panels
                 GamingPanelEnum.StreamDeckMK2 => 15,
 
                 GamingPanelEnum.StreamDeckXL or GamingPanelEnum.StreamDeckXLRev2 => 32,
+
+                GamingPanelEnum.StreamDeckPlus => 8,
+
                 _ => throw new Exception("Failed to determine Stream Deck model")
             };
 

--- a/Source/NonVisuals/Panels/StreamDeck/StreamDeckButton.cs
+++ b/Source/NonVisuals/Panels/StreamDeck/StreamDeckButton.cs
@@ -155,6 +155,7 @@
                         GamingPanelEnum.StreamDeckMK2 => PluginGamingPanelEnum.StreamDeckMK2,
                         GamingPanelEnum.StreamDeckXL => PluginGamingPanelEnum.StreamDeckXL,
                         GamingPanelEnum.StreamDeckXLRev2 => PluginGamingPanelEnum.StreamDeckXL,
+                        GamingPanelEnum.StreamDeckPlus => PluginGamingPanelEnum.StreamDeckPlus,
                         _ => PluginGamingPanelEnum.Unknown
                     };
 

--- a/Source/NonVisuals/Panels/StreamDeck/StreamDeckCommon.cs
+++ b/Source/NonVisuals/Panels/StreamDeck/StreamDeckCommon.cs
@@ -19,6 +19,7 @@
                 GamingPanelEnum.StreamDeckMK2 => PluginGamingPanelEnum.StreamDeckMK2,
                 GamingPanelEnum.StreamDeckXL => PluginGamingPanelEnum.StreamDeckXL,
                 GamingPanelEnum.StreamDeckXLRev2 => PluginGamingPanelEnum.StreamDeckXL,
+                GamingPanelEnum.StreamDeckPlus => PluginGamingPanelEnum.StreamDeckPlus,
                 _ => PluginGamingPanelEnum.Unknown
             };
         }

--- a/Source/SamplePanelEventPlugin1/PanelEventFileWriter.cs
+++ b/Source/SamplePanelEventPlugin1/PanelEventFileWriter.cs
@@ -72,7 +72,8 @@
                 or PluginGamingPanelEnum.StreamDeckV2
                 or PluginGamingPanelEnum.StreamDeck
                 or PluginGamingPanelEnum.StreamDeckMini
-                or PluginGamingPanelEnum.StreamDeckXL => GetEventString<EnumStreamDeckButtonNames>(switchId, pressed),
+                or PluginGamingPanelEnum.StreamDeckXL
+                or PluginGamingPanelEnum.StreamDeckPlus => GetEventString<EnumStreamDeckButtonNames>(switchId, pressed),
                 
                 PluginGamingPanelEnum.BackLitPanel => "BIP Event - ATTN : this panel cannot produce events",
 

--- a/Source/SamplePanelEventPlugin2/PanelEventFileWriter.cs
+++ b/Source/SamplePanelEventPlugin2/PanelEventFileWriter.cs
@@ -72,7 +72,8 @@
                 or PluginGamingPanelEnum.StreamDeckV2
                 or PluginGamingPanelEnum.StreamDeck
                 or PluginGamingPanelEnum.StreamDeckMini
-                or PluginGamingPanelEnum.StreamDeckXL => GetEventString<EnumStreamDeckButtonNames>(switchId, pressed),
+                or PluginGamingPanelEnum.StreamDeckXL
+                or PluginGamingPanelEnum.StreamDeckPlus => GetEventString<EnumStreamDeckButtonNames>(switchId, pressed),
                 
                 PluginGamingPanelEnum.BackLitPanel => "BIP Event - ATTN : this panel cannot produce events",
 


### PR DESCRIPTION
- First implementation of SD+ as only 8 top buttons into DCSFP
- No rotary controls or bottom screen management (yet)

- Tested the button & working as expected in my F-16 profile with DCSBios orders.

Need to merge this submodule PR first :
https://github.com/DCSFlightpanels/DCSFPStreamDeckSharp/pull/5


