### PR TITLE
[SwitchPanel PZ55 Serialize] Makes SwitchPanel Pz55 Serializable

### DIFF
--- a/src/DCSFlightpanels/PanelUserControls/SwitchPanelPZ55UserControl.xaml.cs
+++ b/src/DCSFlightpanels/PanelUserControls/SwitchPanelPZ55UserControl.xaml.cs
@@ -811,6 +811,7 @@ namespace DCSFlightpanels.PanelUserControls
                 if (_switchPanelPZ55 != null)
                 {
                     _switchPanelPZ55.ManualLandingGearLEDs = CheckBoxManualLeDs.IsChecked.HasValue && CheckBoxManualLeDs.IsChecked.Value;
+                    _switchPanelPZ55.SetIsDirty();
                 }
             }
             catch (Exception ex)
@@ -954,21 +955,25 @@ namespace DCSFlightpanels.PanelUserControls
         private void ManualLedUpCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             _switchPanelPZ55.ManualLandingGearLEDsColorUp = (PanelLEDColor)((ComboBox)sender).SelectedValue;
+            _switchPanelPZ55.SetIsDirty();
         }
 
         private void ManualLedTransCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             _switchPanelPZ55.ManualLandingGearLEDsColorTrans = (PanelLEDColor)((ComboBox)sender).SelectedValue;
+            _switchPanelPZ55.SetIsDirty();
         }
 
         private void ManualLedDownCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             _switchPanelPZ55.ManualLandingGearLEDsColorDown = (PanelLEDColor)((ComboBox)sender).SelectedValue;
+            _switchPanelPZ55.SetIsDirty();
         }
 
         private void ManualLedTransSecondsCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             _switchPanelPZ55.ManualLandingGearTransTimeSeconds = (int)((ComboBox)sender).SelectedValue;
+            _switchPanelPZ55.SetIsDirty();
         }
 
         private void SetManualLedColorsSelectionVisibility(bool isVisible)

--- a/src/Tests/Serialization/BIPLinkPZ55_SerializeTests.cs
+++ b/src/Tests/Serialization/BIPLinkPZ55_SerializeTests.cs
@@ -1,6 +1,7 @@
 ﻿using DCSFPTests.Serialization.Common;
 using Newtonsoft.Json;
 using NonVisuals.BindingClasses.BIP;
