### PR TITLE
Fixed CDU broken after InitPanel rework

### DIFF
--- a/Source/NonVisuals/CockpitMaster/Preprogrammed/CDU737PanelA10C.cs
+++ b/Source/NonVisuals/CockpitMaster/Preprogrammed/CDU737PanelA10C.cs
@@ -35,10 +35,10 @@ namespace NonVisuals.CockpitMaster.PreProgrammed
         {
             try
             {
-                CDUPanelKeys = CDUMappedCommandKeyA10C.GetMappedPanelKeys();
-                BIOSEventHandler.AttachStringListener(this);
-                BIOSEventHandler.AttachDataListener(this);
+                base.InitPanel();
 
+                CDUPanelKeys = CDUMappedCommandKeyA10C.GetMappedPanelKeys();
+                
                 // CDU Lines & BRT
 
                 _CDU_LINE_0 = DCSBIOSControlLocator.GetStringDCSBIOSOutput("CDU_LINE0");
@@ -54,6 +54,9 @@ namespace NonVisuals.CockpitMaster.PreProgrammed
 
                 _CDU_BRT = DCSBIOSControlLocator.GetUIntDCSBIOSOutput("CDU_BRT");
                 _MASTER_CAUTION = DCSBIOSControlLocator.GetUIntDCSBIOSOutput("MASTER_CAUTION");
+
+                BIOSEventHandler.AttachStringListener(this);
+                BIOSEventHandler.AttachDataListener(this);
 
                 SetLine(0, string.Format("{0,24}","A10-C profile"));
 

--- a/Source/NonVisuals/CockpitMaster/Preprogrammed/CDU737PanelAH64D.cs
+++ b/Source/NonVisuals/CockpitMaster/Preprogrammed/CDU737PanelAH64D.cs
@@ -43,10 +43,10 @@ namespace NonVisuals.CockpitMaster.PreProgrammed
         {
             try
             {
+                base.InitPanel();
+
                 ConvertTable = CDUTextLineHelpers.AH64ConvertTable;
                 CDUPanelKeys = CDUMappedCommandKeyAH64D.GetMappedPanelKeys();
-                BIOSEventHandler.AttachStringListener(this);
-                BIOSEventHandler.AttachDataListener(this);
 
                 // PLT Keyboard display
 
@@ -77,6 +77,9 @@ namespace NonVisuals.CockpitMaster.PreProgrammed
                 _PLT_EUFD_LINE14 = DCSBIOSControlLocator.GetStringDCSBIOSOutput("PLT_EUFD_LINE14");
 
                 _PLT_MASTER_WARNING_L = DCSBIOSControlLocator.GetStringDCSBIOSOutput("PLT_MASTER_WARNING_L");
+
+                BIOSEventHandler.AttachStringListener(this);
+                BIOSEventHandler.AttachDataListener(this);
 
                 SetLine(0, string.Format("{0,24}", "AH64D profile"));
 
@@ -144,7 +147,7 @@ namespace NonVisuals.CockpitMaster.PreProgrammed
 
                 UpdateCounter(e.Address, e.Data);
 
-                (shouldUpdate, newValue) = ShouldHandleDCSBiosData(e, _PLT_MASTER_IGN_SW);
+/*                (shouldUpdate, newValue) = ShouldHandleDCSBiosData(e, _PLT_MASTER_IGN_SW);
 
                 if (shouldUpdate)
                 {
@@ -155,7 +158,7 @@ namespace NonVisuals.CockpitMaster.PreProgrammed
                     }
                     displayBufferOnCDU();
 
-                }
+                }*/
 
                 ( shouldUpdate, newValue) = ShouldHandleDCSBiosData(e, _PLT_EUFD_BRT);
 

--- a/Source/NonVisuals/CockpitMaster/Preprogrammed/CDU737PanelF14.cs
+++ b/Source/NonVisuals/CockpitMaster/Preprogrammed/CDU737PanelF14.cs
@@ -80,11 +80,10 @@ namespace NonVisuals.CockpitMaster.PreProgrammed
         {
             try
             {
+                base.InitPanel();
+
                 CDUPanelKeys = CDUMappedCommandKeyF14.GetMappedPanelKeys();
                 
-                BIOSEventHandler.AttachStringListener(this);
-                BIOSEventHandler.AttachDataListener(this);
-
                 BaseColor = CDUColor.WHITE;
 
                 _RIO_CAP_CATEGORY = DCSBIOSControlLocator.GetUIntDCSBIOSOutput("RIO_CAP_CATRGORY");
@@ -101,6 +100,9 @@ namespace NonVisuals.CockpitMaster.PreProgrammed
                 _RIO_RADAR_RWS = DCSBIOSControlLocator.GetUIntDCSBIOSOutput("RIO_RADAR_RWS");
                 _RIO_RADAR_PDSTT = DCSBIOSControlLocator.GetUIntDCSBIOSOutput("RIO_RADAR_PDSTT");
                 _RIO_RADAR_PSTT = DCSBIOSControlLocator.GetUIntDCSBIOSOutput("RIO_RADAR_PSTT");
+
+                BIOSEventHandler.AttachStringListener(this);
+                BIOSEventHandler.AttachDataListener(this);
 
                 SetLine(0, string.Format("{0,24}","F14 RIO profile"));
 

--- a/Source/NonVisuals/CockpitMaster/Preprogrammed/CDU737PanelFA18C.cs
+++ b/Source/NonVisuals/CockpitMaster/Preprogrammed/CDU737PanelFA18C.cs
@@ -51,10 +51,10 @@ namespace NonVisuals.CockpitMaster.PreProgrammed
         {
             try
             {
+                base.InitPanel();
+
                 ConvertTable = CDUTextLineHelpers.AH64ConvertTable;
                 CDUPanelKeys = CDUMappedCommandKeyFA18C.GetMappedPanelKeys();
-                BIOSEventHandler.AttachStringListener(this);
-                BIOSEventHandler.AttachDataListener(this);
 
                 // UFC_BRT = DCSBIOSControlLocator.GetDCSBIOSOutput("UFC_BRT");
 
@@ -85,6 +85,9 @@ namespace NonVisuals.CockpitMaster.PreProgrammed
                 UFC_SCRATCHPAD_STRING_2_DISPLAY = DCSBIOSControlLocator.GetStringDCSBIOSOutput("UFC_SCRATCHPAD_STRING_2_DISPLAY");
 
                 MASTER_CAUTION_LT = DCSBIOSControlLocator.GetUIntDCSBIOSOutput("MASTER_CAUTION_LT");
+
+                BIOSEventHandler.AttachStringListener(this);
+                BIOSEventHandler.AttachDataListener(this);
 
                 SetLine(0, string.Format("{0,24}", "F/A-18C profile"));
 

--- a/Source/NonVisuals/CockpitMaster/Preprogrammed/CDU737PanelM2000C.cs
+++ b/Source/NonVisuals/CockpitMaster/Preprogrammed/CDU737PanelM2000C.cs
@@ -21,6 +21,8 @@ namespace NonVisuals.CockpitMaster.PreProgrammed
         {
             try
             {
+                base.InitPanel();
+
                 CDUPanelKeys = CDUMappedCommandKeyM2000C.GetMappedPanelKeys();
                 
                 BIOSEventHandler.AttachStringListener(this);

--- a/Source/NonVisuals/CockpitMaster/Preprogrammed/CDU737PanelSA342.cs
+++ b/Source/NonVisuals/CockpitMaster/Preprogrammed/CDU737PanelSA342.cs
@@ -19,6 +19,8 @@ namespace NonVisuals.CockpitMaster.PreProgrammed
         {
             try
             {
+                base.InitPanel();
+
                 CDUPanelKeys = CDUMappedCommandKeySA342.GetMappedPanelKeys();
 
                 BIOSEventHandler.AttachStringListener(this);


### PR DESCRIPTION
Missing base.initPanel() call in each aircraft specific panel 
Moved Listener attachemen after biosControl init to prevent some unnecessary exceptions (  in step by step, listeners were called before beeing initialized