### PR TITLE
#401

### DIFF
--- a/Source/DCSFlightpanels/Windows/StreamDeck/StreamDeckDCSBIOSDecoderWindow.xaml.cs
+++ b/Source/DCSFlightpanels/Windows/StreamDeck/StreamDeckDCSBIOSDecoderWindow.xaml.cs
@@ -159,7 +159,8 @@ namespace DCSFlightpanels.Windows.StreamDeck
                 CheckBoxUseFormula.IsChecked = false;
             }
 
-            ButtonOK.IsEnabled = _dcsbiosDecoder.DecoderConfigurationOK() && (!string.IsNullOrEmpty(TextBoxDCSBIOSId.Text) || !string.IsNullOrEmpty(TextBoxFormula.Text));
+            ButtonOK.IsEnabled = _dcsbiosDecoder.DecoderConfigurationOK() && (!string.IsNullOrEmpty(TextBoxDCSBIOSId.Text) || !string.IsNullOrEmpty(TextBoxFormula.Text)) &&
+                                 (_dcsbiosDecoder.DCSBIOSConverters.Count != 0  || !string.IsNullOrEmpty(TextBoxOutputTextRaw.Text));
 
             ComboBoxDecimals.IsEnabled = CheckBoxLimitDecimals.IsChecked == true;
             DisplayImagePreview();


### PR DESCRIPTION
StreamdeckDecoder window OK button was enabled although user had not chosen converter nor raw value. This caused the button to be blank.