### PR TITLE
Updated the technique to Refresh Leds and Brightness

### DIFF
--- a/Source/NonVisuals/CockpitMaster/Panels/CDU737PanelBase.cs
+++ b/Source/NonVisuals/CockpitMaster/Panels/CDU737PanelBase.cs
@@ -28,10 +28,10 @@
         public const int MAX_BRIGHT = 0xff;
         private const int BRIGHTNESS_STEP = 10;
 
-        // refresh the CDU 2 times / sec. 
+        // refresh the CDU 4 times / sec. 
         // ok for most case , except when the master caution is blinking very fast in the A10
 
-        private const int TICK_DISPLAY = 500;
+        private const int TICK_DISPLAY = 250;
 
         private int _screenBrightness = MAX_BRIGHT / 2;
         private int _keyboardBrightness = MAX_BRIGHT / 2;
@@ -413,21 +413,24 @@
                     // Screenbuffers are declared 63 bytes
                     // Doing this here, ensure the Numbering of HidReport is not "broken" 
                     // by mistake, and simplifies "recopy of lines in buffers
-                    
+
                     _hidReport[i].Data[0] = (byte)(i + 1);
                     Array.Copy(ScreenBuffer[i], 0, _hidReport[i].Data, 1, 63);
-                    
                     _ = HIDWriteDevice.WriteReportAsync(_hidReport[i]);
                 }
-
-                // Handles LED 
-                // BrightAndLefbuffer[0] = 9 and should not be modified 
-                
-                BrightAndLedBuffer[3] = _ledStatus;
-                _hidReport[8].Data = BrightAndLedBuffer;
-
-                _ = HIDWriteDevice.WriteReport(_hidReport[8]);
             }
+
+        }
+
+        public void refreshLedsAndBrightness()
+        {
+            // Handles LED 
+            // BrightAndLefbuffer[0] = 9 and should not be modified 
+
+            BrightAndLedBuffer[3] = _ledStatus;
+            _hidReport[8].Data = BrightAndLedBuffer;
+
+            _ = HIDWriteDevice.WriteReportAsync(_hidReport[8]);
 
         }
 

--- a/Source/NonVisuals/CockpitMaster/Preprogrammed/CDU737PanelA10C.cs
+++ b/Source/NonVisuals/CockpitMaster/Preprogrammed/CDU737PanelA10C.cs
@@ -119,6 +119,8 @@ namespace NonVisuals.CockpitMaster.Preprogrammed
 
         public override void DcsBiosDataReceived(object sender, DCSBIOSDataEventArgs e)
         {
+            bool refreshLedOrLight = false;
+
             if (SettingsLoading)
             {
                 return;
@@ -141,6 +143,8 @@ namespace NonVisuals.CockpitMaster.Preprogrammed
                             IncreaseBrightness();
                             break;
                     }
+                    refreshLedOrLight = true;
+
 
                 }
 
@@ -156,7 +160,12 @@ namespace NonVisuals.CockpitMaster.Preprogrammed
                     {
                         Led_OFF(CDU737Led.FAIL);
                     }
+                    refreshLedOrLight = true;
 
+                }
+
+                if (refreshLedOrLight) {
+                    refreshLedsAndBrightness();
                 }
             }
             catch (Exception)

--- a/Source/NonVisuals/CockpitMaster/Preprogrammed/CDU737PanelAH64D.cs
+++ b/Source/NonVisuals/CockpitMaster/Preprogrammed/CDU737PanelAH64D.cs
@@ -179,7 +179,7 @@ namespace NonVisuals.CockpitMaster.Preprogrammed
                     // MAX_BRIGHT is 256 , so 655356 / 256 is 256 , we need to divide by 2^8
                     ScreenBrightness = eufdBright >> 8;
                     KeyboardBrightness= eufdBright >>8;
-                    displayBufferOnCDU();
+                    refreshLedsAndBrightness();
                 }
 
                 // AH - 64D / PLT_MASTER_WARNING_L
@@ -194,7 +194,7 @@ namespace NonVisuals.CockpitMaster.Preprogrammed
                     {
                         Led_OFF(CDU737Led.FAIL);
                     }
-                    displayBufferOnCDU();
+                    refreshLedsAndBrightness();
 
                 }
             }

--- a/Source/NonVisuals/CockpitMaster/Preprogrammed/CDU737PanelFA18C.cs
+++ b/Source/NonVisuals/CockpitMaster/Preprogrammed/CDU737PanelFA18C.cs
@@ -177,7 +177,7 @@ namespace NonVisuals.CockpitMaster.Preprogrammed
                         {
                             Led_ON(CDU737Led.FAIL);
                         }
-                        displayBufferOnCDU();
+                        refreshLedsAndBrightness();
                     }
 
                 }


### PR DESCRIPTION
HidReports can indeed be send independently. 

i extracted the hid 8 ( leds & brightness) from display and made direct call when needed. 
This way, the blinking speed is better matching the speed in the plane. 