+using System.Collections.Generic;
 using Xunit;
 
 namespace DCSFPTests.Serialization {
@@ -28,6 +29,14 @@ namespace DCSFPTests.Serialization {
             Assert.Equal(s.WhenTurnedOn, deseralizedObjFromFile.WhenTurnedOn);
             Assert.Equal(s.Description, deseralizedObjFromFile.Description);
             DeepAssert.Equal(s.BIPLights, deseralizedObjFromFile.BIPLights);
+        }
+
+        public static HashSet<BIPLinkPZ55> GetObjects() {
+            HashSet<BIPLinkPZ55> hashSet = new();
+            for (int i = 0; i < 3; i++) {
+                hashSet.Add(GetObject(i));
+            }
+            return hashSet;
         }
 
         private static BIPLinkPZ55 GetObject(int instanceNbr = 1) {

--- a/src/Tests/Serialization/DCSBIOSActionBindingPZ55_SerializeTests.cs
+++ b/src/Tests/Serialization/DCSBIOSActionBindingPZ55_SerializeTests.cs
@@ -1,6 +1,7 @@
 ﻿using DCSFPTests.Serialization.Common;
 using Newtonsoft.Json;
 using NonVisuals.BindingClasses.DCSBIOSBindings;
+using System.Collections.Generic;
 using Xunit;
 
 namespace DCSFPTests.Serialization {
@@ -30,6 +31,14 @@ namespace DCSFPTests.Serialization {
             Assert.Equal(s.Description, deseralizedObjFromFile.Description);
             Assert.Equal(s.IsSequenced, deseralizedObjFromFile.IsSequenced);
             DeepAssert.Equal(s.DCSBIOSInputs, deseralizedObjFromFile.DCSBIOSInputs);
+        }
+
+        public static HashSet<DCSBIOSActionBindingPZ55> GetObjects() {
+            HashSet<DCSBIOSActionBindingPZ55> hashSet = new();
+            for (int i = 0; i<3; i++) {
+                hashSet.Add(GetObject(i));
+            }
+            return hashSet;
         }
 
         private static DCSBIOSActionBindingPZ55 GetObject(int instanceNbr = 1) {

--- a/src/Tests/Serialization/KeyBindingPZ55_SerializeTests.cs
+++ b/src/Tests/Serialization/KeyBindingPZ55_SerializeTests.cs
@@ -3,6 +3,7 @@ using Xunit;
 using Newtonsoft.Json;
 using NonVisuals.BindingClasses.Key;
 using MEF;
+using System.Collections.Generic;
 
 namespace DCSFPTests.Serialization {
     public class KeyBindingPZ55_SerializeTests {
@@ -60,6 +61,14 @@ namespace DCSFPTests.Serialization {
                 20 => SwitchPanelPZ55Keys.LEVER_GEAR_DOWN,
                 _ => SwitchPanelPZ55Keys.SWITCHKEY_MASTER_BAT
             };
+        }
+
+        public static HashSet<KeyBindingPZ55> GetObjects() {
+            HashSet<KeyBindingPZ55> hashSet = new();
+            for (int i = 0; i < 3; i++) {
+                hashSet.Add(GetObject(i));
+            }
+            return hashSet;
         }
 
         private static KeyBindingPZ55 GetObject(int instanceNbr = 1) {

--- a/src/Tests/Serialization/OSCommandBindingPZ55_SerializeTests.cs
+++ b/src/Tests/Serialization/OSCommandBindingPZ55_SerializeTests.cs
@@ -1,6 +1,7 @@
 ﻿using DCSFPTests.Serialization.Common;
 using Newtonsoft.Json;
 using NonVisuals.BindingClasses.OSCommand;
+using System.Collections.Generic;
 using Xunit;
 
 namespace DCSFPTests.Serialization {
@@ -29,6 +30,14 @@ namespace DCSFPTests.Serialization {
             Assert.Equal(s.SwitchPanelPZ55Key, deseralizedObjFromFile.SwitchPanelPZ55Key);
             Assert.Equal(s.WhenTurnedOn, deseralizedObjFromFile.WhenTurnedOn);
             DeepAssert.Equal(s.OSCommandObject, deseralizedObjFromFile.OSCommandObject);
+        }
+
+        public static HashSet<OSCommandBindingPZ55> GetObjects() {
+            HashSet<OSCommandBindingPZ55> hashSet = new();
+            for (int i = 0; i < 3; i++) {
+                hashSet.Add(GetObject(i));
+            }
+            return hashSet;
         }
 
         private static OSCommandBindingPZ55 GetObject(int instanceNbr = 1) {

--- a/src/Tests/Serialization/Panels/SwitchPanelPZ55_SerializeTests.cs
+++ b/src/Tests/Serialization/Panels/SwitchPanelPZ55_SerializeTests.cs
@@ -1,0 +1,46 @@
+﻿using DCSFPTests.Serialization.Common;
+using NonVisuals.Panels.Saitek.Panels;
+using Xunit;
+using Newtonsoft.Json;
+using ClassLibraryCommon;
+using NonVisuals.HID;
+using System.Linq;
+
+
+namespace DCSFPTests.Serialization.Panels {
+    public class SwitchPanelPZ55_SerializeTests {
+        [Fact]
+        public static void SwitchPanelPZ55_ShouldBeSerializable() {
+            SwitchPanelPZ55 s = GetObject();
+
+            string serializedObj = JsonConvert.SerializeObject(s, Formatting.Indented, JSonSettings.JsonDefaultSettings);
+           // SwitchPanelPZ55 d = JsonConvert.DeserializeObject<SwitchPanelPZ55>(serializedObj);
+
+            RepositorySerialized repo = new();
+            //Save sample file in project (use it only once)
+            //repo.SaveSerializedObjectToFile(s.GetType(), serializedObj);
+
+            //SwitchPanelPZ55 deseralizedObjFromFile = JsonConvert.DeserializeObject<SwitchPanelPZ55>(repo.GetSerializedObjectString(s.GetType()));
+
+           // DeepAssert.Equal(s, deseralizedObjFromFile);
+           // DeepAssert.Equal(d, deseralizedObjFromFile);
+        }
+
+        public static SwitchPanelPZ55 GetObject(int instanceNbr = 1) {
+            GamingPanelSkeleton gamingPanelSkeleton = new(GamingPanelVendorEnum.Saitek, GamingPanelEnum.PZ55SwitchPanel);
+            return new SwitchPanelPZ55(new HIDSkeleton(gamingPanelSkeleton, "FakeHidInstanceForTests"))
+            {
+                ManualLandingGearLEDs = false,
+                ManualLandingGearLEDsColorDown = BIPLight_SerializeTests.GetPanelLEDColorFromInstance(instanceNbr),
+                ManualLandingGearLEDsColorUp = BIPLight_SerializeTests.GetPanelLEDColorFromInstance(instanceNbr + 1),
+                ManualLandingGearLEDsColorTrans = BIPLight_SerializeTests.GetPanelLEDColorFromInstance(instanceNbr + 2),
+                ManualLandingGearTransTimeSeconds = instanceNbr + 6,
+                
+                DCSBiosBindings = DCSBIOSActionBindingPZ55_SerializeTests.GetObjects(),
+                KeyBindingsHashSet = KeyBindingPZ55_SerializeTests.GetObjects(),
+                OSCommandList = OSCommandBindingPZ55_SerializeTests.GetObjects().ToList(),
+                BIPLinkHashSet = BIPLinkPZ55_SerializeTests.GetObjects()
+            };
+        }
+    }
+}

--- a/src/Tests/Serialization/Resources/SwitchPanelPZ55.json
+++ b/src/Tests/Serialization/Resources/SwitchPanelPZ55.json
@@ -1,0 +1,717 @@
+{
+  "$type": "NonVisuals.Panels.Saitek.Panels.SwitchPanelPZ55, NonVisuals",
+  "DCSBiosBindings": {
+    "$type": "System.Collections.Generic.HashSet`1[[NonVisuals.BindingClasses.DCSBIOSBindings.DCSBIOSActionBindingPZ55, NonVisuals]], System.Private.CoreLib",
+    "$values": [
+      {
+        "$type": "NonVisuals.BindingClasses.DCSBIOSBindings.DCSBIOSActionBindingPZ55, NonVisuals",
+        "SwitchPanelPZ55Key": 8,
+        "WhenTurnedOn": true,
+        "Description": "iiu kkh 0",
+        "DCSBIOSInputs": {
+          "$type": "System.Collections.Generic.List`1[[DCS_BIOS.Serialized.DCSBIOSInput, DCS-BIOS]], System.Private.CoreLib",
+          "$values": [
+            {
+              "$type": "DCS_BIOS.Serialized.DCSBIOSInput, DCS-BIOS",
+              "SelectedDCSBIOSInterface": {
+                "$type": "DCS_BIOS.Serialized.DCSBIOSInputInterface, DCS-BIOS",
+                "Delay": 1,
+                "ControlId": "ijw evv 1",
+                "Description": "urt vdf 1",
+                "Interface": 4,
+                "MaxValue": 2,
+                "SuggestedStep": 3,
+                "SpecifiedActionArgument": "dov csd 1",
+                "SpecifiedSetStateArgument": 4,
+                "SpecifiedVariableStepArgument": 5,
+                "SpecifiedFixedStepArgument": 0,
+                "SpecifiedSetStringArgument": "sdd vbn",
+                "SelectedArgumentValue": "sdd vbn"
+              },
+              "ControlId": "uyt ffs 2",
+              "Delay": 1,
+              "ControlDescription": "ikf xsd 2",
+              "DCSBIOSInputInterfaces": {
+                "$type": "System.Collections.Generic.List`1[[DCS_BIOS.Serialized.DCSBIOSInputInterface, DCS-BIOS]], System.Private.CoreLib",
+                "$values": [
+                  {
+                    "$type": "DCS_BIOS.Serialized.DCSBIOSInputInterface, DCS-BIOS",
+                    "Delay": 1,
+                    "ControlId": "ijw evv 1",
+                    "Description": "urt vdf 1",
+                    "Interface": 4,
+                    "MaxValue": 2,
+                    "SuggestedStep": 3,
+                    "SpecifiedActionArgument": "dov csd 1",
+                    "SpecifiedSetStateArgument": 4,
+                    "SpecifiedVariableStepArgument": 5,
+                    "SpecifiedFixedStepArgument": 0,
+                    "SpecifiedSetStringArgument": "sdd vbn",
+                    "SelectedArgumentValue": "sdd vbn"
+                  },
+                  {
+                    "$type": "DCS_BIOS.Serialized.DCSBIOSInputInterface, DCS-BIOS",
+                    "Delay": 1,
+                    "ControlId": "ijw evv 2",
+                    "Description": "urt vdf 2",
+                    "Interface": 4,
+                    "MaxValue": 2,
+                    "SuggestedStep": 3,
+                    "SpecifiedActionArgument": "dov csd 2",
+                    "SpecifiedSetStateArgument": 4,
+                    "SpecifiedVariableStepArgument": 6,
+                    "SpecifiedFixedStepArgument": 0,
+                    "SpecifiedSetStringArgument": "sdd vbn",
+                    "SelectedArgumentValue": "sdd vbn"
+                  }
+                ]
+              }
+            },
+            {
+              "$type": "DCS_BIOS.Serialized.DCSBIOSInput, DCS-BIOS",
+              "SelectedDCSBIOSInterface": {
+                "$type": "DCS_BIOS.Serialized.DCSBIOSInputInterface, DCS-BIOS",
+                "Delay": 1,
+                "ControlId": "ijw evv 1",
+                "Description": "urt vdf 1",
+                "Interface": 4,
+                "MaxValue": 2,
+                "SuggestedStep": 3,
+                "SpecifiedActionArgument": "dov csd 1",
+                "SpecifiedSetStateArgument": 4,
+                "SpecifiedVariableStepArgument": 5,
+                "SpecifiedFixedStepArgument": 0,
+                "SpecifiedSetStringArgument": "sdd vbn",
+                "SelectedArgumentValue": "sdd vbn"
+              },
+              "ControlId": "uyt ffs 3",
+              "Delay": 1,
+              "ControlDescription": "ikf xsd 3",
+              "DCSBIOSInputInterfaces": {
+                "$type": "System.Collections.Generic.List`1[[DCS_BIOS.Serialized.DCSBIOSInputInterface, DCS-BIOS]], System.Private.CoreLib",
+                "$values": [
+                  {
+                    "$type": "DCS_BIOS.Serialized.DCSBIOSInputInterface, DCS-BIOS",
+                    "Delay": 1,
+                    "ControlId": "ijw evv 1",
+                    "Description": "urt vdf 1",
+                    "Interface": 4,
+                    "MaxValue": 2,
+                    "SuggestedStep": 3,
+                    "SpecifiedActionArgument": "dov csd 1",
+                    "SpecifiedSetStateArgument": 4,
+                    "SpecifiedVariableStepArgument": 5,
+                    "SpecifiedFixedStepArgument": 0,
+                    "SpecifiedSetStringArgument": "sdd vbn",
+                    "SelectedArgumentValue": "sdd vbn"
+                  },
+                  {
+                    "$type": "DCS_BIOS.Serialized.DCSBIOSInputInterface, DCS-BIOS",
+                    "Delay": 1,
+                    "ControlId": "ijw evv 2",
+                    "Description": "urt vdf 2",
+                    "Interface": 4,
+                    "MaxValue": 2,
+                    "SuggestedStep": 3,
+                    "SpecifiedActionArgument": "dov csd 2",
+                    "SpecifiedSetStateArgument": 4,
+                    "SpecifiedVariableStepArgument": 6,
+                    "SpecifiedFixedStepArgument": 0,
+                    "SpecifiedSetStringArgument": "sdd vbn",
+                    "SelectedArgumentValue": "sdd vbn"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "WhenOnTurnedOn": true,
+        "IsSequenced": true
+      },
+      {
+        "$type": "NonVisuals.BindingClasses.DCSBIOSBindings.DCSBIOSActionBindingPZ55, NonVisuals",
+        "SwitchPanelPZ55Key": 16,
+        "WhenTurnedOn": true,
+        "Description": "iiu kkh 1",
+        "DCSBIOSInputs": {
+          "$type": "System.Collections.Generic.List`1[[DCS_BIOS.Serialized.DCSBIOSInput, DCS-BIOS]], System.Private.CoreLib",
+          "$values": [
+            {
+              "$type": "DCS_BIOS.Serialized.DCSBIOSInput, DCS-BIOS",
+              "SelectedDCSBIOSInterface": {
+                "$type": "DCS_BIOS.Serialized.DCSBIOSInputInterface, DCS-BIOS",
+                "Delay": 1,
+                "ControlId": "ijw evv 1",
+                "Description": "urt vdf 1",
+                "Interface": 4,
+                "MaxValue": 2,
+                "SuggestedStep": 3,
+                "SpecifiedActionArgument": "dov csd 1",
+                "SpecifiedSetStateArgument": 4,
+                "SpecifiedVariableStepArgument": 5,
+                "SpecifiedFixedStepArgument": 0,
+                "SpecifiedSetStringArgument": "sdd vbn",
+                "SelectedArgumentValue": "sdd vbn"
+              },
+              "ControlId": "uyt ffs 3",
+              "Delay": 1,
+              "ControlDescription": "ikf xsd 3",
+              "DCSBIOSInputInterfaces": {
+                "$type": "System.Collections.Generic.List`1[[DCS_BIOS.Serialized.DCSBIOSInputInterface, DCS-BIOS]], System.Private.CoreLib",
+                "$values": [
+                  {
+                    "$type": "DCS_BIOS.Serialized.DCSBIOSInputInterface, DCS-BIOS",
+                    "Delay": 1,
+                    "ControlId": "ijw evv 1",
+                    "Description": "urt vdf 1",
+                    "Interface": 4,
+                    "MaxValue": 2,
+                    "SuggestedStep": 3,
+                    "SpecifiedActionArgument": "dov csd 1",
+                    "SpecifiedSetStateArgument": 4,
+                    "SpecifiedVariableStepArgument": 5,
+                    "SpecifiedFixedStepArgument": 0,
+                    "SpecifiedSetStringArgument": "sdd vbn",
+                    "SelectedArgumentValue": "sdd vbn"
+                  },
+                  {
+                    "$type": "DCS_BIOS.Serialized.DCSBIOSInputInterface, DCS-BIOS",
+                    "Delay": 1,
+                    "ControlId": "ijw evv 2",
+                    "Description": "urt vdf 2",
+                    "Interface": 4,
+                    "MaxValue": 2,
+                    "SuggestedStep": 3,
+                    "SpecifiedActionArgument": "dov csd 2",
+                    "SpecifiedSetStateArgument": 4,
+                    "SpecifiedVariableStepArgument": 6,
+                    "SpecifiedFixedStepArgument": 0,
+                    "SpecifiedSetStringArgument": "sdd vbn",
+                    "SelectedArgumentValue": "sdd vbn"
+                  }
+                ]
+              }
+            },
+            {
+              "$type": "DCS_BIOS.Serialized.DCSBIOSInput, DCS-BIOS",
+              "SelectedDCSBIOSInterface": {
+                "$type": "DCS_BIOS.Serialized.DCSBIOSInputInterface, DCS-BIOS",
+                "Delay": 1,
+                "ControlId": "ijw evv 1",
+                "Description": "urt vdf 1",
+                "Interface": 4,
+                "MaxValue": 2,
+                "SuggestedStep": 3,
+                "SpecifiedActionArgument": "dov csd 1",
+                "SpecifiedSetStateArgument": 4,
+                "SpecifiedVariableStepArgument": 5,
+                "SpecifiedFixedStepArgument": 0,
+                "SpecifiedSetStringArgument": "sdd vbn",
+                "SelectedArgumentValue": "sdd vbn"
+              },
+              "ControlId": "uyt ffs 4",
+              "Delay": 1,
+              "ControlDescription": "ikf xsd 4",
+              "DCSBIOSInputInterfaces": {
+                "$type": "System.Collections.Generic.List`1[[DCS_BIOS.Serialized.DCSBIOSInputInterface, DCS-BIOS]], System.Private.CoreLib",
+                "$values": [
+                  {
+                    "$type": "DCS_BIOS.Serialized.DCSBIOSInputInterface, DCS-BIOS",
+                    "Delay": 1,
+                    "ControlId": "ijw evv 1",
+                    "Description": "urt vdf 1",
+                    "Interface": 4,
+                    "MaxValue": 2,
+                    "SuggestedStep": 3,
+                    "SpecifiedActionArgument": "dov csd 1",
+                    "SpecifiedSetStateArgument": 4,
+                    "SpecifiedVariableStepArgument": 5,
+                    "SpecifiedFixedStepArgument": 0,
+                    "SpecifiedSetStringArgument": "sdd vbn",
+                    "SelectedArgumentValue": "sdd vbn"
+                  },
+                  {
+                    "$type": "DCS_BIOS.Serialized.DCSBIOSInputInterface, DCS-BIOS",
+                    "Delay": 1,
+                    "ControlId": "ijw evv 2",
+                    "Description": "urt vdf 2",
+                    "Interface": 4,
+                    "MaxValue": 2,
+                    "SuggestedStep": 3,
+                    "SpecifiedActionArgument": "dov csd 2",
+                    "SpecifiedSetStateArgument": 4,
+                    "SpecifiedVariableStepArgument": 6,
+                    "SpecifiedFixedStepArgument": 0,
+                    "SpecifiedSetStringArgument": "sdd vbn",
+                    "SelectedArgumentValue": "sdd vbn"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "WhenOnTurnedOn": true,
+        "IsSequenced": true
+      },
+      {
+        "$type": "NonVisuals.BindingClasses.DCSBIOSBindings.DCSBIOSActionBindingPZ55, NonVisuals",
+        "SwitchPanelPZ55Key": 32,
+        "WhenTurnedOn": true,
+        "Description": "iiu kkh 2",
+        "DCSBIOSInputs": {
+          "$type": "System.Collections.Generic.List`1[[DCS_BIOS.Serialized.DCSBIOSInput, DCS-BIOS]], System.Private.CoreLib",
+          "$values": [
+            {
+              "$type": "DCS_BIOS.Serialized.DCSBIOSInput, DCS-BIOS",
+              "SelectedDCSBIOSInterface": {
+                "$type": "DCS_BIOS.Serialized.DCSBIOSInputInterface, DCS-BIOS",
+                "Delay": 1,
+                "ControlId": "ijw evv 1",
+                "Description": "urt vdf 1",
+                "Interface": 4,
+                "MaxValue": 2,
+                "SuggestedStep": 3,
+                "SpecifiedActionArgument": "dov csd 1",
+                "SpecifiedSetStateArgument": 4,
+                "SpecifiedVariableStepArgument": 5,
+                "SpecifiedFixedStepArgument": 0,
+                "SpecifiedSetStringArgument": "sdd vbn",
+                "SelectedArgumentValue": "sdd vbn"
+              },
+              "ControlId": "uyt ffs 4",
+              "Delay": 1,
+              "ControlDescription": "ikf xsd 4",
+              "DCSBIOSInputInterfaces": {
+                "$type": "System.Collections.Generic.List`1[[DCS_BIOS.Serialized.DCSBIOSInputInterface, DCS-BIOS]], System.Private.CoreLib",
+                "$values": [
+                  {
+                    "$type": "DCS_BIOS.Serialized.DCSBIOSInputInterface, DCS-BIOS",
+                    "Delay": 1,
+                    "ControlId": "ijw evv 1",
+                    "Description": "urt vdf 1",
+                    "Interface": 4,
+                    "MaxValue": 2,
+                    "SuggestedStep": 3,
+                    "SpecifiedActionArgument": "dov csd 1",
+                    "SpecifiedSetStateArgument": 4,
+                    "SpecifiedVariableStepArgument": 5,
+                    "SpecifiedFixedStepArgument": 0,
+                    "SpecifiedSetStringArgument": "sdd vbn",
+                    "SelectedArgumentValue": "sdd vbn"
+                  },
+                  {
+                    "$type": "DCS_BIOS.Serialized.DCSBIOSInputInterface, DCS-BIOS",
+                    "Delay": 1,
+                    "ControlId": "ijw evv 2",
+                    "Description": "urt vdf 2",
+                    "Interface": 4,
+                    "MaxValue": 2,
+                    "SuggestedStep": 3,
+                    "SpecifiedActionArgument": "dov csd 2",
+                    "SpecifiedSetStateArgument": 4,
+                    "SpecifiedVariableStepArgument": 6,
+                    "SpecifiedFixedStepArgument": 0,
+                    "SpecifiedSetStringArgument": "sdd vbn",
+                    "SelectedArgumentValue": "sdd vbn"
+                  }
+                ]
+              }
+            },
+            {
+              "$type": "DCS_BIOS.Serialized.DCSBIOSInput, DCS-BIOS",
+              "SelectedDCSBIOSInterface": {
+                "$type": "DCS_BIOS.Serialized.DCSBIOSInputInterface, DCS-BIOS",
+                "Delay": 1,
+                "ControlId": "ijw evv 1",
+                "Description": "urt vdf 1",
+                "Interface": 4,
+                "MaxValue": 2,
+                "SuggestedStep": 3,
+                "SpecifiedActionArgument": "dov csd 1",
+                "SpecifiedSetStateArgument": 4,
+                "SpecifiedVariableStepArgument": 5,
+                "SpecifiedFixedStepArgument": 0,
+                "SpecifiedSetStringArgument": "sdd vbn",
+                "SelectedArgumentValue": "sdd vbn"
+              },
+              "ControlId": "uyt ffs 5",
+              "Delay": 1,
+              "ControlDescription": "ikf xsd 5",
+              "DCSBIOSInputInterfaces": {
+                "$type": "System.Collections.Generic.List`1[[DCS_BIOS.Serialized.DCSBIOSInputInterface, DCS-BIOS]], System.Private.CoreLib",
+                "$values": [
+                  {
+                    "$type": "DCS_BIOS.Serialized.DCSBIOSInputInterface, DCS-BIOS",
+                    "Delay": 1,
+                    "ControlId": "ijw evv 1",
+                    "Description": "urt vdf 1",
+                    "Interface": 4,
+                    "MaxValue": 2,
+                    "SuggestedStep": 3,
+                    "SpecifiedActionArgument": "dov csd 1",
+                    "SpecifiedSetStateArgument": 4,
+                    "SpecifiedVariableStepArgument": 5,
+                    "SpecifiedFixedStepArgument": 0,
+                    "SpecifiedSetStringArgument": "sdd vbn",
+                    "SelectedArgumentValue": "sdd vbn"
+                  },
+                  {
+                    "$type": "DCS_BIOS.Serialized.DCSBIOSInputInterface, DCS-BIOS",
+                    "Delay": 1,
+                    "ControlId": "ijw evv 2",
+                    "Description": "urt vdf 2",
+                    "Interface": 4,
+                    "MaxValue": 2,
+                    "SuggestedStep": 3,
+                    "SpecifiedActionArgument": "dov csd 2",
+                    "SpecifiedSetStateArgument": 4,
+                    "SpecifiedVariableStepArgument": 6,
+                    "SpecifiedFixedStepArgument": 0,
+                    "SpecifiedSetStringArgument": "sdd vbn",
+                    "SelectedArgumentValue": "sdd vbn"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "WhenOnTurnedOn": true,
+        "IsSequenced": true
+      }
+    ]
+  },
+  "KeyBindingsHashSet": {
+    "$type": "System.Collections.Generic.HashSet`1[[NonVisuals.BindingClasses.Key.KeyBindingPZ55, NonVisuals]], System.Private.CoreLib",
+    "$values": [
+      {
+        "$type": "NonVisuals.BindingClasses.Key.KeyBindingPZ55, NonVisuals",
+        "SwitchPanelPZ55Key": 0,
+        "OSKeyPress": {
+          "$type": "NonVisuals.KeyEmulation.KeyPress, NonVisuals",
+          "Information": "ecw azs 0",
+          "Description": "wws zze 0",
+          "KeyPressSequence": {
+            "$type": "System.Collections.Generic.SortedList`2[[System.Int32, System.Private.CoreLib],[MEF.IKeyPressInfo, MEF]], System.Collections",
+            "0": {
+              "$type": "NonVisuals.KeyEmulation.KeyPressInfo, NonVisuals",
+              "LengthOfBreak": 1500,
+              "LengthOfKeyPress": 32,
+              "VirtualKeyCodes": {
+                "$type": "System.Collections.Generic.HashSet`1[[MEF.VirtualKeyCode, MEF]], System.Private.CoreLib",
+                "$values": [
+                  84,
+                  117,
+                  86,
+                  162
+                ]
+              }
+            },
+            "1": {
+              "$type": "NonVisuals.KeyEmulation.KeyPressInfo, NonVisuals",
+              "LengthOfBreak": 32,
+              "LengthOfKeyPress": 500,
+              "VirtualKeyCodes": {
+                "$type": "System.Collections.Generic.HashSet`1[[MEF.VirtualKeyCode, MEF]], System.Private.CoreLib",
+                "$values": [
+                  117,
+                  86,
+                  162,
+                  32
+                ]
+              }
+            }
+          },
+          "Abort": true
+        },
+        "WhenTurnedOn": true
+      },
+      {
+        "$type": "NonVisuals.BindingClasses.Key.KeyBindingPZ55, NonVisuals",
+        "SwitchPanelPZ55Key": 0,
+        "OSKeyPress": {
+          "$type": "NonVisuals.KeyEmulation.KeyPress, NonVisuals",
+          "Information": "ecw azs 1",
+          "Description": "wws zze 1",
+          "KeyPressSequence": {
+            "$type": "System.Collections.Generic.SortedList`2[[System.Int32, System.Private.CoreLib],[MEF.IKeyPressInfo, MEF]], System.Collections",
+            "1": {
+              "$type": "NonVisuals.KeyEmulation.KeyPressInfo, NonVisuals",
+              "LengthOfBreak": 32,
+              "LengthOfKeyPress": 500,
+              "VirtualKeyCodes": {
+                "$type": "System.Collections.Generic.HashSet`1[[MEF.VirtualKeyCode, MEF]], System.Private.CoreLib",
+                "$values": [
+                  117,
+                  86,
+                  162,
+                  32
+                ]
+              }
+            },
+            "2": {
+              "$type": "NonVisuals.KeyEmulation.KeyPressInfo, NonVisuals",
+              "LengthOfBreak": 500,
+              "LengthOfKeyPress": 2000,
+              "VirtualKeyCodes": {
+                "$type": "System.Collections.Generic.HashSet`1[[MEF.VirtualKeyCode, MEF]], System.Private.CoreLib",
+                "$values": [
+                  86,
+                  162,
+                  32,
+                  46
+                ]
+              }
+            }
+          },
+          "Abort": true
+        },
+        "WhenTurnedOn": true
+      },
+      {
+        "$type": "NonVisuals.BindingClasses.Key.KeyBindingPZ55, NonVisuals",
+        "SwitchPanelPZ55Key": 2,
+        "OSKeyPress": {
+          "$type": "NonVisuals.KeyEmulation.KeyPress, NonVisuals",
+          "Information": "ecw azs 2",
+          "Description": "wws zze 2",
+          "KeyPressSequence": {
+            "$type": "System.Collections.Generic.SortedList`2[[System.Int32, System.Private.CoreLib],[MEF.IKeyPressInfo, MEF]], System.Collections",
+            "2": {
+              "$type": "NonVisuals.KeyEmulation.KeyPressInfo, NonVisuals",
+              "LengthOfBreak": 500,
+              "LengthOfKeyPress": 2000,
+              "VirtualKeyCodes": {
+                "$type": "System.Collections.Generic.HashSet`1[[MEF.VirtualKeyCode, MEF]], System.Private.CoreLib",
+                "$values": [
+                  86,
+                  162,
+                  32,
+                  46
+                ]
+              }
+            },
+            "3": {
+              "$type": "NonVisuals.KeyEmulation.KeyPressInfo, NonVisuals",
+              "LengthOfBreak": 2000,
+              "LengthOfKeyPress": 5000,
+              "VirtualKeyCodes": {
+                "$type": "System.Collections.Generic.HashSet`1[[MEF.VirtualKeyCode, MEF]], System.Private.CoreLib",
+                "$values": [
+                  162,
+                  32,
+                  46,
+                  112
+                ]
+              }
+            }
+          },
+          "Abort": true
+        },
+        "WhenTurnedOn": true
+      }
+    ]
+  },
+  "OSCommandList": {
+    "$type": "System.Collections.Generic.List`1[[NonVisuals.BindingClasses.OSCommand.OSCommandBindingPZ55, NonVisuals]], System.Private.CoreLib",
+    "$values": [
+      {
+        "$type": "NonVisuals.BindingClasses.OSCommand.OSCommandBindingPZ55, NonVisuals",
+        "SwitchPanelPZ55Key": 8,
+        "WhenTurnedOn": true,
+        "OSCommandObject": {
+          "$type": "NonVisuals.OSCommand, NonVisuals",
+          "Command": "ggt ooi 5",
+          "Arguments": "bvr opm 5",
+          "Name": "hrv kfp 5",
+          "IsEmpty": false
+        }
+      },
+      {
+        "$type": "NonVisuals.BindingClasses.OSCommand.OSCommandBindingPZ55, NonVisuals",
+        "SwitchPanelPZ55Key": 16,
+        "WhenTurnedOn": true,
+        "OSCommandObject": {
+          "$type": "NonVisuals.OSCommand, NonVisuals",
+          "Command": "ggt ooi 6",
+          "Arguments": "bvr opm 6",
+          "Name": "hrv kfp 6",
+          "IsEmpty": false
+        }
+      },
+      {
+        "$type": "NonVisuals.BindingClasses.OSCommand.OSCommandBindingPZ55, NonVisuals",
+        "SwitchPanelPZ55Key": 32,
+        "WhenTurnedOn": true,
+        "OSCommandObject": {
+          "$type": "NonVisuals.OSCommand, NonVisuals",
+          "Command": "ggt ooi 7",
+          "Arguments": "bvr opm 7",
+          "Name": "hrv kfp 7",
+          "IsEmpty": false
+        }
+      }
+    ]
+  },
+  "BIPLinkHashSet": {
+    "$type": "System.Collections.Generic.HashSet`1[[NonVisuals.BindingClasses.BIP.BIPLinkPZ55, NonVisuals]], System.Private.CoreLib",
+    "$values": [
+      {
+        "$type": "NonVisuals.BindingClasses.BIP.BIPLinkPZ55, NonVisuals",
+        "SwitchPanelPZ55Key": 8,
+        "BIPLights": {
+          "$type": "System.Collections.Generic.SortedList`2[[System.Int32, System.Private.CoreLib],[NonVisuals.Panels.Saitek.BIPLight, NonVisuals]], System.Collections",
+          "0": {
+            "$type": "NonVisuals.Panels.Saitek.BIPLight, NonVisuals",
+            "LEDColor": 0,
+            "BIPLedPosition": 0,
+            "DelayBefore": 0,
+            "BindingHash": "dre tiy 1",
+            "Separator": {
+              "$type": "System.String[], System.Private.CoreLib",
+              "$values": [
+                "|"
+              ]
+            }
+          },
+          "1": {
+            "$type": "NonVisuals.Panels.Saitek.BIPLight, NonVisuals",
+            "LEDColor": 1,
+            "BIPLedPosition": 1,
+            "DelayBefore": 50,
+            "BindingHash": "dre tiy 2",
+            "Separator": {
+              "$type": "System.String[], System.Private.CoreLib",
+              "$values": [
+                "|"
+              ]
+            }
+          },
+          "2": {
+            "$type": "NonVisuals.Panels.Saitek.BIPLight, NonVisuals",
+            "LEDColor": 2,
+            "BIPLedPosition": 2,
+            "DelayBefore": 100,
+            "BindingHash": "dre tiy 3",
+            "Separator": {
+              "$type": "System.String[], System.Private.CoreLib",
+              "$values": [
+                "|"
+              ]
+            }
+          }
+        },
+        "WhenTurnedOn": true,
+        "Description": "hgh ido 0"
+      },
+      {
+        "$type": "NonVisuals.BindingClasses.BIP.BIPLinkPZ55, NonVisuals",
+        "SwitchPanelPZ55Key": 16,
+        "BIPLights": {
+          "$type": "System.Collections.Generic.SortedList`2[[System.Int32, System.Private.CoreLib],[NonVisuals.Panels.Saitek.BIPLight, NonVisuals]], System.Collections",
+          "1": {
+            "$type": "NonVisuals.Panels.Saitek.BIPLight, NonVisuals",
+            "LEDColor": 1,
+            "BIPLedPosition": 1,
+            "DelayBefore": 50,
+            "BindingHash": "dre tiy 2",
+            "Separator": {
+              "$type": "System.String[], System.Private.CoreLib",
+              "$values": [
+                "|"
+              ]
+            }
+          },
+          "2": {
+            "$type": "NonVisuals.Panels.Saitek.BIPLight, NonVisuals",
+            "LEDColor": 2,
+            "BIPLedPosition": 2,
+            "DelayBefore": 100,
+            "BindingHash": "dre tiy 3",
+            "Separator": {
+              "$type": "System.String[], System.Private.CoreLib",
+              "$values": [
+                "|"
+              ]
+            }
+          },
+          "3": {
+            "$type": "NonVisuals.Panels.Saitek.BIPLight, NonVisuals",
+            "LEDColor": 4,
+            "BIPLedPosition": 3,
+            "DelayBefore": 200,
+            "BindingHash": "dre tiy 4",
+            "Separator": {
+              "$type": "System.String[], System.Private.CoreLib",
+              "$values": [
+                "|"
+              ]
+            }
+          }
+        },
+        "WhenTurnedOn": true,
+        "Description": "hgh ido 1"
+      },
+      {
+        "$type": "NonVisuals.BindingClasses.BIP.BIPLinkPZ55, NonVisuals",
+        "SwitchPanelPZ55Key": 32,
+        "BIPLights": {
+          "$type": "System.Collections.Generic.SortedList`2[[System.Int32, System.Private.CoreLib],[NonVisuals.Panels.Saitek.BIPLight, NonVisuals]], System.Collections",
+          "2": {
+            "$type": "NonVisuals.Panels.Saitek.BIPLight, NonVisuals",
+            "LEDColor": 2,
+            "BIPLedPosition": 2,
+            "DelayBefore": 100,
+            "BindingHash": "dre tiy 3",
+            "Separator": {
+              "$type": "System.String[], System.Private.CoreLib",
+              "$values": [
+                "|"
+              ]
+            }
+          },
+          "3": {
+            "$type": "NonVisuals.Panels.Saitek.BIPLight, NonVisuals",
+            "LEDColor": 4,
+            "BIPLedPosition": 3,
+            "DelayBefore": 200,
+            "BindingHash": "dre tiy 4",
+            "Separator": {
+              "$type": "System.String[], System.Private.CoreLib",
+              "$values": [
+                "|"
+              ]
+            }
+          },
+          "4": {
+            "$type": "NonVisuals.Panels.Saitek.BIPLight, NonVisuals",
+            "LEDColor": 1,
+            "BIPLedPosition": 4,
+            "DelayBefore": 300,
+            "BindingHash": "dre tiy 5",
+            "Separator": {
+              "$type": "System.String[], System.Private.CoreLib",
+              "$values": [
+                "|"
+              ]
+            }
+          }
+        },
+        "WhenTurnedOn": true,
+        "Description": "hgh ido 2"
+      }
+    ]
+  },
+  "ManualLandingGearLEDs": false,
+  "ManualLandingGearLEDsColorDown": 0,
+  "ManualLandingGearLEDsColorUp": 1,
+  "ManualLandingGearLEDsColorTrans": 2,
+  "ManualLandingGearTransTimeSeconds": 7,
+  "IsDirty": false,
+  "SettingsLoading": false,
+  "TypeOfPanel": 3431,
+  "ForwardPanelEvent": false,
+  "VendorId": 1699,
+  "ProductId": 3431,
+  "HIDInstance": "FakeHidInstanceForTests",
+  "BindingHash": "e0bb02a4b46459d211ba5cef6ec20358"
+}


### PR DESCRIPTION
* Simplify properties to auto properties in PZ55 Panel.
* Makes all The switchPanel properties PZ55 Serializable
* Add PanelPz55 Serialize test & JSon Example of serialized Panel

Notes:
* Custom ImportSettings/ ExportSettings is unchanged. No changes in current behavior of the panel.
* Not deserialize tests for the moment because on how panel are instanciated with a HidSkeletton & HidInstance. Must find a way around that a little later.

Full panels serialization in JSon is more of a proof of concept than anything else for the moment. This is the first step. Could be discarded at any moment if it becomes too complicated or not realizable. 

We still have the benefits of the individual componnents serialization tests and we could eventually replace the cutom import / exports settings of those. But better try to make it work on the full panels to get the full benefits.